### PR TITLE
fix: detect missing return errors in diagnostics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 tool github.com/goplus/xgolsw/cmd/pkgdatagen
 
 require (
-	github.com/goplus/gogen v1.19.6
+	github.com/goplus/gogen v1.19.7
 	github.com/goplus/mod v0.17.2
 	github.com/goplus/spx/v2 v2.0.0-pre.37
 	github.com/goplus/xgo v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/goplus/gogen v1.19.6 h1:NbWqC3WtBJQvwORPra6za0KRi01w4kAeAYMscZCt4j4=
-github.com/goplus/gogen v1.19.6/go.mod h1:owX2e1EyU5WD+Nm6oH2m/GXjLdlBYcwkLO4wN8HHXZI=
+github.com/goplus/gogen v1.19.7 h1:0i30on0GwtYIJ+D9/I5QujswBU+mnnmNewoRk/uRVkw=
+github.com/goplus/gogen v1.19.7/go.mod h1:owX2e1EyU5WD+Nm6oH2m/GXjLdlBYcwkLO4wN8HHXZI=
 github.com/goplus/mod v0.17.2 h1:7S4WQlgjw1EpYkJhToypDHgVve9JRJiN0gP3L2MeE7Y=
 github.com/goplus/mod v0.17.2/go.mod h1:/LyX3X45fuk1PINbNZCiAu0Eu85rTkU2Iz4PCYt/GdE=
 github.com/goplus/spbase v0.1.0 h1:JNZ0D/65DerYyv9/9IfrXHZZbd0WNK0jHiVvgCtZhwY=

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -610,7 +610,18 @@ func extractErrorMessage(fullError string) string {
 	// We want to extract just the "actual error message" part
 	parts := strings.SplitN(fullError, ": ", 2)
 	if len(parts) >= 2 {
-		return parts[1]
+		msg := parts[1]
+		// Remove "missing return" errors that may appear on subsequent lines.
+		// These are additional errors reported by gogen but not part of the primary error.
+		lines := strings.Split(msg, "\n")
+		var result []string
+		for _, line := range lines {
+			if strings.HasSuffix(line, ": missing return") {
+				continue
+			}
+			result = append(result, line)
+		}
+		return strings.Join(result, "\n")
 	}
 	return fullError
 }

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -601,8 +601,10 @@ func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
 			}
 		}
 
-		documentURI := s.toDocumentURI(spxFile)
-		result.addDiagnostics(documentURI, diagnostics...)
+		if len(diagnostics) > 0 {
+			documentURI := s.toDocumentURI(spxFile)
+			result.addDiagnostics(documentURI, diagnostics...)
+		}
 	}
 }
 

--- a/internal/server/text_synchronization.go
+++ b/internal/server/text_synchronization.go
@@ -219,8 +219,8 @@ func (s *Server) getDiagnostics(path string) ([]Diagnostic, error) {
 			// Handle code generation errors.
 			diagnostics = append(diagnostics, Diagnostic{
 				Severity: SeverityError,
-				Range:    RangeForPos(proj, codeError.Pos),
-				Message:  codeError.Error(),
+				Range:    RangeForPosEnd(proj, codeError.Pos, codeError.End),
+				Message:  codeError.Msg,
 			})
 		} else {
 			// Handle unknown errors (including recovered panics).


### PR DESCRIPTION
- Update gogen to include missing return detection for funcs with return values[^1], enabling "missing return" errors to be reported in the editor rather than only at runtime
- Use `RangeForPosEnd` instead of `RangeForPos` to properly report both start and end positions from `gogen.CodeError`
- Use `codeError.Msg` instead of `codeError.Error` to avoid duplicate position info in message
- Add `MissingReturn` test case for diagnostic detection
- Skip empty diagnosticss in `inspectDiagnosticsAnalyzers`

Fixes goplus/builder#2576

[^1]: https://github.com/goplus/gogen/pull/550