### PR TITLE
fix(completion): deduplicate spx resource suggestions

### DIFF
--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -103,6 +103,7 @@ type completionContext struct {
 	kind completionKind
 
 	enclosingNode      xgoast.Node
+	enclosingCallExpr  *xgoast.CallExpr
 	selectorExpr       *xgoast.SelectorExpr
 	expectedTypes      []types.Type
 	expectedStructType *types.Struct
@@ -135,6 +136,9 @@ func (ctx *completionContext) analyze() {
 				ctx.selectorExpr = node
 			}
 		case *xgoast.CallExpr:
+			if ctx.enclosingCallExpr == nil {
+				ctx.enclosingCallExpr = node
+			}
 			if typ := ctx.typeInfo.TypeOf(node.Fun); !xgoutil.IsValidType(typ) {
 				continue
 			}
@@ -420,10 +424,16 @@ func (ctx *completionContext) analyze() {
 				}
 			}
 		case *xgoast.GoStmt:
+			if ctx.enclosingCallExpr == nil {
+				ctx.enclosingCallExpr = node.Call
+			}
 			ctx.kind = completionKindCall
 			ctx.enclosingNode = node.Call
 			ctx.valueExpression = true
 		case *xgoast.DeferStmt:
+			if ctx.enclosingCallExpr == nil {
+				ctx.enclosingCallExpr = node.Call
+			}
 			ctx.kind = completionKindCall
 			ctx.enclosingNode = node.Call
 			ctx.valueExpression = true
@@ -1279,7 +1289,7 @@ func (ctx *completionContext) collectCall() error {
 					expectedTypes = append(expectedTypes, sig.Params().At(sig.Params().Len()-1).Type().(*types.Slice).Elem())
 				}
 			}
-			ctx.expectedTypes = slices.Compact(expectedTypes)
+			ctx.expectedTypes = deduplicateTypes(expectedTypes)
 			return ctx.collectGeneral()
 		}
 	}
@@ -1290,6 +1300,23 @@ func (ctx *completionContext) collectCall() error {
 		ctx.expectedTypes = []types.Type{sig.Params().At(sig.Params().Len() - 1).Type().(*types.Slice).Elem()}
 	}
 	return ctx.collectGeneral()
+}
+
+func deduplicateTypes(expectedTypes []types.Type) []types.Type {
+	if len(expectedTypes) <= 1 {
+		return expectedTypes
+	}
+
+	deduplicated := make([]types.Type, 0, len(expectedTypes))
+	for _, expectedType := range expectedTypes {
+		if slices.ContainsFunc(deduplicated, func(existing types.Type) bool {
+			return types.Identical(existing, expectedType)
+		}) {
+			continue
+		}
+		deduplicated = append(deduplicated, expectedType)
+	}
+	return deduplicated
 }
 
 // getCurrentArgIndex gets the current argument index in a function call.
@@ -1391,8 +1418,13 @@ func (ctx *completionContext) collectTypeSpecific(typ types.Type) error {
 			spxResourceIDs = append(spxResourceIDs, SpxWidgetResourceID{spxWidgetName})
 		}
 	}
+	seenResourceNames := make(map[string]struct{}, len(spxResourceIDs))
 	for _, spxResourceID := range spxResourceIDs {
 		name := spxResourceID.Name()
+		if _, ok := seenResourceNames[name]; ok {
+			continue
+		}
+		seenResourceNames[name] = struct{}{}
 		if !ctx.inStringLit {
 			name = strconv.Quote(name)
 		}
@@ -1410,42 +1442,25 @@ func (ctx *completionContext) collectTypeSpecific(typ types.Type) error {
 // getSpxSpriteResource returns a [SpxSpriteResource] for the current context.
 // It returns nil if no [SpxSpriteResource] can be inferred.
 func (ctx *completionContext) getSpxSpriteResource() *SpxSpriteResource {
-	if ctx.kind != completionKindCall {
-		return nil
+	callExpr := ctx.getEnclosingCallExpr()
+	if callExpr != nil {
+		return inferSpxSpriteResourceEnclosingNode(ctx.result, callExpr)
 	}
+	return ctx.getCurrentFileSpxSpriteResource()
+}
 
-	callExpr, ok := ctx.enclosingNode.(*xgoast.CallExpr)
-	if !ok {
-		return nil
+func (ctx *completionContext) getEnclosingCallExpr() *xgoast.CallExpr {
+	if callExpr, ok := ctx.enclosingNode.(*xgoast.CallExpr); ok {
+		return callExpr
 	}
-	sel, ok := callExpr.Fun.(*xgoast.SelectorExpr)
-	if !ok {
-		if ctx.spxFile == "main.spx" {
-			return nil
-		}
-		return ctx.result.spxResourceSet.sprites[strings.TrimSuffix(ctx.spxFile, ".spx")]
-	}
+	return ctx.enclosingCallExpr
+}
 
-	ident, ok := sel.X.(*xgoast.Ident)
-	if !ok {
+func (ctx *completionContext) getCurrentFileSpxSpriteResource() *SpxSpriteResource {
+	if ctx.spxFile == "" || path.Base(ctx.spxFile) == path.Base(ctx.result.mainSpxFile) {
 		return nil
 	}
-	obj := ctx.typeInfo.ObjectOf(ident)
-	if obj == nil {
-		return nil
-	}
-	named, ok := xgoutil.DerefType(obj.Type()).(*types.Named)
-	if !ok {
-		return nil
-	}
-
-	if named == GetSpxSpriteType() {
-		return ctx.result.spxResourceSet.sprites[ident.Name]
-	}
-	if ctx.result.hasSpxSpriteType(named) {
-		return ctx.result.spxResourceSet.sprites[obj.Name()]
-	}
-	return nil
+	return ctx.result.spxResourceSet.sprites[strings.TrimSuffix(path.Base(ctx.spxFile), ".spx")]
 }
 
 // getPropertyTarget returns the target type name for property name completions.

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -761,6 +761,147 @@ onClick => {
 		assert.True(t, containsCompletionItemLabel(items, "Sprite2Costume"))
 	})
 
+	t.Run("WithCrossSpxSpriteResourceInGoStmt", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Sprite1.spx": []byte(`
+onClick => {
+	go Sprite2.setCostume("c")
+}
+`),
+			"Sprite2.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///Sprite1.spx"},
+				Position:     Position{Line: 2, Character: 25},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, items)
+		assert.NotEmpty(t, items)
+		assert.True(t, containsCompletionItemLabel(items, "Sprite2Costume"))
+	})
+
+	t.Run("WithCrossSpxSpriteResourceInDeferStmt", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Sprite1.spx": []byte(`
+onClick => {
+	defer Sprite2.setCostume("c")
+}
+`),
+			"Sprite2.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///Sprite1.spx"},
+				Position:     Position{Line: 2, Character: 28},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, items)
+		assert.NotEmpty(t, items)
+		assert.True(t, containsCompletionItemLabel(items, "Sprite2Costume"))
+	})
+
+	t.Run("SpriteCostumeNameInImplicitCallUsesCurrentSprite", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Sprite1.spx": []byte(`
+onStart => {
+	setCostume C
+}
+`),
+			"Sprite2.spx":                       []byte(``),
+			"Sprite3.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Crab2"},{"name":"Crab3"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+			"assets/sprites/Sprite3/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///Sprite1.spx"},
+				Position:     Position{Line: 2, Character: 13},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, items)
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
+	})
+
+	t.Run("SpriteCostumeNameInDeclDeduplicatesCrossSpriteNames", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	var costume SpriteCostumeName = C
+}
+`),
+			"Sprite1.spx":                       []byte(``),
+			"Sprite2.spx":                       []byte(``),
+			"Sprite3.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Crab2"},{"name":"Crab3"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+			"assets/sprites/Sprite3/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 34},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, items)
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
+	})
+
+	t.Run("StepToOverloadsDeduplicateSpriteNameSuggestions", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Runner.spx": []byte(`
+onStart => {
+	stepTo C
+}
+`),
+			"Crab2.spx":                        []byte(``),
+			"Crab3.spx":                        []byte(``),
+			"assets/index.json":                []byte(`{}`),
+			"assets/sprites/Runner/index.json": []byte(`{"costumes":[]}`),
+			"assets/sprites/Crab2/index.json":  []byte(`{"costumes":[]}`),
+			"assets/sprites/Crab3/index.json":  []byte(`{"costumes":[]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///Runner.spx"},
+				Position:     Position{Line: 2, Character: 10},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, items)
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
+	})
+
 	t.Run("AtLineStartWithAnIdentifier", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`
@@ -2631,6 +2772,16 @@ func containsCompletionItemLabel(items []CompletionItem, label string) bool {
 	return slices.ContainsFunc(items, func(item CompletionItem) bool {
 		return item.Label == label
 	})
+}
+
+func countCompletionItemLabel(items []CompletionItem, label string) int {
+	count := 0
+	for _, item := range items {
+		if item.Label == label {
+			count++
+		}
+	}
+	return count
 }
 
 func containsCompletionSpxDefinitionID(items []CompletionItem, id SpxDefinitionIdentifier) bool {


### PR DESCRIPTION
Track the nearest enclosing call while analyzing completion context so sprite-scoped resource name completion can still infer the target sprite outside direct call-value contexts.

Deduplicate overload-derived expected types before collecting type- specific items so calls like `stepTo` do not emit repeated sprite-name suggestions. Also deduplicate emitted resource names as a final guard when multiple sprites share the same asset name.

Add regression coverage for implicit `setCostume`, typed `SpriteCostumeName` declarations, and overload-based `stepTo` completions.

---

<img width="776" height="423" alt="Screenshot 2026-04-10 at 11 56 02" src="https://github.com/user-attachments/assets/ef95bf5d-8d04-4bcb-ad43-f061cc8dfc77" />
