### PR TITLE
test(server): replace sleep-based waits with condition variable synchronization

### DIFF
--- a/internal/server/text_synchronization_test.go
+++ b/internal/server/text_synchronization_test.go
@@ -256,7 +256,6 @@ func TestDidOpen(t *testing.T) {
 			// Execute test
 			err := server.didOpen(tt.params)
 
-			time.Sleep(1 * time.Second)
 			// Verify results
 			if (err != nil) != tt.wantErr {
 				t.Errorf("didOpen() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Replace fixed `time.Sleep` calls in tests with a condition variable-based `waitForMessages` method that returns immediately when expected messages arrive.

Changes:
- Add `waitForMessages` method to `mockReplier` using `sync.Cond`
- Remove unnecessary 1s sleep in `TestDidOpen`
- Replace 100ms sleeps in `TestHandleMessage_Call` and `TestHandleMessage_Notification`
- Replace 10ms sleep in `TestServerCancellation`