### PR TITLE
refactor: safely resolve package path using `util.PackagePath`

### DIFF
--- a/internal/analysis/protocol/analysis.go
+++ b/internal/analysis/protocol/analysis.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goplus/gop/ast"
 	"github.com/goplus/gop/token"
 	goptypesutil "github.com/goplus/gop/x/typesutil"
+	"github.com/goplus/goxlsw/internal/util"
 )
 
 // An Analyzer describes an analysis function and its options.
@@ -189,7 +190,7 @@ func (pass *Pass) ReportRangef(rng Range, format string, args ...interface{}) {
 }
 
 func (pass *Pass) String() string {
-	return fmt.Sprintf("%s@%s", pass.Analyzer.Name, pass.Pkg.Path())
+	return fmt.Sprintf("%s@%s", pass.Analyzer.Name, util.PackagePath(pass.Pkg))
 }
 
 // A Fact is an intermediate fact produced during analysis.

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -371,7 +371,7 @@ func (r *compileResult) spxDefinitionsFor(obj types.Object, selectorTypeName str
 	}
 
 	var pkgDoc *pkgdoc.PkgDoc
-	if pkgPath := obj.Pkg().Path(); pkgPath == "main" {
+	if pkgPath := util.PackagePath(obj.Pkg()); pkgPath == "main" {
 		pkgDoc = getPkgDoc(r.proj)
 	} else {
 		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
@@ -448,7 +448,8 @@ func (r *compileResult) spxDefinitionForField(field *types.Var, selectorTypeName
 		pkgDoc = getPkgDoc(r.proj)
 	} else {
 		pkg := field.Pkg()
-		pkgDoc, _ = pkgdata.GetPkgDoc(pkg.Path())
+		pkgPath := util.PackagePath(pkg)
+		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
 	}
 	return GetSpxDefinitionForVar(field, selectorTypeName, forceVar, pkgDoc)
 }
@@ -467,7 +468,8 @@ func (r *compileResult) spxDefinitionForMethod(method *types.Func, selectorTypeN
 			selectorTypeName = selectorTypeName[idx+1:]
 		}
 		pkg := method.Pkg()
-		pkgDoc, _ = pkgdata.GetPkgDoc(pkg.Path())
+		pkgPath := util.PackagePath(pkg)
+		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
 	}
 	return GetSpxDefinitionForFunc(method, selectorTypeName, pkgDoc)
 }

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -610,7 +610,7 @@ func (ctx *completionContext) collectPackageMembers(pkg *types.Package) error {
 	}
 
 	var pkgDoc *pkgdoc.PkgDoc
-	if pkgPath := pkg.Path(); pkgPath == "main" {
+	if pkgPath := util.PackagePath(pkg); pkgPath == "main" {
 		pkgDoc = ctx.pkgDoc()
 	} else {
 		var err error
@@ -887,10 +887,10 @@ func (ctx *completionContext) collectSwitchCase() error {
 	}
 
 	var pkgDoc *pkgdoc.PkgDoc
-	if pkg.Path() == "main" {
+	if pkgPath := util.PackagePath(pkg); pkgPath == "main" {
 		pkgDoc = ctx.pkgDoc()
 	} else {
-		pkgDoc, _ = pkgdata.GetPkgDoc(pkg.Path())
+		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
 	}
 
 	scope := pkg.Scope()

--- a/internal/server/semantic_token.go
+++ b/internal/server/semantic_token.go
@@ -8,6 +8,7 @@ import (
 
 	gopast "github.com/goplus/gop/ast"
 	goptoken "github.com/goplus/gop/token"
+	"github.com/goplus/goxlsw/internal/util"
 )
 
 var (
@@ -160,7 +161,7 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (t
 				}
 			case *types.Var:
 				if obj.IsField() {
-					if obj.Pkg().Path() == "main" && result.isDefinedInFirstVarBlock(obj) {
+					if isMainPkgObject(obj) && result.isDefinedInFirstVarBlock(obj) {
 						tokenType = VariableType
 					} else {
 						tokenType = PropertyType
@@ -192,7 +193,7 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (t
 			if result.defIdentFor(obj) == node {
 				modifiers = append(modifiers, ModDeclaration)
 			}
-			if obj.Pkg() != nil && obj.Pkg().Path() != "main" && !strings.Contains(obj.Pkg().Path(), ".") {
+			if obj.Pkg() != nil && !isMainPkgObject(obj) && !strings.Contains(util.PackagePath(obj.Pkg()), ".") {
 				modifiers = append(modifiers, ModDefaultLibrary)
 			}
 			addToken(node.Pos(), node.End(), tokenType, modifiers)

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -476,7 +476,8 @@ var (
 	// GetSpxPkgDefinitions returns the spx definitions for the spx package.
 	GetSpxPkgDefinitions = sync.OnceValue(func() []SpxDefinition {
 		spxPkg := GetSpxPkg()
-		spxPkgDoc, err := pkgdata.GetPkgDoc(spxPkg.Path())
+		spxPkgPath := util.PackagePath(spxPkg)
+		spxPkgDoc, err := pkgdata.GetPkgDoc(spxPkgPath)
 		if err != nil {
 			panic(fmt.Errorf("failed to get spx package doc: %w", err))
 		}
@@ -501,7 +502,7 @@ var nonMainPkgSpxDefsCache sync.Map // map[*types.Package][]SpxDefinition
 
 // GetSpxDefinitionsForPkg returns the spx definitions for the given package.
 func GetSpxDefinitionsForPkg(pkg *types.Package, pkgDoc *pkgdoc.PkgDoc) (defs []SpxDefinition) {
-	if pkg.Path() != "main" {
+	if util.PackagePath(pkg) != "main" {
 		if defsIface, ok := nonMainPkgSpxDefsCache.Load(pkg); ok {
 			return defsIface.([]SpxDefinition)
 		}
@@ -602,7 +603,7 @@ func GetSpxDefinitionForVar(v *types.Var, selectorTypeName string, forceVar bool
 		TypeHint: v.Type(),
 
 		ID: SpxDefinitionIdentifier{
-			Package: util.ToPtr(v.Pkg().Path()),
+			Package: util.ToPtr(util.PackagePath(v.Pkg())),
 			Name:    &idName,
 		},
 		Overview: overview.String(),
@@ -646,7 +647,7 @@ func GetSpxDefinitionForConst(c *types.Const, pkgDoc *pkgdoc.PkgDoc) (def SpxDef
 		TypeHint: c.Type(),
 
 		ID: SpxDefinitionIdentifier{
-			Package: util.ToPtr(c.Pkg().Path()),
+			Package: util.ToPtr(util.PackagePath(c.Pkg())),
 			Name:    util.ToPtr(c.Name()),
 		},
 		Overview: overview.String(),
@@ -701,7 +702,7 @@ func GetSpxDefinitionForType(typeName *types.TypeName, pkgDoc *pkgdoc.PkgDoc) (d
 		TypeHint: typeName.Type(),
 
 		ID: SpxDefinitionIdentifier{
-			Package: util.ToPtr(typeName.Pkg().Path()),
+			Package: util.ToPtr(util.PackagePath(typeName.Pkg())),
 			Name:    util.ToPtr(typeName.Name()),
 		},
 		Overview: overview.String(),
@@ -771,7 +772,7 @@ func GetSpxDefinitionForFunc(fun *types.Func, recvTypeName string, pkgDoc *pkgdo
 		TypeHint: fun.Type(),
 
 		ID: SpxDefinitionIdentifier{
-			Package:    util.ToPtr(fun.Pkg().Path()),
+			Package:    util.ToPtr(util.PackagePath(fun.Pkg())),
 			Name:       &idName,
 			OverloadID: overloadID,
 		},
@@ -790,7 +791,7 @@ func GetSpxDefinitionForFunc(fun *types.Func, recvTypeName string, pkgDoc *pkgdo
 // is used in [SpxDefinition].
 func makeSpxDefinitionOverviewForFunc(fun *types.Func) (overview, parsedRecvTypeName, parsedName string, overloadID *string) {
 	pkg := fun.Pkg()
-	pkgPath := pkg.Path()
+	pkgPath := util.PackagePath(pkg)
 	isGopPkg := pkg.Scope().Lookup(util.GopPackage) != nil
 	name := fun.Name()
 	sig := fun.Type().(*types.Signature)
@@ -900,7 +901,7 @@ func GetSpxDefinitionForPkg(pkgName *types.PkgName, pkgDoc *pkgdoc.PkgDoc) (def 
 		TypeHint: pkgName.Type(),
 
 		ID: SpxDefinitionIdentifier{
-			Package: util.ToPtr(pkgName.Pkg().Path()),
+			Package: util.ToPtr(util.PackagePath(pkgName.Pkg())),
 		},
 		Overview: "package " + pkgName.Name(),
 		Detail:   detail,

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -230,14 +230,12 @@ func isSpxPkgObject(obj types.Object) bool {
 
 // isBuiltinObject reports whether the given object is a builtin object.
 func isBuiltinObject(obj types.Object) bool {
-	// Builtin objects do not belong to any package. But in the type system,
-	// they may have non-nil package with an empty path, e.g., append.
-	return obj != nil && (obj.Pkg() == nil || obj.Pkg().Path() == "")
+	return obj != nil && util.PackagePath(obj.Pkg()) == "builtin"
 }
 
 // isMainPkgObject reports whether the given object is defined in the main package.
 func isMainPkgObject(obj types.Object) bool {
-	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == "main"
+	return obj != nil && util.PackagePath(obj.Pkg()) == "main"
 }
 
 // isExportedOrMainPkgObject reports whether the given object is exported or

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -68,3 +68,18 @@ func SplitGopxFuncName(name string) (funcName string, ok bool) {
 	ok = true
 	return
 }
+
+// PackagePath returns the package path of the given pkg. It returns "builtin"
+// if the pkg is nil.
+func PackagePath(pkg *types.Package) string {
+	if pkg == nil {
+		return "builtin"
+	}
+	pkgPath := pkg.Path()
+	if pkgPath == "" {
+		// Builtin objects do not belong to any package. But in the type system of Go+,
+		// they may have non-nil package with an empty path, e.g., append.
+		return "builtin"
+	}
+	return pkgPath
+}


### PR DESCRIPTION
Fixes goplus/builder#1669