### PR TITLE
refactor(xgo.TypeInfo): optimize `DefIdentFor` with reverse mapping for `O(1)` lookup

### DIFF
--- a/internal/server/definition_test.go
+++ b/internal/server/definition_test.go
@@ -40,7 +40,7 @@ onStart => {
 			URI: "file:///main.spx",
 			Range: Range{
 				Start: Position{Line: 2, Character: 1},
-				End:   Position{Line: 2, Character: 1},
+				End:   Position{Line: 2, Character: 9},
 			},
 		}, mainSpxMySpriteDef.(Location))
 
@@ -66,7 +66,7 @@ onStart => {
 			URI: "file:///main.spx",
 			Range: Range{
 				Start: Position{Line: 2, Character: 1},
-				End:   Position{Line: 2, Character: 1},
+				End:   Position{Line: 2, Character: 9},
 			},
 		}, mainSpxMySpriteDef.(Location))
 	})
@@ -174,7 +174,7 @@ fmt2.println "Hello, spx!"
 			URI: "file:///main.spx",
 			Range: Range{
 				Start: Position{Line: 1, Character: 7},
-				End:   Position{Line: 1, Character: 7},
+				End:   Position{Line: 1, Character: 11},
 			},
 		}, def.(Location))
 	})


### PR DESCRIPTION
- Add `objToDef` reverse mapping field to `TypeInfo` for efficient object-to-identifier lookups.
- Partially revert #117 by reintroducing `DefIdentFor` usage in definition resolution with fallback.