### PR TITLE
refactor(spx): assume implicit `run` and fixed `assets`

### DIFF
--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -2084,7 +2084,6 @@ func TestIsPropertyOfEnclosingType(t *testing.T) {
 	t.Run("PropertyField", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "Test"}
 `),
 			"MySprite.spx": []byte(`
 var (
@@ -2156,7 +2155,6 @@ func onStart() {
 	t.Run("PropertyMethod", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "Test"}
 `),
 			"MySprite.spx": []byte(`
 var (
@@ -2240,7 +2238,6 @@ func TestFindEnclosingType(t *testing.T) {
 	t.Run("FieldEnclosingType", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "Test"}
 `),
 			"MySprite.spx": []byte(`
 var (
@@ -2361,7 +2358,6 @@ func onStart() {
 	t.Run("MethodEnclosingType", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "Test"}
 `),
 			"MySprite.spx": []byte(`
 func Speed() float64 {
@@ -2486,7 +2482,6 @@ func onStart() {
 	t.Run("EdgeCases", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "Test"}
 `),
 			"MySprite.spx": []byte(`
 var x int

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -497,44 +497,7 @@ func (s *Server) compileAndGetASTFileForDocumentURI(uri DocumentURI) (result *co
 
 // inspectForSpxResourceSet inspects for spx resource set in main.spx.
 func (s *Server) inspectForSpxResourceSet(snapshot *xgo.Project, result *compileResult) {
-	mainASTFile, _ := result.proj.ASTFile(result.mainSpxFile)
-	typeInfo, _ := snapshot.TypeInfo()
-	if typeInfo == nil {
-		return
-	}
-
-	var spxResourceRootDir string
-	for expr, tv := range typeInfo.Types {
-		if expr == nil || !expr.Pos().IsValid() || expr.Pos() < mainASTFile.Pos() || expr.End() > mainASTFile.End() {
-			continue
-		}
-
-		callExpr, ok := expr.(*xgoast.CallExpr)
-		if !ok || len(callExpr.Args) == 0 || tv.Type != GetSpxXGotGameRunFunc().Type() {
-			continue
-		}
-		firstArg := callExpr.Args[0]
-		firstArgTV, ok := typeInfo.Types[firstArg]
-		if !ok {
-			continue
-		}
-
-		if types.AssignableTo(firstArgTV.Type, types.Typ[types.String]) {
-			spxResourceRootDir, _ = xgoutil.StringLitOrConstValue(firstArg, firstArgTV)
-		} else {
-			documentURI := s.toDocumentURI(result.mainSpxFile)
-			result.addDiagnostics(documentURI, Diagnostic{
-				Severity: SeverityError,
-				Range:    RangeForNode(result.proj, firstArg),
-				Message:  s.translate("first argument of run must be a string literal or constant"),
-			})
-		}
-		break
-	}
-	if spxResourceRootDir == "" {
-		spxResourceRootDir = "assets"
-	}
-	spxResourceSet, err := NewSpxResourceSet(snapshot, spxResourceRootDir)
+	spxResourceSet, err := NewSpxResourceSet(snapshot)
 	if err != nil {
 		documentURI := s.toDocumentURI(result.mainSpxFile)
 		result.addDiagnostics(documentURI, Diagnostic{

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -14,7 +14,6 @@ func TestServerTextDocumentCompletion(t *testing.T) {
 			"main.spx": []byte(`
 
 MySprite.
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -98,7 +97,6 @@ onStart => {
 onStart => {
 
 }
-run "assets", {Title: "My Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -125,7 +123,7 @@ run "assets", {Title: "My Game"}
 	t.Run("InStringLit", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "a
+echo "a
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -133,7 +131,7 @@ run "a
 		items, err := s.textDocumentCompletion(&CompletionParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 6},
+				Position:     Position{Line: 1, Character: 7},
 			},
 		})
 		require.NoError(t, err)
@@ -145,7 +143,6 @@ run "a
 		m := map[string][]byte{
 			"main.spx": []byte(`
 // Run My G
-run "assets", {Title: "My Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -154,25 +151,6 @@ run "assets", {Title: "My Game"}
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
 				Position:     Position{Line: 1, Character: 11},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, items)
-		assert.Empty(t, items)
-	})
-
-	t.Run("InStringLit", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-run "a
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		items, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 6},
 			},
 		})
 		require.NoError(t, err)
@@ -509,7 +487,6 @@ fmt.
 onStart => {
 
 }
-run "assets", {Title: "My Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -554,7 +531,6 @@ func test() {}
 onStart => {
 	var x i
 }
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 `),
@@ -586,7 +562,6 @@ run "assets", {Title: "My Game"}
 onStart => {
 	var x SpriteName = "m"
 }
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 `),
@@ -615,7 +590,6 @@ type MySpriteName = SpriteName
 onStart => {
 	var x MySpriteName = "m"
 }
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx":                       []byte(``),
 			"assets/index.json":                  []byte(`{}`),
@@ -639,7 +613,6 @@ run "assets", {Title: "My Game"}
 		m := map[string][]byte{
 			"main.spx": []byte(`
 play "r"
-run "assets", {Title: "My Game"}
 `),
 			"assets/index.json":                  []byte(`{}`),
 			"assets/sounds/recording/index.json": []byte(`{}`),
@@ -662,7 +635,6 @@ run "assets", {Title: "My Game"}
 		m := map[string][]byte{
 			"main.spx": []byte(`
 play r
-run "assets", {Title: "My Game"}
 `),
 			"assets/index.json":                  []byte(`{}`),
 			"assets/sounds/recording/index.json": []byte(`{}`),
@@ -684,7 +656,6 @@ run "assets", {Title: "My Game"}
 	t.Run("WithImplicitSpxSpriteResource", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onClick => {
@@ -712,7 +683,6 @@ onClick => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.setCostume "c"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx":                       []byte(``),
 			"assets/index.json":                  []byte(`{}`),
@@ -735,7 +705,6 @@ run "assets", {Title: "My Game"}
 	t.Run("WithCrossSpxSpriteResource", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"Sprite1.spx": []byte(`
 onClick => {
@@ -2473,7 +2442,6 @@ onStart => {}
 		m := map[string][]byte{
 			"main.spx": []byte(`
 var score int
-run "assets", {Title: "My Game"}
 onStart => {
 	showVar(x)
 }
@@ -2487,7 +2455,7 @@ onStart => {
 		items, err := s.textDocumentCompletion(&CompletionParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 4, Character: 10}, // inside 'x' arg of showVar
+				Position:     Position{Line: 3, Character: 10}, // inside 'x' arg of showVar
 			},
 		})
 		require.NoError(t, err)
@@ -2507,7 +2475,6 @@ onStart => {
 		// hp is a field of MySprite, so its appearance confirms the correct target is used.
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 var hp int
@@ -2538,7 +2505,6 @@ onStart => {
 		// MySprite.showVar(x) in main.spx → getPropertyTarget returns "MySprite"
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 onStart => {
 	MySprite.showVar(x)
 }
@@ -2555,7 +2521,7 @@ var hp int
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
 				// Line 3: "\tMySprite.showVar(x)" — tab(0)+MySprite(1-8)+.(9)+showVar(10-16)+(17)+x(18)
-				Position: Position{Line: 3, Character: 19},
+				Position: Position{Line: 2, Character: 19},
 			},
 		})
 		require.NoError(t, err)
@@ -2571,7 +2537,6 @@ var hp int
 		// SpriteImpl is embedded in MySprite; its property methods should appear.
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 var hp int

--- a/internal/server/definition_test.go
+++ b/internal/server/definition_test.go
@@ -12,7 +12,6 @@ func TestServerTextDocumentDefinition(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.turn Left
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -73,7 +72,6 @@ var x int
 	t.Run("ThisPtr", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-this.run "assets", {Title: "My Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})

--- a/internal/server/diagnostic_test.go
+++ b/internal/server/diagnostic_test.go
@@ -10,7 +10,6 @@ import (
 func newTestFileMap() map[string][]byte {
 	return map[string][]byte{
 		"main.spx": []byte(`
-run "assets", {Title: "Bullet (by XGo)"}
 `),
 		"MyAircraft.spx": []byte(`
 onStart => {
@@ -304,7 +303,6 @@ var (
 		m := map[string][]byte{
 			"main.spx": []byte(`
 play "Sound1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 const ConstSoundName = "ConstSoundName"
@@ -388,7 +386,6 @@ onStart => {
 			"main.spx": []byte(`
 onBackdrop "", func() {}
 onBackdrop "NonExistentBackdrop", func() {}
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 const ConstBackdropName = "ConstBackdropName"
@@ -459,7 +456,6 @@ onStart => {
 			"main.spx": []byte(`
 MySprite.say "hi"
 MySprite.touching "OtherSprite"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -509,7 +505,6 @@ onStart => {
 	t.Run("SpriteCostumeResourceNotFound", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -557,7 +552,6 @@ onStart => {
 	t.Run("SpriteAnimationResourceNotFound", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -605,7 +599,6 @@ onStart => {
 	t.Run("WidgetResourceNotFound", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 const ConstWidgetName = "ConstWidgetName"
@@ -665,7 +658,6 @@ onStart => {
 	t.Run("WithNonBasicTypeAliases", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 import "image/color"
@@ -697,7 +689,6 @@ onKey KeyLeft, => {}
 
 onKey [KeyRight, KeyUp, KeyDown], => {}
 
-run "assets", {Title: "My Game"}
 `),
 			"assets/index.json": []byte(`{}`),
 		}

--- a/internal/server/document_test.go
+++ b/internal/server/document_test.go
@@ -13,7 +13,6 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 			"main.spx": []byte(`
 const Backdrop1 BackdropName = "backdrop1"
 const Backdrop1a = Backdrop1
-run "assets", {Title: "Bullet (by XGo)"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -36,7 +35,7 @@ onStart => {
 			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
 		})
 		require.NoError(t, err)
-		require.Len(t, linksForMainSpx, 8)
+		require.Len(t, linksForMainSpx, 6)
 		assert.Contains(t, linksForMainSpx, DocumentLink{
 			Range: Range{
 				Start: Position{Line: 1, Character: 6},
@@ -85,21 +84,6 @@ onStart => {
 				Kind: SpxResourceRefKindConstantReference,
 			},
 		})
-		assert.Contains(t, linksForMainSpx, DocumentLink{
-			Range: Range{
-				Start: Position{Line: 3, Character: 0},
-				End:   Position{Line: 3, Character: 3},
-			},
-			Target: toURI("xgo:github.com/goplus/spx/v2?Game.run"),
-		})
-		assert.Contains(t, linksForMainSpx, DocumentLink{
-			Range: Range{
-				Start: Position{Line: 3, Character: 15},
-				End:   Position{Line: 3, Character: 20},
-			},
-			Target: toURI("xgo:github.com/goplus/spx/v2?Config.Title"),
-		})
-
 		linksForMySpriteSpx, err := s.textDocumentDocumentLink(&DocumentLinkParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
 		})

--- a/internal/server/format_test.go
+++ b/internal/server/format_test.go
@@ -19,7 +19,6 @@ var (
   Bullet Bullet
 )
 type Score int
-run "assets",    { Title:    "Bullet (by XGo)" }
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -33,7 +32,7 @@ run "assets",    { Title:    "Bullet (by XGo)" }
 		assert.Contains(t, edits, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 9, Character: 0},
+				End:   Position{Line: 8, Character: 0},
 			},
 			NewText: `// An spx game.
 
@@ -43,8 +42,6 @@ var (
 	MyAircraft MyAircraft
 	Bullet     Bullet
 )
-
-run "assets", {Title: "Bullet (by XGo)"}
 `,
 		})
 	})
@@ -76,7 +73,7 @@ run "assets", {Title: "Bullet (by XGo)"}
 
 	t.Run("NoChangesNeeded", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`run "assets", {Title: "Bullet (by XGo)"}` + "\n"),
+			"main.spx": []byte(``),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
 		params := &DocumentFormattingParams{
@@ -250,8 +247,6 @@ var (
 var (
 	MySprite
 )
-
-run "assets", {Title: "My Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -272,8 +267,6 @@ import "math"
 onClick => {
 	println math.floor(2.5)
 }
-
-run "assets", {Title: "My Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -428,7 +421,6 @@ const b = "123"
 
 // floating comment4
 
-run "assets", {Title: "My Game"}
 
 // floating comment5
 `),
@@ -444,7 +436,7 @@ run "assets", {Title: "My Game"}
 		assert.Contains(t, edits, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 24, Character: 0},
+				End:   Position{Line: 23, Character: 0},
 			},
 			NewText: `import "fmt"
 
@@ -468,8 +460,6 @@ func test() {
 }
 
 // floating comment4
-
-run "assets", {Title: "My Game"}
 
 // floating comment5
 `,
@@ -569,7 +559,6 @@ var (
 	moveStep int = 20
 )
 
-run "assets", {Title: "Snake Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -583,7 +572,7 @@ run "assets", {Title: "Snake Game"}
 		assert.Contains(t, edits, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 12, Character: 0},
+				End:   Position{Line: 11, Character: 0},
 			},
 			NewText: `// An spx game.
 
@@ -595,8 +584,6 @@ var (
 var (
 	moveStep int = 20
 )
-
-run "assets", {Title: "Snake Game"}
 `,
 		})
 	})
@@ -623,7 +610,6 @@ var (
     gameSpeed int = 5
 )
 
-run "assets", {Title: "Game"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -637,7 +623,7 @@ run "assets", {Title: "Game"}
 		assert.Contains(t, edits, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 21, Character: 0},
+				End:   Position{Line: 20, Character: 0},
 			},
 			NewText: `// An spx game.
 
@@ -654,8 +640,6 @@ var (
 
 	gameSpeed int = 5
 )
-
-run "assets", {Title: "Game"}
 `,
 		})
 	})
@@ -680,7 +664,6 @@ var (
     name string = "DefaultPlayer"
 )
 
-run "assets", {Title: "Game With Comments"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -694,7 +677,7 @@ run "assets", {Title: "Game With Comments"}
 		assert.Contains(t, edits, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 19, Character: 0},
+				End:   Position{Line: 18, Character: 0},
 			},
 			NewText: `// An spx game.
 
@@ -713,8 +696,6 @@ var (
 	// Player name
 	name string = "DefaultPlayer"
 )
-
-run "assets", {Title: "Game With Comments"}
 `,
 		})
 	})
@@ -728,7 +709,6 @@ var y int = 10
 var z string
 var name string = "Player"
 
-run "assets", {Title: "Single Vars"}
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -742,7 +722,7 @@ run "assets", {Title: "Single Vars"}
 		assert.Contains(t, edits, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 8, Character: 0},
+				End:   Position{Line: 7, Character: 0},
 			},
 			NewText: `// An spx game.
 
@@ -757,8 +737,6 @@ var (
 
 	name string = "Player"
 )
-
-run "assets", {Title: "Single Vars"}
 `,
 		})
 	})

--- a/internal/server/highlight_test.go
+++ b/internal/server/highlight_test.go
@@ -13,7 +13,6 @@ func TestServerTextDocumentDocumentHighlight(t *testing.T) {
 			"main.spx": []byte(`
 MySprite.turn Left
 MySprite.turn Right
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -48,7 +48,6 @@ MySprite.setCostume "costume1"
 Game.onClick => {}
 onClick => {}
 Camera.follow "MySprite"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 MySprite.onClick => {}

--- a/internal/server/reference_test.go
+++ b/internal/server/reference_test.go
@@ -13,7 +13,6 @@ func TestServerTextDocumentReferences(t *testing.T) {
 			"main.spx": []byte(`
 MySprite.turn Left
 MySprite.turn Right
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {

--- a/internal/server/rename_test.go
+++ b/internal/server/rename_test.go
@@ -13,7 +13,6 @@ func TestServerTextDocumentPrepareRename(t *testing.T) {
 			"main.spx": []byte(`
 const title = "My Game"
 MySprite.turn Left
-run "assets", {Title: title}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -63,7 +62,6 @@ onStart => {
 onClick => {
 	_ = this
 }
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onClick => {
@@ -100,7 +98,6 @@ onClick => {
 onClick => {
 	_ = this
 }
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onClick => {
@@ -156,7 +153,6 @@ func TestServerTextDocumentRename(t *testing.T) {
 			"main.spx": []byte(`
 const Foo = "bar"
 MySprite.turn Left
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 println Foo
@@ -204,7 +200,6 @@ onStart => {
 			"main.spx": []byte(`
 const Foo = "bar"
 MySprite.turn Left
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 println Foo
@@ -251,7 +246,6 @@ onStart => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.turnTo "OtherSprite"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -288,7 +282,6 @@ onStart => {
 onClick => {
 	_ = this
 }
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onClick => {
@@ -323,7 +316,6 @@ func TestServerSpxRenameBackdropResource(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 onBackdrop "backdrop1", func() {}
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -370,7 +362,6 @@ onStart => {
 			"main.spx": []byte(`
 const Backdrop1 = "backdrop1"
 onBackdrop Backdrop1, func() {}
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -410,7 +401,6 @@ onStart => {
 			"main.spx": []byte(`
 const Backdrop1 BackdropName = "backdrop1"
 onBackdrop "backdrop1", func() {}
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -463,7 +453,6 @@ onStart => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 onBackdrop "backdrop1", func() {}
-run "assets", {Title: "My Game"}
 `),
 			"assets/index.json": []byte(`{"backdrops":[{"name":"backdrop1","path":"backdrop1.png"},{"name":"backdrop2","path":"backdrop2.png"}]}`),
 		}
@@ -486,7 +475,6 @@ func TestServerSpxRenameSoundResource(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 play "Sound1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -534,7 +522,6 @@ onStart => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 play "Sound1"
-run "assets", {Title: "My Game"}
 `),
 			"assets/index.json":               []byte(`{}`),
 			"assets/sounds/Sound1/index.json": []byte(`{"path":"sound1.wav"}`),
@@ -559,7 +546,6 @@ func TestServerSpxRenameSpriteResource(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 Sprite1.turn Left
-run "assets", {Title: "My Game"}
 `),
 			"Sprite1.spx": []byte(`
 onStart => {
@@ -607,7 +593,6 @@ onStart => {
 			"main.spx": []byte(`
 Sprite1.turn Left
 Sprite2.turn Left
-run "assets", {Title: "My Game"}
 `),
 			"Sprite1.spx": []byte(`
 onStart => {
@@ -682,7 +667,6 @@ func TestServerSpxRenameSpriteCostumeResource(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.setCostume "costume1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -729,7 +713,6 @@ onStart => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.setCostume "costume1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -756,7 +739,6 @@ onStart => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.setCostume "costume1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -785,7 +767,6 @@ func TestServerSpxRenameSpriteAnimationResource(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.animate "anim1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -832,7 +813,6 @@ onStart => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.animate "anim1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -859,7 +839,6 @@ onStart => {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.animate "anim1"
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -887,7 +866,6 @@ func TestServerSpxRenameWidgetResource(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -922,7 +900,6 @@ onStart => {
 	t.Run("AlreadyExists", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {

--- a/internal/server/semantic_token_test.go
+++ b/internal/server/semantic_token_test.go
@@ -12,7 +12,6 @@ func TestServerTextDocumentSemanticTokensFull(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
 MySprite.turn Left
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {
@@ -35,14 +34,7 @@ onStart => {
 			0, 8, 1, 13, 0, // .
 			0, 1, 4, 8, 0, // turn
 			0, 5, 4, 5, 6, // Left
-			1, 0, 3, 7, 0, // run
-			0, 4, 8, 11, 0, // assets
-			0, 10, 1, 13, 0, // {
-			0, 1, 5, 6, 0, // Title
-			0, 5, 1, 13, 0, // :
-			0, 2, 9, 11, 0, // My Game
-			0, 9, 1, 13, 0, // }
-			0, 1, 1, 13, 0, // }
+			0, 4, 1, 13, 0, // }
 		}, mainSpxTokens.Data)
 
 		mySpriteTokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{

--- a/internal/server/signature_test.go
+++ b/internal/server/signature_test.go
@@ -14,7 +14,6 @@ func TestTextDocumentSignatureHelp(t *testing.T) {
 import "fmt"
 fmt.Println 
 MySprite.turn Left
-run "assets", {Title: "My Game"}
 `),
 			"MySprite.spx": []byte(`
 onStart => {

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -538,11 +538,6 @@ var (
 		return spxPkg.Scope().Lookup("HSBA").(*types.Func)
 	})
 
-	// GetSpxXGotGameRunFunc returns the [spx.XGot_Game_Run] type.
-	GetSpxXGotGameRunFunc = sync.OnceValue(func() *types.Func {
-		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("XGot_Game_Run").(*types.Func)
-	})
 )
 
 // nonMainPkgSpxDefsCache is a cache of non-main package spx definitions.

--- a/internal/server/spx_resource.go
+++ b/internal/server/spx_resource.go
@@ -80,10 +80,12 @@ type SpxResourceSet struct {
 	widgets   map[string]*SpxWidgetResource
 }
 
+const spxResourceRootDir = "assets"
+
 // NewSpxResourceSet creates a new spx resource set.
-func NewSpxResourceSet(proj *xgo.Project, rootDir string) (*SpxResourceSet, error) {
+func NewSpxResourceSet(proj *xgo.Project) (*SpxResourceSet, error) {
 	// Read and parse the main index.json for backdrops and widgets.
-	metadataPath := rootDir + "/index.json"
+	metadataPath := spxResourceRootDir + "/index.json"
 	metadataFile, ok := proj.File(metadataPath)
 	if !ok {
 		return nil, fmt.Errorf("failed to read metadata: %w", fs.ErrNotExist)
@@ -116,10 +118,10 @@ func NewSpxResourceSet(proj *xgo.Project, rootDir string) (*SpxResourceSet, erro
 	}
 
 	// Read sounds directory.
-	soundDirs := listSubdirs(proj, rootDir+"/sounds")
+	soundDirs := listSubdirs(proj, spxResourceRootDir+"/sounds")
 	sounds := make(map[string]*SpxSoundResource, len(soundDirs))
 	for _, soundName := range soundDirs {
-		soundMetadataPath := rootDir + "/sounds/" + soundName + "/index.json"
+		soundMetadataPath := spxResourceRootDir + "/sounds/" + soundName + "/index.json"
 		soundMetadataFile, ok := proj.File(soundMetadataPath)
 		if !ok {
 			return nil, fmt.Errorf("failed to read sound metadata: %w", fs.ErrNotExist)
@@ -136,10 +138,10 @@ func NewSpxResourceSet(proj *xgo.Project, rootDir string) (*SpxResourceSet, erro
 	}
 
 	// Read sprites directory.
-	spriteDirs := listSubdirs(proj, rootDir+"/sprites")
+	spriteDirs := listSubdirs(proj, spxResourceRootDir+"/sprites")
 	sprites := make(map[string]*SpxSpriteResource, len(spriteDirs))
 	for _, spriteName := range spriteDirs {
-		spriteMetadataPath := rootDir + "/sprites/" + spriteName + "/index.json"
+		spriteMetadataPath := spxResourceRootDir + "/sprites/" + spriteName + "/index.json"
 		spriteMetadataFile, ok := proj.File(spriteMetadataPath)
 		if !ok {
 			return nil, fmt.Errorf("failed to read sprite metadata: %w", fs.ErrNotExist)


### PR DESCRIPTION
Stop deriving the resource root from `run` and always load the spx resource set from `assets`.

Remove stale `run`-specific server expectations and update test fixtures to avoid explicit `run` calls now that spx invokes it implicitly. Keep the string-literal completion cases with minimal non-`run` context so they still exercise the same code path.