### PR TITLE
refactor: expose xgo-prefixed commands and protocol types

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,43 +82,42 @@ For detailed API references, please check the [index.d.ts](index.d.ts) file.
 
 ## Predefined commands
 
-### Resource renaming
+### XGo resource renaming
 
-The `spx.renameResources` command enables renaming of resources referenced by string literals (e.g., `play "explosion"`)
-across the workspace.
+The `xgo.renameResources` command enables renaming of XGo resources referenced by string literals (e.g.,
+`play "explosion"`) across the workspace.
 
 *Request:*
 
 - method: [`workspace/executeCommand`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_executeCommand)
-- params: [`ExecuteCommandParams`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#executeCommandParams)
-defined as follows:
+- params: `XGoRenameResourcesExecuteCommandParams` defined as follows:
 
 ```typescript
-interface ExecuteCommandParams {
+type XGoRenameResourcesExecuteCommandParams = Omit<ExecuteCommandParams, 'command' | 'arguments'> & {
   /**
    * The identifier of the actual command handler.
    */
-  command: 'spx.renameResources'
+  command: 'xgo.renameResources'
 
   /**
    * Arguments that the command should be invoked with.
    */
-  arguments: SpxRenameResourceParams[]
+  arguments: XGoRenameResourceParams[]
 }
 ```
 
 ```typescript
 /**
- * Parameters to rename an spx resource in the workspace.
+ * Parameters to rename an XGo resource in the workspace.
  */
-interface SpxRenameResourceParams {
+interface XGoRenameResourceParams {
   /**
-   * The spx resource.
+   * The XGo resource to rename.
    */
-  resource: SpxResourceIdentifier
+  resource: XGoResourceIdentifier
 
   /**
-   * The new name of the spx resource.
+   * The new name of the XGo resource.
    */
   newName: string
 }
@@ -126,21 +125,21 @@ interface SpxRenameResourceParams {
 
 ```typescript
 /**
- * The spx resource's identifier.
+ * The XGo resource's identifier.
  */
-interface SpxResourceIdentifier {
+interface XGoResourceIdentifier {
   /**
-   * The spx resource's URI.
+   * The XGo resource's URI.
    */
-  uri: SpxResourceUri
+  uri: XGoResourceUri
 }
 ```
 
 ```typescript
 /**
- * The spx resource's URI.
+ * The XGo resource's URI.
  *
- * @example
+ * For example:
  * - `spx://resources/sounds/MySound`
  * - `spx://resources/sprites/MySprite`
  * - `spx://resources/sprites/MySprite/costumes/MyCostume`
@@ -148,7 +147,7 @@ interface SpxResourceIdentifier {
  * - `spx://resources/backdrops/MyBackdrop`
  * - `spx://resources/widgets/MyWidget`
  */
-type SpxResourceUri = string
+type XGoResourceUri = string
 ```
 
 *Response:*
@@ -157,40 +156,39 @@ type SpxResourceUri = string
   | `null` describing the modification to the workspace. `null` should be treated the same as
   [`WorkspaceEdit`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspaceEdit)
 with no changes (no change was required).
-- error: code and message set in case when rename could not be performed for any reason.
+- error: code and message set when the rename operation cannot be performed for any reason.
 
-### Input slots lookup
+### XGo input slots lookup
 
-The `spx.getInputSlots` command retrieves all modifiable items (input slots) in a document, which can be used to
+The `xgo.getInputSlots` command retrieves all modifiable items (XGo input slots) in a document, which can be used to
 provide UI controls for assisting users with code modifications.
 
 *Request:*
 
 - method: [`workspace/executeCommand`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_executeCommand)
-- params: [`ExecuteCommandParams`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#executeCommandParams)
-defined as follows:
+- params: `XGoGetInputSlotsExecuteCommandParams` defined as follows:
 
 ```typescript
-interface ExecuteCommandParams {
+type XGoGetInputSlotsExecuteCommandParams = Omit<ExecuteCommandParams, 'command' | 'arguments'> & {
   /**
    * The identifier of the actual command handler.
    */
-  command: 'spx.getInputSlots'
+  command: 'xgo.getInputSlots'
 
   /**
    * Arguments that the command should be invoked with.
    */
-  arguments: [SpxGetInputSlotsParams]
+  arguments: [XGoGetInputSlotsParams]
 }
 ```
 
 ```typescript
 /**
- * Parameters to get input slots in a document.
+ * Parameters to retrieve XGo input slots in a document.
  */
-interface SpxGetInputSlotsParams {
+interface XGoGetInputSlotsParams {
   /**
-   * The text document identifier.
+   * The text document.
    */
   textDocument: TextDocumentIdentifier
 }
@@ -198,58 +196,62 @@ interface SpxGetInputSlotsParams {
 
 *Response:*
 
-- result: `SpxInputSlot[]` | `null` describing the input slots found in the document. `null` indicates no input slots
-  were found.
-- error: code and message set in case when input slots could not be retrieved for any reason.
+- result: `XGoInputSlot[]` | `null` describing the XGo input slots found in the document. `null` indicates no XGo input
+  slots were found.
+- error: code and message set when XGo input slots cannot be retrieved for any reason.
 
 ```typescript
 /**
- * Represents a modifiable item in the code.
+ * The XGo input slot for a modifiable item in code.
  */
-interface SpxInputSlot {
+interface XGoInputSlot {
   /**
-   * Kind of the slot.
-   * - Value: Modifiable values that can be replaced with different values.
-   * - Address: Modifiable operation objects that can be replaced with user-defined objects.
-   */
-  kind: SpxInputSlotKind
-
-  /**
-   * Info describing what inputs are accepted by the slot.
-   */
-  accept: SpxInputSlotAccept
-
-  /**
-   * Current input in the slot.
-   */
-  input: SpxInput
-
-  /**
-   * Names for available user-predefined identifiers.
-   */
-  predefinedNames: string[]
-
-  /**
-   * Range in code for the slot.
+   * The document range of the XGo input slot.
    */
   range: Range
+
+  /**
+   * The kind of the XGo input slot.
+   */
+  kind: XGoInputSlotKind
+
+  /**
+   * The accepted inputs for the XGo input slot.
+   */
+  accept: XGoInputSlotAccept
+
+  /**
+   * The current input in the XGo input slot.
+   */
+  input: XGoInput
+
+  /**
+   * The available user-predefined identifiers.
+   */
+  predefinedNames: string[]
 }
 ```
 
 ```typescript
 /**
- * The kind of input slot.
+ * The kinds of XGo input slots.
  */
-enum SpxInputSlotKind {
+enum XGoInputSlotKind {
   /**
-   * The slot accepts value, which may be an in-place value or a predefined identifier.
-   * For example: `123` in `println 123`.
+   * The slot accepts a value, which may be an in-place value or a predefined identifier.
+   *
+   * For example:
+   * - `123` in `println 123`
+   * - `name` in `println name`
    */
   Value = 'value',
 
   /**
-   * The slot accepts address, which must be a predefined identifier.
-   * For example: `x` in `x = 123`.
+   * The slot accepts an address, which must be a predefined identifier.
+   *
+   * For example:
+   * - `x` in `x = 123`
+   * - `y` in `x = y`
    */
   Address = 'address'
 }
@@ -257,37 +259,38 @@ enum SpxInputSlotKind {
 
 ```typescript
 /**
- * Info about what inputs are accepted by a slot.
+ * The accepted input for an XGo input slot.
  */
-type SpxInputSlotAccept =
+type XGoInputSlotAccept =
   | {
       /**
-       * Input type accepted by the slot.
+       * The input type accepted by the slot.
        */
       type:
-        | SpxInputType.Integer
-        | SpxInputType.Decimal
-        | SpxInputType.String
-        | SpxInputType.Boolean
-        | SpxInputType.SpxDirection
-        | SpxInputType.SpxLayerAction
-        | SpxInputType.SpxDirAction
-        | SpxInputType.SpxColor
-        | SpxInputType.SpxEffectKind
-        | SpxInputType.SpxKey
-        | SpxInputType.SpxSpecialObj
-        | SpxInputType.SpxRotationStyle
-        | SpxInputType.Unknown
+        | XGoInputType.String
+        | XGoInputType.Integer
+        | XGoInputType.Decimal
+        | XGoInputType.Boolean
+        | XGoInputType.Unknown
+        | XGoInputType.SpxDirection
+        | XGoInputType.SpxLayerAction
+        | XGoInputType.SpxDirAction
+        | XGoInputType.SpxColor
+        | XGoInputType.SpxEffectKind
+        | XGoInputType.SpxKey
+        | XGoInputType.SpxSpecialObj
+        | XGoInputType.SpxRotationStyle
     }
   | {
       /**
-       * Input type accepted by the slot.
+       * The input type accepted by the slot.
        */
-      type: SpxInputType.SpxResourceName
+      type: XGoInputType.SpxResourceName
+
       /**
-       * Resource context.
+       * The resource context for the resource name input type.
        */
-      resourceContext: SpxResourceContextURI
+      resourceContext: XGoResourceContextUri
     }
 ```
 
@@ -295,7 +298,12 @@ type SpxInputSlotAccept =
 /**
  * The type of input for a slot.
  */
-enum SpxInputType {
+enum XGoInputType {
+  /**
+   * String values.
+   */
+  String = 'string',
+
   /**
    * Integer number values.
    */
@@ -307,14 +315,14 @@ enum SpxInputType {
   Decimal = 'decimal',
 
   /**
-   * String values.
-   */
-  String = 'string',
-
-  /**
    * Boolean values.
    */
   Boolean = 'boolean',
+
+  /**
+   * Unknown type.
+   */
+  Unknown = 'unknown',
 
   /**
    * Resource name (`SpriteName`, `SoundName`, etc.) in spx.
@@ -359,76 +367,80 @@ enum SpxInputType {
   /**
    * Rotation style values in spx.
    */
-  SpxRotationStyle = 'spx-rotation-style',
-
-  /**
-   * Unknown type.
-   */
-  Unknown = 'unknown'
+  SpxRotationStyle = 'spx-rotation-style'
 }
 ```
 
 ```typescript
 /**
- * Name for color constructors.
+ * The names of color constructors.
  */
-type SpxInputTypeSpxColorConstructor = 'HSB' | 'HSBA'
+type XGoInputTypeSpxColorConstructor = 'HSB' | 'HSBA'
 ```
 
 ```typescript
 /**
- * Input value with type information.
+ * The input value with type information.
  */
-type SpxInputTypedValue =
-  | { type: SpxInputType.Integer; value: number }
-  | { type: SpxInputType.Decimal; value: number }
-  | { type: SpxInputType.String; value: string }
-  | { type: SpxInputType.Boolean; value: boolean }
-  | { type: SpxInputType.SpxResourceName; value: ResourceURI }
-  | { type: SpxInputType.SpxDirection; value: number }
-  | { type: SpxInputType.SpxLayerAction; value: string }
-  | { type: SpxInputType.SpxDirAction; value: string }
+type XGoInputTypedValue =
+  | { type: XGoInputType.String; value: string }
+  | { type: XGoInputType.Integer; value: number }
+  | { type: XGoInputType.Decimal; value: number }
+  | { type: XGoInputType.Boolean; value: boolean }
+  | { type: XGoInputType.Unknown; value: void }
+  | { type: XGoInputType.SpxResourceName; value: XGoResourceUri }
+  | { type: XGoInputType.SpxDirection; value: number }
+  | { type: XGoInputType.SpxLayerAction; value: string }
+  | { type: XGoInputType.SpxDirAction; value: string }
   | {
-      type: SpxInputType.SpxColor
+      type: XGoInputType.SpxColor
       value: {
         /**
          * Constructor for color.
          */
-        constructor: SpxInputTypeSpxColorConstructor
+        constructor: XGoInputTypeSpxColorConstructor
+
         /**
          * Arguments passed to the constructor.
          */
         args: number[]
       }
     }
-  | { type: SpxInputType.SpxEffectKind; value: string }
-  | { type: SpxInputType.SpxKey; value: string }
-  | { type: SpxInputType.SpxSpecialObj; value: string }
-  | { type: SpxInputType.SpxRotationStyle; value: string }
-  | { type: SpxInputType.Unknown; value: void }
+  | { type: XGoInputType.SpxEffectKind; value: string }
+  | { type: XGoInputType.SpxKey; value: string }
+  | { type: XGoInputType.SpxSpecialObj; value: string }
+  | { type: XGoInputType.SpxRotationStyle; value: string }
 ```
 
 ```typescript
 /**
- * URI of the resource context. Examples:
+ * The URI of the resource context.
+ *
+ * For example:
  * - `spx://resources/sprites`
  * - `spx://resources/sounds`
  * - `spx://resources/sprites/<sName>/costumes`
  */
-type SpxResourceContextURI = string
+type XGoResourceContextUri = string
 ```
 
 ```typescript
 /**
  * Represents the current input in a slot.
  */
-type SpxInput<T extends SpxInputTypedValue = SpxInputTypedValue> =
+type XGoInput<T extends XGoInputTypedValue = XGoInputTypedValue> =
   | {
       /**
-       * In-place value
-       * For example: `"hello world"`, `123`, `true`, spx `Left`, spx `HSB(0,0,0)`
+       * In-place value.
+       *
+       * For example:
+       * - `"hello world"`
+       * - `123`
+       * - `true`
+       * - spx `Left`
+       * - spx `HSB(0,0,0)`
        */
-      kind: SpxInputKind.InPlace
+      kind: XGoInputKind.InPlace
 
       /**
        * Type of the input.
@@ -442,10 +454,14 @@ type SpxInput<T extends SpxInputTypedValue = SpxInputTypedValue> =
     }
   | {
       /**
-       * (Reference to) user predefined identifier
-       * For example: var `costume1`, const `name2`, field `num3`
+       * (Reference to) user predefined identifier.
+       *
+       * For example:
+       * - var `costume1`
+       * - const `name2`
+       * - field `num3`
        */
-      kind: SpxInputKind.Predefined
+      kind: XGoInputKind.Predefined
 
       /**
        * Type of the input.
@@ -463,17 +479,27 @@ type SpxInput<T extends SpxInputTypedValue = SpxInputTypedValue> =
 /**
  * The kind of input.
  */
-enum SpxInputKind {
-  /**
-   * In-place value
-   * For example: `"hello world"`, `123`, `true`, spx `Left`, spx `HSB(0,0,0)`
-   */
+enum XGoInputKind {
+ /**
+  * In-place value.
+  *
+   * For example:
+   * - `"hello world"`
+   * - `123`
+   * - `true`
+   * - spx `Left`
+   * - spx `HSB(0,0,0)`
+  */
   InPlace = 'in-place',
 
   /**
-   * (Reference to) user predefined identifier
-   * For example: var `costume1`, const `name2`, field `num3`
-   */
+   * (Reference to) user predefined identifier.
+   *
+   * For example:
+   * - var `costume1`
+   * - const `name2`
+   * - field `num3`
+  */
   Predefined = 'predefined'
 }
 ```
@@ -484,25 +510,25 @@ enum SpxInputKind {
 
 ```typescript
 /**
- * The data of an spx resource reference DocumentLink.
+ * The data of an XGo resource reference DocumentLink.
  */
-interface SpxResourceRefDocumentLinkData {
+interface XGoResourceRefDocumentLinkData {
   /**
-   * The kind of the spx resource reference.
+   * The kind of the XGo resource reference.
    */
-  kind: SpxResourceRefKind
+  kind: XGoResourceRefKind
 }
 ```
 
 ```typescript
 /**
- * The kind of the spx resource reference.
+ * The kind of the XGo resource reference.
  *
  * - stringLiteral: String literal as a resource-reference, e.g., `play "explosion"`
  * - autoBindingReference: Reference for auto-binding variable as a resource-reference, e.g., `play explosion`
  * - constantReference: Reference for constant as a resource-reference, e.g., `play EXPLOSION` (`EXPLOSION` is a constant)
  */
-type SpxResourceRefKind = 'stringLiteral' | 'autoBindingReference' | 'constantReference'
+type XGoResourceRefKind = 'stringLiteral' | 'autoBindingReference' | 'constantReference'
 ```
 
 ### Completion item data types
@@ -511,11 +537,11 @@ type SpxResourceRefKind = 'stringLiteral' | 'autoBindingReference' | 'constantRe
 /**
  * The data of a completion item.
  */
-interface CompletionItemData {
+interface XGoCompletionItemData {
   /**
    * The corresponding definition of the completion item.
    */
-  definition?: SpxDefinitionIdentifier
+  definition?: XGoDefinitionIdentifier
 }
 ```
 
@@ -523,12 +549,13 @@ interface CompletionItemData {
 /**
  * The identifier of a definition.
  */
-interface SpxDefinitionIdentifier {
+interface XGoDefinitionIdentifier {
   /**
    * Full name of source package.
    * If not provided, it's assumed to be kind-statement.
    * If `main`, it's the current user package.
-   * Examples:
+   *
+   * For example:
    * - `fmt`
    * - `github.com/goplus/spx/v2`
    * - `main`
@@ -538,7 +565,8 @@ interface SpxDefinitionIdentifier {
   /**
    * Exported name of the definition.
    * If not provided, it's assumed to be kind-package.
-   * Examples:
+   *
+   * For example:
    * - `Println`
    * - `Sprite`
    * - `Sprite.turn`

--- a/client.ts
+++ b/client.ts
@@ -1,10 +1,10 @@
-import { type Files, type NotificationMessage, type RequestMessage, type ResponseMessage, type ResponseError as ResponseErrorObj, type Spxls } from '.'
+import { type Files, type NotificationMessage, type RequestMessage, type ResponseMessage, type ResponseError as ResponseErrorObj, type XGoLanguageServer } from '.'
 
 /**
- * Client wrapper for the spxls.
+ * Language client wrapper for the XGo language server.
  */
-export class Spxlc {
-  private ls: Spxls
+export class XGoLanguageClient {
+  private ls: XGoLanguageServer
   private nextRequestId: number = 1
   private pendingRequests = new Map<number, {
     resolve: (response: any) => void
@@ -17,7 +17,8 @@ export class Spxlc {
    * @param filesProvider Function that provides access to workspace files.
    */
   constructor(filesProvider: () => Files) {
-    const ls = NewSpxls(filesProvider, this.handleMessage.bind(this))
+    const factory = typeof NewXGoLanguageServer === 'function' ? NewXGoLanguageServer : NewSpxls
+    const ls = factory(filesProvider, this.handleMessage.bind(this))
     if (ls instanceof Error) throw ls
     this.ls = ls
   }
@@ -134,6 +135,13 @@ export class Spxlc {
   dispose(): void {
     this.pendingRequests.clear()
     this.notificationHandlers.clear()
+  }
+}
+
+/** @deprecated Use {@link XGoLanguageClient}. */
+export class Spxlc extends XGoLanguageClient {
+  constructor(filesProvider: () => Files) {
+    super(filesProvider)
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
-  * A lightweight XGo language server for spx that runs in the browser using WebAssembly.
+  * A lightweight XGo language server that runs in the browser using WebAssembly.
   */
-export interface Spxls {
+export interface XGoLanguageServer {
   /**
    * Handles incoming LSP messages from the client.
    *
@@ -10,9 +10,12 @@ export interface Spxls {
   handleMessage(message: RequestMessage | NotificationMessage): Error | null
 }
 
+/** @deprecated Use {@link XGoLanguageServer}. */
+export type Spxls = XGoLanguageServer
+
 declare global {
   /**
-   * Creates a new instance of the spx language server.
+   * Creates a new instance of the XGo language server.
    *
    * @param filesProvider - Function that provides access to the workspace files. All paths in the returned Files are
    *                       relative to the workspace root. This will be called whenever the language server needs to
@@ -21,7 +24,10 @@ declare global {
    * @param messageReplier - Function called when the language server needs to reply to the client. The client should
    *                        handle these messages according to the LSP specification.
    */
-  function NewSpxls(filesProvider: () => Files, messageReplier: (message: ResponseMessage | NotificationMessage) => void): Spxls | Error
+  function NewXGoLanguageServer(filesProvider: () => Files, messageReplier: (message: ResponseMessage | NotificationMessage) => void): XGoLanguageServer | Error
+
+  /** @deprecated Use {@link NewXGoLanguageServer}. */
+  function NewSpxls(filesProvider: () => Files, messageReplier: (message: ResponseMessage | NotificationMessage) => void): XGoLanguageServer | Error
 
   /**
    * Sets custom package data that will be used with higher priority than the embedded package data.

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -64,6 +64,14 @@ onStart => {
 				shouldExist bool
 			}{
 				{
+					name:        "String",
+					value:       "Hello",
+					acceptType:  SpxInputTypeString,
+					inputType:   SpxInputTypeString,
+					inputKind:   SpxInputKindInPlace,
+					shouldExist: true,
+				},
+				{
 					name:        "Integer",
 					value:       int64(5),
 					acceptType:  SpxInputTypeInteger,
@@ -72,10 +80,10 @@ onStart => {
 					shouldExist: true,
 				},
 				{
-					name:        "String",
-					value:       "Hello",
-					acceptType:  SpxInputTypeString,
-					inputType:   SpxInputTypeString,
+					name:        "Boolean",
+					value:       true,
+					acceptType:  SpxInputTypeBoolean,
+					inputType:   SpxInputTypeBoolean,
 					inputKind:   SpxInputKindInPlace,
 					shouldExist: true,
 				},
@@ -100,14 +108,6 @@ onStart => {
 					value:       "Forward",
 					acceptType:  SpxInputTypeDirAction,
 					inputType:   SpxInputTypeDirAction,
-					inputKind:   SpxInputKindInPlace,
-					shouldExist: true,
-				},
-				{
-					name:        "Boolean",
-					value:       true,
-					acceptType:  SpxInputTypeBoolean,
-					inputType:   SpxInputTypeBoolean,
 					inputKind:   SpxInputKindInPlace,
 					shouldExist: true,
 				},
@@ -414,6 +414,12 @@ onStart => {
 			wantInputType  SpxInputType
 		}{
 			{
+				name:           "String",
+				value:          "text",
+				wantAcceptType: SpxInputTypeUnknown,
+				wantInputType:  SpxInputTypeString,
+			},
+			{
 				name:           "Integer",
 				value:          int64(42),
 				wantAcceptType: SpxInputTypeUnknown,
@@ -426,10 +432,10 @@ onStart => {
 				wantInputType:  SpxInputTypeDecimal,
 			},
 			{
-				name:           "String",
-				value:          "text",
-				wantAcceptType: SpxInputTypeUnknown,
-				wantInputType:  SpxInputTypeString,
+				name:           "Boolean",
+				value:          true,
+				wantAcceptType: SpxInputTypeBoolean,
+				wantInputType:  SpxInputTypeBoolean,
 			},
 			{
 				name:           "RotationStyle",
@@ -448,12 +454,6 @@ onStart => {
 				value:          SpxResourceURI("spx://resources/sprites/OtherSprite"),
 				wantAcceptType: SpxInputTypeResourceName,
 				wantInputType:  SpxInputTypeResourceName,
-			},
-			{
-				name:           "Boolean",
-				value:          true,
-				wantAcceptType: SpxInputTypeBoolean,
-				wantInputType:  SpxInputTypeBoolean,
 			},
 			{
 				name:           "BinaryExprResult",
@@ -843,6 +843,14 @@ onStart => {
 		wantValue      any
 	}{
 		{
+			name:           "String",
+			litPosition:    Position{Line: 11, Character: 13},
+			wantAcceptType: SpxInputTypeString,
+			wantInputType:  SpxInputTypeString,
+			wantInputKind:  SpxInputKindInPlace,
+			wantValue:      "Hello, world!",
+		},
+		{
 			name:           "Integer",
 			litPosition:    Position{Line: 3, Character: 7},
 			wantAcceptType: SpxInputTypeInteger,
@@ -873,14 +881,6 @@ onStart => {
 			wantInputType:  SpxInputTypeDecimal,
 			wantInputKind:  SpxInputKindInPlace,
 			wantValue:      150.0, // 1.5e2 = 150
-		},
-		{
-			name:           "String",
-			litPosition:    Position{Line: 11, Character: 13},
-			wantAcceptType: SpxInputTypeString,
-			wantInputType:  SpxInputTypeString,
-			wantInputKind:  SpxInputKindInPlace,
-			wantValue:      "Hello, world!",
 		},
 		{
 			name:           "SpxResourceString",
@@ -1324,8 +1324,8 @@ func TestInferSpxInputTypeFromType(t *testing.T) {
 			typ  types.Type
 			want SpxInputType
 		}{
-			{"Bool", types.Typ[types.Bool], SpxInputTypeBoolean},
-			{"UntypedBool", types.Typ[types.UntypedBool], SpxInputTypeBoolean},
+			{"String", types.Typ[types.String], SpxInputTypeString},
+			{"UntypedString", types.Typ[types.UntypedString], SpxInputTypeString},
 
 			{"Int", types.Typ[types.Int], SpxInputTypeInteger},
 			{"Int8", types.Typ[types.Int8], SpxInputTypeInteger},
@@ -1343,8 +1343,8 @@ func TestInferSpxInputTypeFromType(t *testing.T) {
 			{"Float64", types.Typ[types.Float64], SpxInputTypeDecimal},
 			{"UntypedFloat", types.Typ[types.UntypedFloat], SpxInputTypeDecimal},
 
-			{"String", types.Typ[types.String], SpxInputTypeString},
-			{"UntypedString", types.Typ[types.UntypedString], SpxInputTypeString},
+			{"Bool", types.Typ[types.Bool], SpxInputTypeBoolean},
+			{"UntypedBool", types.Typ[types.UntypedBool], SpxInputTypeBoolean},
 
 			{"Complex64", types.Typ[types.Complex64], SpxInputTypeUnknown},
 			{"Complex128", types.Typ[types.Complex128], SpxInputTypeUnknown},

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -166,45 +166,46 @@ func toURI(s string) *URI {
 	return &u
 }
 
-// SpxRenameResourceParams represents parameters to rename an spx resource in
+// XGoRenameResourceParams represents parameters to rename an XGo resource in
 // the workspace.
-type SpxRenameResourceParams struct {
-	// The spx resource.
-	Resource SpxResourceIdentifier `json:"resource"`
-	// The new name of the spx resource.
+type XGoRenameResourceParams struct {
+	// The XGo resource to rename.
+	Resource XGoResourceIdentifier `json:"resource"`
+
+	// The new name of the XGo resource.
 	NewName string `json:"newName"`
 }
 
-// SpxResourceIdentifier identifies an spx resource.
-type SpxResourceIdentifier struct {
-	// The spx resource's URI.
-	URI SpxResourceURI `json:"uri"`
+// XGoResourceIdentifier identifies an XGo resource.
+type XGoResourceIdentifier struct {
+	// The XGo resource URI.
+	URI XGoResourceURI `json:"uri"`
 }
 
-// SpxResourceURI represents a URI string for an spx resource.
-type SpxResourceURI string
+// XGoResourceURI represents a URI string for an XGo resource.
+type XGoResourceURI string
 
-// HTML returns the HTML representation of the spx resource URI.
-func (u SpxResourceURI) HTML() string {
+// HTML returns the HTML representation of the XGo resource URI.
+func (u XGoResourceURI) HTML() string {
 	return fmt.Sprintf("<resource-preview resource=%q />\n", template.HTMLEscapeString(string(u)))
 }
 
-// SpxResourceContextURI represents a URI for resource context.
+// XGoResourceContextURI represents a URI for XGo resource context.
 // Examples:
 // - `spx://resources/sprites`
 // - `spx://resources/sounds`
 // - `spx://resources/sprites/<sName>/costumes`
-type SpxResourceContextURI string
+type XGoResourceContextURI string
 
-// SpxGetDefinitionsParams represents parameters to get definitions at a
+// XGoGetDefinitionsParams represents parameters to get definitions at a
 // specific position in a document.
-type SpxGetDefinitionsParams struct {
+type XGoGetDefinitionsParams struct {
 	// The text document position params.
 	protocol.TextDocumentPositionParams
 }
 
-// SpxDefinitionIdentifier identifies an spx definition.
-type SpxDefinitionIdentifier struct {
+// XGoDefinitionIdentifier identifies an XGo definition.
+type XGoDefinitionIdentifier struct {
 	// Full name of source package.
 	// If not provided, it's assumed to be kind-statement.
 	// If `main`, it's the current user package.
@@ -228,7 +229,7 @@ type SpxDefinitionIdentifier struct {
 }
 
 // String implements [fmt.Stringer].
-func (id SpxDefinitionIdentifier) String() string {
+func (id XGoDefinitionIdentifier) String() string {
 	s := "xgo:"
 	if id.Package != nil {
 		s += *id.Package
@@ -242,110 +243,200 @@ func (id SpxDefinitionIdentifier) String() string {
 	return s
 }
 
-// SpxGetInputSlotsParams represents parameters to get input slots for a
+// XGoGetInputSlotsParams holds parameters to get XGo input slots for a
 // specific document.
-type SpxGetInputSlotsParams struct {
-	// The text document indentifier.
+type XGoGetInputSlotsParams struct {
+	// The text document.
 	TextDocument protocol.TextDocumentIdentifier `json:"textDocument"`
 }
 
-// SpxInputSlot represents a modifiable item in the code.
-type SpxInputSlot struct {
-	Kind            SpxInputSlotKind   `json:"kind"`
-	Accept          SpxInputSlotAccept `json:"accept"`
-	Input           SpxInput           `json:"input"`
-	PredefinedNames []string           `json:"predefinedNames"`
+// XGoInputSlot describes a modifiable item in code.
+type XGoInputSlot struct {
 	Range           Range              `json:"range"`
+	Kind            XGoInputSlotKind   `json:"kind"`
+	Accept          XGoInputSlotAccept `json:"accept"`
+	Input           XGoInput           `json:"input"`
+	PredefinedNames []string           `json:"predefinedNames"`
 }
 
-// SpxInputSlotKind represents the kind of input slot.
-type SpxInputSlotKind string
+// XGoInputSlotKind enumerates kinds of XGo input slots.
+type XGoInputSlotKind string
 
-// SpxInputSlotKind constants.
+// XGoInputSlotKind constants.
 const (
-	// SpxInputSlotKindValue slot accepts value, which may be an in-place value or a predefined identifier.
-	SpxInputSlotKindValue SpxInputSlotKind = "value"
+	// XGoInputSlotKindValue slot accepts value, which may be an in-place value or a predefined identifier.
+	XGoInputSlotKindValue XGoInputSlotKind = "value"
 
-	// SpxInputSlotKindAddress slot accepts address, which must be a predefined identifier.
-	SpxInputSlotKindAddress SpxInputSlotKind = "address"
+	// XGoInputSlotKindAddress slot accepts address, which must be a predefined identifier.
+	XGoInputSlotKindAddress XGoInputSlotKind = "address"
 )
 
-// SpxInputSlotAccept represents info about what inputs are accepted by a slot.
-type SpxInputSlotAccept struct {
+// XGoInputSlotAccept represents info about what inputs are accepted by a slot.
+type XGoInputSlotAccept struct {
 	// Type of input accepted by the slot.
-	Type SpxInputType `json:"type"`
+	Type XGoInputType `json:"type"`
 
-	// Resource context for SpxInputTypeResourceName.
-	// Only valid when Type is SpxInputTypeResourceName.
-	ResourceContext *SpxResourceContextURI `json:"resourceContext,omitempty"`
+	// Resource context for XGoInputTypeSpxResourceName.
+	// Only valid when Type is XGoInputTypeSpxResourceName.
+	ResourceContext *XGoResourceContextURI `json:"resourceContext,omitempty"`
 }
 
-// SpxInputType represents the type of input for a slot.
-type SpxInputType string
+// XGoInputType represents the type of input for a slot.
+type XGoInputType string
 
-// SpxInputType constants.
+// XGoInputType constants.
 const (
-	SpxInputTypeInteger       SpxInputType = "integer"
-	SpxInputTypeDecimal       SpxInputType = "decimal"
-	SpxInputTypeString        SpxInputType = "string"
-	SpxInputTypeBoolean       SpxInputType = "boolean"
-	SpxInputTypeResourceName  SpxInputType = "spx-resource-name"
-	SpxInputTypeDirection     SpxInputType = "spx-direction"
-	SpxInputTypeLayerAction   SpxInputType = "spx-layer-action"
-	SpxInputTypeDirAction     SpxInputType = "spx-dir-action"
-	SpxInputTypeColor         SpxInputType = "spx-color"
-	SpxInputTypeEffectKind    SpxInputType = "spx-effect-kind"
-	SpxInputTypeKey           SpxInputType = "spx-key"
-	SpxInputTypeSpecialObj    SpxInputType = "spx-special-obj"
-	SpxInputTypeRotationStyle SpxInputType = "spx-rotation-style"
-	SpxInputTypeUnknown       SpxInputType = "unknown"
+	XGoInputTypeString           XGoInputType = "string"
+	XGoInputTypeInteger          XGoInputType = "integer"
+	XGoInputTypeDecimal          XGoInputType = "decimal"
+	XGoInputTypeBoolean          XGoInputType = "boolean"
+	XGoInputTypeUnknown          XGoInputType = "unknown"
+	XGoInputTypeSpxResourceName  XGoInputType = "spx-resource-name"
+	XGoInputTypeSpxDirection     XGoInputType = "spx-direction"
+	XGoInputTypeSpxLayerAction   XGoInputType = "spx-layer-action"
+	XGoInputTypeSpxDirAction     XGoInputType = "spx-dir-action"
+	XGoInputTypeSpxColor         XGoInputType = "spx-color"
+	XGoInputTypeSpxEffectKind    XGoInputType = "spx-effect-kind"
+	XGoInputTypeSpxKey           XGoInputType = "spx-key"
+	XGoInputTypeSpxSpecialObj    XGoInputType = "spx-special-obj"
+	XGoInputTypeSpxRotationStyle XGoInputType = "spx-rotation-style"
 )
 
-// SpxInputTypeSpxColorConstructor represents the name for color constructors.
-type SpxInputTypeSpxColorConstructor string
+// XGoInputTypeSpxColorConstructor represents the name for color constructors.
+type XGoInputTypeSpxColorConstructor string
 
-// SpxInputTypeSpxColorConstructor constants.
+// XGoInputTypeSpxColorConstructor constants.
 const (
-	SpxInputTypeSpxColorConstructorHSB  SpxInputTypeSpxColorConstructor = "HSB"
-	SpxInputTypeSpxColorConstructorHSBA SpxInputTypeSpxColorConstructor = "HSBA"
+	XGoInputTypeSpxColorConstructorHSB  XGoInputTypeSpxColorConstructor = "HSB"
+	XGoInputTypeSpxColorConstructorHSBA XGoInputTypeSpxColorConstructor = "HSBA"
 )
 
-// SpxColorInputValue represents the value structure for an [SpxInput] when its
-// type is [SpxInputTypeColor] and kind is [SpxInputKindInPlace].
-type SpxColorInputValue struct {
-	Constructor SpxInputTypeSpxColorConstructor `json:"constructor"`
-	Args        []float64                       `json:"args"`
-}
-
-// SpxInput represents the current input in a slot.
-type SpxInput struct {
-	Kind  SpxInputKind `json:"kind"`
-	Type  SpxInputType `json:"type"`
+// XGoInput represents the current input in a slot.
+type XGoInput struct {
+	Kind  XGoInputKind `json:"kind"`
+	Type  XGoInputType `json:"type"`
 	Value any          `json:"value,omitempty"` // For InPlace kind
 	Name  string       `json:"name,omitempty"`  // For Predefined kind
 }
 
-// SpxInputKind represents the kind of input.
-type SpxInputKind string
+// XGoInputKind represents the kind of input.
+type XGoInputKind string
 
-// SpxInputKind constants.
+// XGoInputKind constants.
 const (
-	// SpxInputKindInPlace in-place value like "hello world", 123, true, etc.
-	SpxInputKindInPlace SpxInputKind = "in-place"
+	// XGoInputKindInPlace in-place value like "hello world", 123, true, etc.
+	XGoInputKindInPlace XGoInputKind = "in-place"
 
-	// SpxInputKindPredefined reference to user predefined identifier.
-	SpxInputKindPredefined SpxInputKind = "predefined"
+	// XGoInputKindPredefined reference to user predefined identifier.
+	XGoInputKindPredefined XGoInputKind = "predefined"
 )
 
-// SpxResourceRefDocumentLinkData represents data for an spx resource reference
+// XGoInputSpxColorValue represents the value structure for an [XGoInput] when
+// its type is [XGoInputTypeSpxColor] and kind is [XGoInputKindInPlace].
+type XGoInputSpxColorValue struct {
+	Constructor XGoInputTypeSpxColorConstructor `json:"constructor"`
+	Args        []float64                       `json:"args"`
+}
+
+// XGoResourceRefDocumentLinkData represents data for an XGo resource reference
 // document link.
-type SpxResourceRefDocumentLinkData struct {
-	// The kind of the spx resource reference.
+type XGoResourceRefDocumentLinkData struct {
+	// The kind of the XGo resource reference.
 	Kind SpxResourceRefKind `json:"kind"`
 }
 
-// CompletionItemData represents data in a completion item.
-type CompletionItemData struct {
+// XGoCompletionItemData represents data in a completion item.
+type XGoCompletionItemData struct {
 	// The corresponding definition of the completion item.
-	Definition *SpxDefinitionIdentifier `json:"definition,omitempty"`
+	Definition *XGoDefinitionIdentifier `json:"definition,omitempty"`
 }
+
+// Deprecated: use XGoRenameResourceParams.
+type SpxRenameResourceParams = XGoRenameResourceParams
+
+// Deprecated: use XGoGetDefinitionsParams.
+type SpxGetDefinitionsParams = XGoGetDefinitionsParams
+
+// Deprecated: use XGoDefinitionIdentifier.
+type SpxDefinitionIdentifier = XGoDefinitionIdentifier
+
+// Deprecated: use XGoGetInputSlotsParams.
+type SpxGetInputSlotsParams = XGoGetInputSlotsParams
+
+// Deprecated: use XGoInputSlot.
+type SpxInputSlot = XGoInputSlot
+
+// Deprecated: use XGoInputSlotKind.
+type SpxInputSlotKind = XGoInputSlotKind
+
+const (
+	// Deprecated: use XGoInputSlotKindValue.
+	SpxInputSlotKindValue = XGoInputSlotKindValue
+	// Deprecated: use XGoInputSlotKindAddress.
+	SpxInputSlotKindAddress = XGoInputSlotKindAddress
+)
+
+// Deprecated: use XGoInputSlotAccept.
+type SpxInputSlotAccept = XGoInputSlotAccept
+
+// Deprecated: use XGoInput.
+type SpxInput = XGoInput
+
+// Deprecated: use XGoInputType.
+type SpxInputType = XGoInputType
+
+// Deprecated: use XGoInputType*.
+const (
+	SpxInputTypeString        SpxInputType = XGoInputTypeString
+	SpxInputTypeInteger       SpxInputType = XGoInputTypeInteger
+	SpxInputTypeDecimal       SpxInputType = XGoInputTypeDecimal
+	SpxInputTypeBoolean       SpxInputType = XGoInputTypeBoolean
+	SpxInputTypeUnknown       SpxInputType = XGoInputTypeUnknown
+	SpxInputTypeResourceName  SpxInputType = XGoInputTypeSpxResourceName
+	SpxInputTypeDirection     SpxInputType = XGoInputTypeSpxDirection
+	SpxInputTypeLayerAction   SpxInputType = XGoInputTypeSpxLayerAction
+	SpxInputTypeDirAction     SpxInputType = XGoInputTypeSpxDirAction
+	SpxInputTypeColor         SpxInputType = XGoInputTypeSpxColor
+	SpxInputTypeEffectKind    SpxInputType = XGoInputTypeSpxEffectKind
+	SpxInputTypeKey           SpxInputType = XGoInputTypeSpxKey
+	SpxInputTypeSpecialObj    SpxInputType = XGoInputTypeSpxSpecialObj
+	SpxInputTypeRotationStyle SpxInputType = XGoInputTypeSpxRotationStyle
+)
+
+// Deprecated: use XGoInputTypeSpxColorConstructor.
+type SpxInputTypeSpxColorConstructor = XGoInputTypeSpxColorConstructor
+
+// Deprecated: use XGoInputTypeSpxColorConstructor*.
+const (
+	SpxInputTypeSpxColorConstructorHSB  SpxInputTypeSpxColorConstructor = XGoInputTypeSpxColorConstructorHSB
+	SpxInputTypeSpxColorConstructorHSBA SpxInputTypeSpxColorConstructor = XGoInputTypeSpxColorConstructorHSBA
+)
+
+// Deprecated: use XGoInputKind.
+type SpxInputKind = XGoInputKind
+
+const (
+	// Deprecated: use XGoInputKindInPlace.
+	SpxInputKindInPlace = XGoInputKindInPlace
+
+	// Deprecated: use XGoInputKindPredefined.
+	SpxInputKindPredefined = XGoInputKindPredefined
+)
+
+// Deprecated: use XGoInputSpxColorValue.
+type SpxColorInputValue = XGoInputSpxColorValue
+
+// Deprecated: use XGoResourceRefDocumentLinkData.
+type SpxResourceRefDocumentLinkData = XGoResourceRefDocumentLinkData
+
+// Deprecated: use XGoResourceIdentifier.
+type SpxResourceIdentifier = XGoResourceIdentifier
+
+// Deprecated: use XGoResourceURI.
+type SpxResourceURI = XGoResourceURI
+
+// Deprecated: use XGoResourceContextURI.
+type SpxResourceContextURI = XGoResourceContextURI
+
+// Deprecated: use XGoCompletionItemData.
+type CompletionItemData = XGoCompletionItemData

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -404,7 +404,28 @@ fmt.Println("Hello, World!")
 			name:   "Workspace/ExecuteCommand",
 			method: "workspace/executeCommand",
 			params: ExecuteCommandParams{
-				Command: "spx.renameResource",
+				Command: CommandXGoRenameResources,
+				Arguments: func() []json.RawMessage {
+					arg := map[string]any{
+						"resource": map[string]any{
+							"uri": "spx://resources/sprites/sprite1",
+						},
+						"newName": "sprite2",
+					}
+					data, _ := json.Marshal(arg)
+					return []json.RawMessage{data}
+				}(),
+			},
+			files: map[string][]byte{
+				"main.spx": []byte("var x = 100\necho x"),
+			},
+			msgNum: 2,
+		},
+		{
+			name:   "Workspace/ExecuteCommandLegacy",
+			method: "workspace/executeCommand",
+			params: ExecuteCommandParams{
+				Command: CommandSpxRenameResources,
 				Arguments: func() []json.RawMessage {
 					arg := map[string]any{
 						"resource": map[string]any{

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ import (
 	"github.com/goplus/xgolsw/xgo"
 )
 
-// Spxls implements a lightweight XGo language server for spx that runs in the
-// browser using WebAssembly.
+// Spxls implements a lightweight XGo language server that runs in the browser
+// using WebAssembly.
 type Spxls struct {
 	messageReplier js.Value
 	server         *server.Server
@@ -190,6 +190,7 @@ func ConvertJSFilesToMap(files js.Value) map[string]*xgo.File {
 }
 
 func main() {
+	js.Global().Set("NewXGoLanguageServer", JSFuncOfWithError(NewSpxls))
 	js.Global().Set("NewSpxls", JSFuncOfWithError(NewSpxls))
 	js.Global().Set("SetCustomPkgdataZip", JSFuncOfWithError(SetCustomPkgdataZip))
 	js.Global().Set("SetClassfileAutoImportedPackages", JSFuncOfWithError(SetClassfileAutoImportedPackages))


### PR DESCRIPTION
- Promote `xgo.renameResources`/`xgo.getInputSlots` while keeping `spx.*` aliases
- Rename public protocol structs to `XGo*` and export deprecated `Spx*` aliases
- Refresh WASM/TS bindings with `XGoLanguageServer`/`Client` entry points