### PR TITLE
chore: remove `GODEBUG=gotypesalias=1`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,8 +21,6 @@ jobs:
           go-version: 1.23.4
 
       - name: Run unit test cases
-        env:
-          GODEBUG: gotypesalias=1
         run: go test -v -race -coverprofile=coverage.txt $(go list ./... | grep -v github.com/goplus/goxlsw/internal/pkgdata/gen)
 
       - name: Build WASM

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ through its API interfaces.
 1. Generate required package data:
 
   ```bash
-  GODEBUG=gotypesalias=1 go generate ./internal/pkgdata
+  go generate ./internal/pkgdata
   ```
 
 2. Build the project:
 
   ```bash
-  GOOS=js GOARCH=wasm GODEBUG=gotypesalias=1 go build -trimpath -o spxls.wasm
+  GOOS=js GOARCH=wasm go build -trimpath -o spxls.wasm
   ```
 
 ## Usage

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-GOOS=js GOARCH=wasm GODEBUG=gotypesalias=1 go build -trimpath -o spxls.wasm
+GOOS=js GOARCH=wasm go build -trimpath -o spxls.wasm


### PR DESCRIPTION
Since Go 1.23, the default value of the `GODEBUG=gotypesalias` flag has changed from `0` to `1`[^1]. Given that our minimum required version is now Go 1.23.4, this override is no longer necessary and can be safely removed.

[^1]: https://go.dev/doc/go1.23#gotypespkggotypes