### PR TITLE
fix(compileResult): skip spx definitions lookup for blank identifiers

### DIFF
--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -409,6 +409,9 @@ func (r *compileResult) spxDefinitionsFor(obj types.Object, selectorTypeName str
 // It returns multiple definitions only if the identifier is a Go+ overloadable
 // function.
 func (r *compileResult) spxDefinitionsForIdent(ident *gopast.Ident) []SpxDefinition {
+	if ident.Name == "_" {
+		return nil
+	}
 	typeInfo := getTypeInfo(r.proj)
 	return r.spxDefinitionsFor(typeInfo.ObjectOf(ident), r.selectorTypeNameForIdent(ident))
 }

--- a/internal/server/document_test.go
+++ b/internal/server/document_test.go
@@ -461,4 +461,18 @@ var (
 			Target: toURI("gop:main?Game.MySound"),
 		})
 	})
+
+	t.Run("BlankIdentifier", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx":          []byte(`type`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newMapFSWithoutModTime(m), nil, fileMapGetter(m))
+
+		links, err := s.textDocumentDocumentLink(&DocumentLinkParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.Empty(t, links)
+	})
 }


### PR DESCRIPTION
Fixes goplus/builder#1588