### PR TITLE
chore: configure Dependabot multi-ecosystem groups for streamlined updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,21 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: weekly
+  go-modules:
+    schedule:
+      interval: weekly
+
 updates:
   - package-ecosystem: github-actions
     directory: /
-    labels:
-      - dependabot
-      - actions
-    schedule:
-      interval: daily
-
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
+    patterns:
+      - "*"
+    multi-ecosystem-group: infrastructure
+  - package-ecosystem: gomod
+    directory: /
+    patterns:
+      - "*"
+    multi-ecosystem-group: go-modules


### PR DESCRIPTION
Follow goplus/builder#2124 to migrate from individual ecosystem updates to multi-ecosystem groups for reduced PR volume and improved dependency management workflow.