### PR TITLE
fix(completion): avoid potential panic on typeless map literal

### DIFF
--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -811,11 +811,11 @@ func (s *Server) resolveSpxSpriteContextFromCallExpr(result *compileResult, call
 		return nil
 	}
 
-	funcTV, ok := typeInfo.Types[callExpr.Fun]
-	if !ok {
+	funcType := typeInfo.TypeOf(callExpr.Fun)
+	if !xgoutil.IsValidType(funcType) {
 		return nil
 	}
-	funcSig, ok := funcTV.Type.(*types.Signature)
+	funcSig, ok := funcType.(*types.Signature)
 	if !ok {
 		return nil
 	}

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -200,6 +200,24 @@ import "f
 		assert.True(t, containsCompletionItemLabel(items, "fmt"))
 	})
 
+	t.Run("IncompleteMapLiteralInCall", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+println {"key": }
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 1, Character: 15},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, items)
+	})
+
 	t.Run("InImportGroupStringLit", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`

--- a/xgo/xgoutil/type.go
+++ b/xgo/xgoutil/type.go
@@ -28,6 +28,11 @@ func DerefType(t types.Type) types.Type {
 	return t
 }
 
+// IsValidType reports whether typ is non-nil and not the invalid type sentinel.
+func IsValidType(typ types.Type) bool {
+	return typ != nil && typ != types.Typ[types.Invalid]
+}
+
 // IsTypesCompatible reports whether two types are compatible.
 func IsTypesCompatible(got, want types.Type) bool {
 	if got == nil || want == nil {

--- a/xgo/xgoutil/type_test.go
+++ b/xgo/xgoutil/type_test.go
@@ -70,6 +70,33 @@ func TestDerefType(t *testing.T) {
 	})
 }
 
+func TestIsValidType(t *testing.T) {
+	t.Run("NilType", func(t *testing.T) {
+		assert.False(t, IsValidType(nil))
+	})
+
+	t.Run("InvalidTypeSentinel", func(t *testing.T) {
+		assert.False(t, IsValidType(types.Typ[types.Invalid]))
+	})
+
+	t.Run("NamedType", func(t *testing.T) {
+		named := types.NewNamed(types.NewTypeName(0, nil, "MyInt", nil), types.Typ[types.Int], nil)
+		assert.True(t, IsValidType(named))
+	})
+
+	t.Run("BasicTypes", func(t *testing.T) {
+		assert.True(t, IsValidType(types.Typ[types.Int]))
+		assert.True(t, IsValidType(types.Typ[types.String]))
+		assert.True(t, IsValidType(types.Typ[types.Bool]))
+	})
+
+	t.Run("CompositeTypes", func(t *testing.T) {
+		assert.True(t, IsValidType(types.NewSlice(types.Typ[types.String])))
+		assert.True(t, IsValidType(types.NewPointer(types.Typ[types.Int])))
+		assert.True(t, IsValidType(types.NewStruct(nil, nil)))
+	})
+}
+
 func TestIsTypesCompatible(t *testing.T) {
 	t.Run("NilTypes", func(t *testing.T) {
 		assert.False(t, IsTypesCompatible(nil, nil))

--- a/xgo/xgoutil/xgoutil.go
+++ b/xgo/xgoutil/xgoutil.go
@@ -93,8 +93,8 @@ func EnclosingFuncSignature(typeInfo *xgotypes.Info, path []ast.Node) *types.Sig
 	for _, node := range slices.Backward(path) {
 		switch node := node.(type) {
 		case *ast.FuncLit:
-			if tv, ok := typeInfo.Types[node]; ok {
-				if sig, ok := tv.Type.(*types.Signature); ok {
+			if typ := typeInfo.TypeOf(node); IsValidType(typ) {
+				if sig, ok := typ.(*types.Signature); ok {
 					return sig
 				}
 			}


### PR DESCRIPTION
- Add `xgoutil.IsValidType` helper
- Guard all completion paths with `TypeInfo.TypeOf` and `IsValidType` before calling `Type.Underlying`
- Stop accessing `TypeInfo.Types` directly when only the type is needed