### PR TITLE
fix: detect unused variable errors in diagnostics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,5 @@ require (
 	golang.org/x/mobile v0.0.0-20220518205345-8578da9835fd // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/goplus/gogen => github.com/aofei/fork.goplus.gogen v0.0.0-20251219084322-cf6404f77529

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/aofei/fork.goplus.gogen v0.0.0-20251219084322-cf6404f77529 h1:oOyN9uzybZVME1Wg3hekWYiZWjslLZ1tk5x3Erp0saU=
+github.com/aofei/fork.goplus.gogen v0.0.0-20251219084322-cf6404f77529/go.mod h1:owX2e1EyU5WD+Nm6oH2m/GXjLdlBYcwkLO4wN8HHXZI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/goplus/gogen v1.19.7 h1:0i30on0GwtYIJ+D9/I5QujswBU+mnnmNewoRk/uRVkw=
-github.com/goplus/gogen v1.19.7/go.mod h1:owX2e1EyU5WD+Nm6oH2m/GXjLdlBYcwkLO4wN8HHXZI=
 github.com/goplus/mod v0.17.2 h1:7S4WQlgjw1EpYkJhToypDHgVve9JRJiN0gP3L2MeE7Y=
 github.com/goplus/mod v0.17.2/go.mod h1:/LyX3X45fuk1PINbNZCiAu0Eu85rTkU2Iz4PCYt/GdE=
 github.com/goplus/spbase v0.1.0 h1:JNZ0D/65DerYyv9/9IfrXHZZbd0WNK0jHiVvgCtZhwY=

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -222,7 +222,7 @@ func TestCodeBasedErrorTranslation(t *testing.T) {
 		},
 		{
 			name: "No new variables in :=",
-			code: `a := 1; a := "Hi"`,
+			code: `a := 1; a := "Hi"; _ = a`,
 			expectEnError: `no new variables on left side of :=
 main.xgo:1:14: cannot use "Hi" (type untyped string) as type int in assignment`,
 			expectCnError: `:= 左侧没有新变量
@@ -248,13 +248,14 @@ main.xgo:1:14: 无法将 "Hi" (类型 untyped string) 用作类型 int 在 assig
 func main() {
 	x := 1
 	x = bar()
+	_ = x
 }`,
 			expectEnError: `assignment mismatch: 1 variables but bar returns 2 values`,
 			expectCnError: `赋值不匹配: 1 个变量但 bar 返回 2 个值`,
 		},
 		{
 			name:          "Assignment mismatch multiple values",
-			code:          `x := 1; x = 1, "Hi"`,
+			code:          `x := 1; x = 1, "Hi"; _ = x`,
 			expectEnError: `assignment mismatch: 1 variables but 2 values`,
 			expectCnError: `赋值不匹配: 1 个变量但有 2 个值`,
 		},
@@ -310,7 +311,7 @@ func main() {
 		// 5. Control Flow Errors
 		{
 			name:          "Range type assignment error",
-			code:          `a := 1; var b []string; for _, a = range b {}`,
+			code:          `a := 1; _ = a; var b []string; for _, a = range b {}`,
 			expectEnError: `cannot assign type string to a (type int) in range`,
 			expectCnError: `无法在 range 中将类型 string 赋值给 a (类型 int)`,
 		},
@@ -322,13 +323,13 @@ func main() {
 		},
 		{
 			name:          "Label not defined goto",
-			code:          `x := 1; goto foo`,
+			code:          `x := 1; goto foo; _ = x`,
 			expectEnError: `label foo is not defined`,
 			expectCnError: `标签 foo 未定义`,
 		},
 		{
 			name:          "Label not defined break",
-			code:          `x := 1; break foo`,
+			code:          `x := 1; break foo; _ = x`,
 			expectEnError: `label foo is not defined`,
 			expectCnError: `标签 foo 未定义`,
 		},
@@ -370,19 +371,19 @@ func main() {
 		},
 		{
 			name:          "Array literal bounds with index",
-			code:          `a := "Hi"; b := [10]int{9: 1, 3}`,
+			code:          `_ = [10]int{9: 1, 3}`,
 			expectEnError: `array index 10 out of bounds [0:10]`,
 			expectCnError: `数组索引 10 超出范围 [0:10]`,
 		},
 		{
 			name:          "Array literal bounds overflow",
-			code:          `a := "Hi"; b := [1]int{1, 2}`,
+			code:          `_ = [1]int{1, 2}`,
 			expectEnError: `array index 1 out of bounds [0:1]`,
 			expectCnError: `数组索引 1 超出范围 [0:1]`,
 		},
 		{
 			name:          "Array index with value out of bounds",
-			code:          `a := "Hi"; b := [10]int{12: 2}`,
+			code:          `_ = [10]int{12: 2}`,
 			expectEnError: `array index 12 (value 12) out of bounds [0:10]`,
 			expectCnError: `数组索引 12 (值 12) 超出范围 [0:10]`,
 		},
@@ -468,13 +469,13 @@ func main() {
 		// 7. Struct Errors
 		{
 			name:          "Struct too many values",
-			code:          `x := 1; a := struct{x int; y string}{1, "Hi", 2}`,
+			code:          `_ = struct{x int; y string}{1, "Hi", 2}`,
 			expectEnError: `too many values in struct{x int; y string}{...}`,
 			expectCnError: `struct{...} 中值的数量错误`,
 		},
 		{
 			name:          "Struct too few values",
-			code:          `x := 1; a := struct{x int; y string}{1}`,
+			code:          `_ = struct{x int; y string}{1}`,
 			expectEnError: `too few values in struct{x int; y string}{...}`,
 			expectCnError: `struct{...} 中值的数量错误`,
 		},

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -38,6 +38,8 @@ onStart => {
 
 	// Spx resource name.
 	MySprite.stepTo "OtherSprite"
+
+	_, _, _, _, _, _ = message, direction, layerAction, dirAction, myColor, otherColor
 }
 `),
 			"MySprite.spx":                          []byte(``),
@@ -281,7 +283,7 @@ var (
 
 	t.Run("EmptyParams", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`var a = 1`),
+			"main.spx": []byte(`var a = 1; _ = a`),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
 
@@ -380,6 +382,8 @@ onStart => {
 	// Other commands
 	MySprite.turn MySprite.heading
 	getWidget Monitor, "myWidget"
+
+	_, _, _, _, _, _ = message, sum, isEqual, notTrue, myColor, calculateValue
 }
 `),
 		"MySprite.spx": []byte(`
@@ -601,6 +605,8 @@ onStart => {
 
 	// Other expressions.
 	arrayValue := []int{1, 2, 3}
+
+	_, _, _, _, _, _, _ = numValue, floatValue, strValue, dirValue, boolValue, colorValue, arrayValue
 }
 `),
 		"assets/index.json": []byte(`{}`),
@@ -736,6 +742,7 @@ onStart => {
 	varA = 10
 	println varA
 	otherVar := 20
+	_ = otherVar
 }
 `),
 		"assets/index.json": []byte(`{}`),
@@ -818,6 +825,8 @@ onStart => {
 	// String literals.
 	message := "Hello, world!"
 	MySprite.stepTo "OtherSprite"
+
+	_, _, _, _, _ = x, hexValue, y, scientific, message
 }
 `),
 		"MySprite.spx":                          []byte(``),
@@ -983,6 +992,8 @@ onStart => {
 
 	// Regular
 	myVar := regularVar
+
+	_, _ = boolVar, myVar
 }
 `),
 		"MySprite.spx":                       []byte(``),
@@ -1101,6 +1112,8 @@ onStart => {
 
 	// Logical not with boolean.
 	notBool := !true
+
+	_, _, _, _, _ = negInt, negFloat, posInt, complementInt, notBool
 }
 `),
 		"assets/index.json": []byte(`{}`),
@@ -1203,6 +1216,8 @@ onStart => {
 
 	// Non-color function calls.
 	println 1, 2, 3
+
+	_, _ = myColor1, myColor2
 }
 `),
 		"assets/index.json": []byte(`{}`),

--- a/internal/server/text_synchronization_test.go
+++ b/internal/server/text_synchronization_test.go
@@ -911,7 +911,7 @@ func TestGetDiagnostics(t *testing.T) {
 		},
 		{
 			name:           "type error",
-			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n}", // Type mismatch
+			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n\t_ = x\n}", // Type mismatch
 			path:           "/type_error.xgo",
 			wantDiagCount:  1,
 			wantSeverities: []protocol.DiagnosticSeverity{SeverityError},
@@ -927,7 +927,7 @@ func TestGetDiagnostics(t *testing.T) {
 		},
 		{
 			name:           "multiple type errors",
-			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n\tvar y bool = 42\n}",
+			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n\tvar y bool = 42\n\t_, _ = x, y\n}",
 			path:           "/multiple_errors.xgo",
 			wantDiagCount:  2,
 			wantSeverities: []protocol.DiagnosticSeverity{SeverityError},


### PR DESCRIPTION
- Bump gogen to include unused variable detection[^1], enabling "unused variable" errors to be reported in the editor rather than only at runtime
- Update test cases to use blank identifiers for unused variables

[^1]: https://github.com/goplus/gogen/pull/551