### PR TITLE
fix(ci): exclude `internal/pkgdata/gen` from unit test coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "**" ]
 
 jobs:
   build:
@@ -23,7 +23,7 @@ jobs:
       - name: Run unit test cases
         env:
           GODEBUG: gotypesalias=1
-        run: go test -v -race -coverprofile=coverage.txt ./...
+        run: go test -v -race -coverprofile=coverage.txt $(go list ./... | grep -v github.com/goplus/goxlsw/internal/pkgdata/gen)
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Due to Ebitengine's lack of Linux support, it fails during package initialization on Linux. To work around this, we exclude the `internal/pkgdata/gen` package from unit tests to avoid initializing Ebitengine.