### PR TITLE
Filter invalid resource document links

### DIFF
--- a/internal/server/document.go
+++ b/internal/server/document.go
@@ -24,6 +24,9 @@ func (s *Server) textDocumentDocumentLink(params *DocumentLinkParams) ([]Documen
 		if xgoutil.NodeFilename(result.proj.Fset, spxResourceRef.Node) != spxFile {
 			continue
 		}
+		if !result.spxResourceSet.Contains(spxResourceRef.ID) {
+			continue
+		}
 		target := URI(spxResourceRef.ID.URI())
 		links = append(links, DocumentLink{
 			Range:  RangeForNode(result.proj, spxResourceRef.Node),

--- a/internal/server/document_test.go
+++ b/internal/server/document_test.go
@@ -513,6 +513,58 @@ const _ = 1
 		require.NoError(t, err)
 		require.Empty(t, links)
 	})
+
+	t.Run("InvalidSpxResourceReferencesFiltered", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+const ValidBackdrop BackdropName = "backdrop1"
+const MissingBackdrop BackdropName = "missingBackdrop"
+`),
+			"MySprite.spx": []byte(`
+onStart => {
+	play "MissingSound"
+	onBackdrop "backdrop1", func() {}
+	MySprite.setCostume "missingCostume"
+	MySprite.animate "missingAnim"
+	getWidget Monitor, "missingWidget"
+}
+`),
+			"assets/index.json":                  []byte(`{"backdrops":[{"name":"backdrop1"}],"zorder":[]}`),
+			"assets/sprites/MySprite/index.json": []byte(`{"costumes":[],"fAnimations":{}}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		collectTargets := func(links []DocumentLink) []string {
+			t.Helper()
+			targets := make([]string, 0, len(links))
+			for _, link := range links {
+				if link.Target == nil {
+					continue
+				}
+				targets = append(targets, string(*link.Target))
+			}
+			return targets
+		}
+
+		linksForMainSpx, err := s.textDocumentDocumentLink(&DocumentLinkParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		targetsForMainSpx := collectTargets(linksForMainSpx)
+		assert.Contains(t, targetsForMainSpx, "spx://resources/backdrops/backdrop1")
+		assert.NotContains(t, targetsForMainSpx, "spx://resources/backdrops/missingBackdrop")
+
+		linksForMySpriteSpx, err := s.textDocumentDocumentLink(&DocumentLinkParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+		})
+		require.NoError(t, err)
+		targetsForMySpriteSpx := collectTargets(linksForMySpriteSpx)
+		assert.Contains(t, targetsForMySpriteSpx, "spx://resources/backdrops/backdrop1")
+		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/sounds/MissingSound")
+		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/sprites/MySprite/costumes/missingCostume")
+		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/sprites/MySprite/animations/missingAnim")
+		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/widgets/missingWidget")
+	})
 }
 
 func TestSortDocumentLinks(t *testing.T) {

--- a/internal/server/document_test.go
+++ b/internal/server/document_test.go
@@ -527,6 +527,7 @@ onStart => {
 	MySprite.setCostume "missingCostume"
 	MySprite.animate "missingAnim"
 	getWidget Monitor, "missingWidget"
+	var missingSprite SpriteName = "MissingSprite"
 }
 `),
 			"assets/index.json":                  []byte(`{"backdrops":[{"name":"backdrop1"}],"zorder":[]}`),
@@ -561,6 +562,7 @@ onStart => {
 		targetsForMySpriteSpx := collectTargets(linksForMySpriteSpx)
 		assert.Contains(t, targetsForMySpriteSpx, "spx://resources/backdrops/backdrop1")
 		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/sounds/MissingSound")
+		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/sprites/MissingSprite")
 		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/sprites/MySprite/costumes/missingCostume")
 		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/sprites/MySprite/animations/missingAnim")
 		assert.NotContains(t, targetsForMySpriteSpx, "spx://resources/widgets/missingWidget")

--- a/internal/server/spx_resource.go
+++ b/internal/server/spx_resource.go
@@ -239,6 +239,28 @@ func (set *SpxResourceSet) Widget(name string) *SpxWidgetResource {
 	return set.widgets[name]
 }
 
+// Contains reports whether the given resource ID exists in the set.
+func (set *SpxResourceSet) Contains(id SpxResourceID) bool {
+	switch id := id.(type) {
+	case SpxBackdropResourceID:
+		return set.Backdrop(id.BackdropName) != nil
+	case SpxSoundResourceID:
+		return set.Sound(id.SoundName) != nil
+	case SpxSpriteResourceID:
+		return set.Sprite(id.SpriteName) != nil
+	case SpxSpriteCostumeResourceID:
+		sprite := set.Sprite(id.SpriteName)
+		return sprite != nil && sprite.Costume(id.CostumeName) != nil
+	case SpxSpriteAnimationResourceID:
+		sprite := set.Sprite(id.SpriteName)
+		return sprite != nil && sprite.Animation(id.AnimationName) != nil
+	case SpxWidgetResourceID:
+		return set.Widget(id.WidgetName) != nil
+	default:
+		return false
+	}
+}
+
 // SpxBackdropResource represents a backdrop resource in spx.
 type SpxBackdropResource struct {
 	ID   SpxBackdropResourceID `json:"-"`


### PR DESCRIPTION
Refs goplus/builder#2978

## Summary
- add a centralized SpxResourceSet containment check
- filter invalid resource references out of textDocument/documentLink responses
- add regression coverage for invalid resource references

## Testing
- go test ./internal/server
