### PR TITLE
fix(textDocument/inlayHint): skip unresolved overload func call

### DIFF
--- a/internal/server/inlay_hint_test.go
+++ b/internal/server/inlay_hint_test.go
@@ -385,4 +385,22 @@ onStart => {
 		}
 		assert.Zero(t, rgbHintCount)
 	})
+
+	t.Run("UnresolvedOverloadFuncCall", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	onKey nonExistent
+}
+`),
+		}
+		s := New(newMapFSWithoutModTime(m), nil, fileMapGetter(m))
+
+		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		require.NoError(t, err)
+		require.NotNil(t, astFile)
+
+		inlayHints := collectInlayHints(result, astFile, 0, 0)
+		require.Nil(t, inlayHints)
+	})
 }

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -457,13 +457,18 @@ func funcFromCallExpr(typeInfo *typesutil.Info, expr *gopast.CallExpr) *types.Fu
 }
 
 // walkCallExprArgs walks the arguments of a call expression and calls the
-// provided walkFn for each argument.
+// provided walkFn for each argument. It does nothing if the function is not
+// found or if the function is Go+ FuncEx type.
 func walkCallExprArgs(typeInfo *typesutil.Info, expr *gopast.CallExpr, walkFn func(fun *types.Func, param *types.Var, arg gopast.Expr) bool) {
 	fun := funcFromCallExpr(typeInfo, expr)
 	if fun == nil {
 		return
 	}
 	sig := fun.Signature()
+	if _, ok := gogen.CheckFuncEx(sig); ok {
+		return
+	}
+
 	params := sig.Params()
 	if util.IsGopPackage(fun.Pkg()) {
 		_, methodName, ok := util.SplitGoptMethodName(fun.Name(), false)


### PR DESCRIPTION
Fixes goplus/builder#1653