### PR TITLE
test(xgo): expand coverage and align test conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,27 @@ Guidelines for AI coding agents working on this project.
 This project is the language server implementation for [XBuilder](https://github.com/goplus/builder), providing LSP
 features (completion, diagnostics, hover, etc.) for XGo source files.
 
+## Code conventions
+
+### Import alias conventions
+
+In `xgo` and its subpackages, prefer the XGo package when a corresponding package exists for a standard library `go/*`
+import. When these packages are needed under `xgo/`, keep the XGo package as the simple name.
+
+- Use `ast` for `github.com/goplus/xgo/ast`
+- Use `format` for `github.com/goplus/xgo/format`
+- Use `parser` for `github.com/goplus/xgo/parser`
+- Use `printer` for `github.com/goplus/xgo/printer`
+- Use `scanner` for `github.com/goplus/xgo/scanner`
+- Use `token` for `github.com/goplus/xgo/token`
+- Use `types` for `github.com/goplus/xgolsw/xgo/types`
+
+Only import the standard library counterpart when it is genuinely required. In that case, use a `go` prefix alias such
+as `goast`, `goformat`, `goparser`, `goprinter`, `goscanner`, `gotoken`, or `gotypes`.
+
+Do not use aliases such as `xgoast`, `xgotoken`, or `xgotypes` in `xgo/`. Apply the same convention in both production
+code and unit tests.
+
 ## Testing conventions
 
 ### assert vs require

--- a/xgo/ast.go
+++ b/xgo/ast.go
@@ -18,13 +18,13 @@ package xgo
 
 import (
 	"fmt"
-	"go/scanner"
-	"go/token"
 	"path"
 	"strings"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/parser"
+	"github.com/goplus/xgo/scanner"
+	"github.com/goplus/xgo/token"
 )
 
 // astFileCacheKind is a cache kind type for [ast.File].

--- a/xgo/ast_test.go
+++ b/xgo/ast_test.go
@@ -17,9 +17,9 @@
 package xgo
 
 import (
-	"go/scanner"
 	"testing"
 
+	"github.com/goplus/xgo/scanner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,7 +48,7 @@ func Test() {
 
 		// Verify the AST structure.
 		astFile := astFileCache.astFile
-		assert.NotNil(t, astFile.Name)
+		require.NotNil(t, astFile.Name)
 		assert.Equal(t, "main", astFile.Name.Name)
 		assert.NotEmpty(t, astFile.Decls)
 	})
@@ -95,6 +95,13 @@ func Test() {
 		assert.NotNil(t, astFileCache1.astFile)
 		assert.NotNil(t, astFileCache2.astFile)
 	})
+
+	t.Run("RecoverFromPanic", func(t *testing.T) {
+		cache, err := buildASTFileCache(nil, "main.spx", file(`var x int`))
+		assert.Nil(t, cache)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parser panic")
+	})
 }
 
 func TestProjectASTFile(t *testing.T) {
@@ -114,7 +121,7 @@ func Test() {
 		require.NoError(t, err)
 		require.NotNil(t, astFile)
 
-		assert.NotNil(t, astFile.Name)
+		require.NotNil(t, astFile.Name)
 		assert.Equal(t, "main", astFile.Name.Name)
 		assert.NotEmpty(t, astFile.Decls)
 	})
@@ -203,6 +210,23 @@ func ValidFunc() {}
 		assert.Equal(t, "main", astPkg.Name)
 		assert.Contains(t, astPkg.Files, "valid.spx")
 		assert.NotNil(t, astPkg.Files["valid.spx"])
+	})
+
+	t.Run("ASTFileNonScannerError", func(t *testing.T) {
+		proj := NewProject(nil, map[string]*File{
+			"main.spx": file(`var x int`),
+		}, 0)
+
+		cache, err := buildASTPackageCache(proj)
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+
+		astPackageCache, ok := cache.(*astPackageCache)
+		require.True(t, ok)
+		require.NotNil(t, astPackageCache.astPkg)
+		assert.Error(t, astPackageCache.parserErr)
+		assert.Contains(t, astPackageCache.parserErr.Error(), ErrUnknownCacheKind.Error())
+		assert.Empty(t, astPackageCache.astPkg.Files)
 	})
 }
 

--- a/xgo/cache_test.go
+++ b/xgo/cache_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProjectRegisterCacheBuilder(t *testing.T) {
@@ -43,7 +44,7 @@ func TestProjectRegisterCacheBuilder(t *testing.T) {
 
 		// Test cache building.
 		data, err := proj.Cache(testCacheKind{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "test-data", data)
 	})
 
@@ -68,11 +69,11 @@ func TestProjectRegisterCacheBuilder(t *testing.T) {
 
 		// Test both caches.
 		data1, err1 := proj.Cache(testCacheKind1{})
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, "data-1", data1)
 
 		data2, err2 := proj.Cache(testCacheKind2{})
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "data-2", data2)
 	})
 
@@ -97,7 +98,7 @@ func TestProjectRegisterCacheBuilder(t *testing.T) {
 
 		// Test that new cache builder is used.
 		data, err := proj.Cache(testCacheKind{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "updated-data", data)
 	})
 
@@ -142,7 +143,7 @@ func TestProjectRegisterCacheBuilder(t *testing.T) {
 
 		// Test cache building.
 		data, err := proj.Cache(testCacheKind{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		result := data.(map[string]any)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
@@ -168,7 +169,7 @@ func TestProjectRegisterFileCacheBuilder(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, []byte("package test"), data)
 	})
 
@@ -195,11 +196,11 @@ func TestProjectRegisterFileCacheBuilder(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data1, err1 := proj.FileCache(testCacheKind1{}, "test.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, len("package test"), data1)
 
 		data2, err2 := proj.FileCache(testCacheKind2{}, "test.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "test.go", data2)
 	})
 
@@ -226,7 +227,7 @@ func TestProjectRegisterFileCacheBuilder(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "updated", data)
 	})
 
@@ -274,7 +275,7 @@ func TestProjectRegisterFileCacheBuilder(t *testing.T) {
 
 		// Test cache building.
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		result := data.(map[string]any)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
@@ -297,7 +298,7 @@ func TestProjectCache(t *testing.T) {
 
 		// Test cache retrieval.
 		data, err := proj.Cache(testCacheKind{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "cached-data", data)
 	})
 
@@ -328,12 +329,12 @@ func TestProjectCache(t *testing.T) {
 
 		// First cache access.
 		data1, err1 := proj.Cache(testCacheKind{})
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, 1, data1)
 
 		// Second cache access should reuse cached data.
 		data2, err2 := proj.Cache(testCacheKind{})
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, 1, data2) // Same data as first call.
 
 		// Builder should only be called once.
@@ -402,11 +403,11 @@ func TestProjectCache(t *testing.T) {
 
 		// Test both caches work independently.
 		data1, err1 := proj.Cache(testCacheKind1{})
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, "cache-1", data1)
 
 		data2, err2 := proj.Cache(testCacheKind2{})
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "cache-2", data2)
 	})
 
@@ -437,7 +438,7 @@ func TestProjectCache(t *testing.T) {
 
 		// Test cache building.
 		data, err := proj.Cache(testCacheKind{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		result := data.(map[string]any)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
@@ -500,11 +501,11 @@ func TestProjectCache(t *testing.T) {
 
 		// Both should work independently despite same underlying value.
 		data1, err1 := proj.Cache(kind1)
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, "data1", data1)
 
 		data2, err2 := proj.Cache(kind2)
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "data2", data2)
 	})
 
@@ -529,11 +530,11 @@ func TestProjectCache(t *testing.T) {
 
 		// Both should work independently.
 		data1, err1 := proj.Cache(kind1)
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, "ast-data", data1)
 
 		data2, err2 := proj.Cache(kind2)
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "types-data", data2)
 	})
 }
@@ -553,7 +554,7 @@ func TestProjectFileCache(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, len("package test"), data)
 	})
 
@@ -606,12 +607,12 @@ func TestProjectFileCache(t *testing.T) {
 
 		// First cache access.
 		data1, err1 := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, 1, data1)
 
 		// Second cache access should reuse cached data.
 		data2, err2 := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, 1, data2) // Same data as first call.
 
 		// Builder should only be called once.
@@ -685,11 +686,11 @@ func TestProjectFileCache(t *testing.T) {
 
 		// Test caches work independently per file.
 		data1, err1 := proj.FileCache(testCacheKind{}, "test1.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, "test1.go:package test1", data1)
 
 		data2, err2 := proj.FileCache(testCacheKind{}, "test2.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "test2.go:package test2", data2)
 	})
 
@@ -721,7 +722,7 @@ func TestProjectFileCache(t *testing.T) {
 
 		// Test cache building.
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		result := data.(map[string]any)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
@@ -749,7 +750,7 @@ func TestProjectFileCache(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data1, err1 := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, "package test", data1)
 		assert.Equal(t, 1, buildCount)
 
@@ -758,7 +759,7 @@ func TestProjectFileCache(t *testing.T) {
 
 		// Cache should be rebuilt.
 		data2, err2 := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "package updated", data2)
 		assert.Equal(t, 2, buildCount) // Builder called again.
 	})
@@ -824,11 +825,11 @@ func TestProjectFileCache(t *testing.T) {
 
 		// Both should work independently despite same underlying value.
 		data1, err1 := proj.FileCache(kind1, "test.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, "filedata1", data1)
 
 		data2, err2 := proj.FileCache(kind2, "test.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, "filedata2", data2)
 	})
 }
@@ -851,7 +852,7 @@ func TestProjectDeleteFileCache(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data1, err1 := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, 1, data1)
 		assert.Equal(t, 1, buildCount)
 
@@ -860,7 +861,7 @@ func TestProjectDeleteFileCache(t *testing.T) {
 
 		// Cache should be rebuilt on next access.
 		data2, err2 := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, 2, data2)      // New build number.
 		assert.Equal(t, 2, buildCount) // Builder called again.
 	})
@@ -882,7 +883,7 @@ func TestProjectDeleteFileCache(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "data", data)
 	})
 
@@ -908,11 +909,11 @@ func TestProjectDeleteFileCache(t *testing.T) {
 		proj.PutFile("test.go", file("package test"))
 
 		data1, err1 := proj.FileCache(testCacheKind1{}, "test.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, 1, data1)
 
 		data2, err2 := proj.FileCache(testCacheKind2{}, "test.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, 1, data2)
 
 		// Delete file cache (should delete all caches for this file).
@@ -920,11 +921,11 @@ func TestProjectDeleteFileCache(t *testing.T) {
 
 		// Both caches should be rebuilt.
 		data1New, err1New := proj.FileCache(testCacheKind1{}, "test.go")
-		assert.NoError(t, err1New)
+		require.NoError(t, err1New)
 		assert.Equal(t, 2, data1New)
 
 		data2New, err2New := proj.FileCache(testCacheKind2{}, "test.go")
-		assert.NoError(t, err2New)
+		require.NoError(t, err2New)
 		assert.Equal(t, 2, data2New)
 
 		assert.Equal(t, 2, buildCount1)
@@ -954,11 +955,11 @@ func TestProjectDeleteFileCache(t *testing.T) {
 		proj.PutFile("test2.go", file("package test2"))
 
 		data1, err1 := proj.FileCache(testCacheKind{}, "test1.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 		assert.Equal(t, 1, data1)
 
 		data2, err2 := proj.FileCache(testCacheKind{}, "test2.go")
-		assert.NoError(t, err2)
+		require.NoError(t, err2)
 		assert.Equal(t, 1, data2)
 
 		// Delete cache for one file only.
@@ -966,13 +967,13 @@ func TestProjectDeleteFileCache(t *testing.T) {
 
 		// First file cache should be rebuilt.
 		data1New, err1New := proj.FileCache(testCacheKind{}, "test1.go")
-		assert.NoError(t, err1New)
+		require.NoError(t, err1New)
 		assert.Equal(t, 2, data1New)
 		assert.Equal(t, 2, buildCountTest1)
 
 		// Second file cache should be reused.
 		data2Same, err2Same := proj.FileCache(testCacheKind{}, "test2.go")
-		assert.NoError(t, err2Same)
+		require.NoError(t, err2Same)
 		assert.Equal(t, 1, data2Same)       // Same as before.
 		assert.Equal(t, 1, buildCountTest2) // No rebuild.
 	})
@@ -991,7 +992,7 @@ func TestDataOrErr(t *testing.T) {
 
 		// Verify.
 		assert.Equal(t, originalData, decodedData)
-		assert.NoError(t, decodedErr)
+		require.NoError(t, decodedErr)
 	})
 
 	t.Run("EncodeDecodeErrorData", func(t *testing.T) {
@@ -1027,7 +1028,7 @@ func TestDataOrErr(t *testing.T) {
 
 		// Verify.
 		assert.Equal(t, originalData, decodedData)
-		assert.NoError(t, decodedErr)
+		require.NoError(t, decodedErr)
 	})
 
 	t.Run("EncodeDecodeNilData", func(t *testing.T) {
@@ -1042,7 +1043,7 @@ func TestDataOrErr(t *testing.T) {
 
 		// Verify.
 		assert.Nil(t, decodedData)
-		assert.NoError(t, decodedErr)
+		require.NoError(t, decodedErr)
 	})
 
 	t.Run("EncodeDecodeCustomError", func(t *testing.T) {
@@ -1086,7 +1087,7 @@ func TestDataOrErr(t *testing.T) {
 
 				// Verify.
 				assert.Equal(t, originalData, decodedData)
-				assert.NoError(t, decodedErr)
+				require.NoError(t, decodedErr)
 			})
 		}
 	})

--- a/xgo/pkgdoc_test.go
+++ b/xgo/pkgdoc_test.go
@@ -57,7 +57,7 @@ func Test() {
 		// Check that Game type exists (main.spx creates Game type).
 		gameType, exists := pkgDoc.Types["Game"]
 		require.True(t, exists)
-		assert.NotNil(t, gameType)
+		require.NotNil(t, gameType)
 		assert.NotNil(t, gameType.Fields)
 		assert.NotNil(t, gameType.Methods)
 	})

--- a/xgo/project.go
+++ b/xgo/project.go
@@ -17,8 +17,7 @@
 package xgo
 
 import (
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 	"io/fs"
 	"iter"
 	"maps"
@@ -27,6 +26,7 @@ import (
 	"time"
 
 	"github.com/goplus/mod/xgomod"
+	"github.com/goplus/xgo/token"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -72,7 +72,7 @@ type File struct {
 type Project struct {
 	PkgPath  string
 	Mod      *xgomod.Module
-	Importer types.Importer
+	Importer gotypes.Importer
 	Fset     *token.FileSet
 
 	mu            sync.RWMutex

--- a/xgo/project_test.go
+++ b/xgo/project_test.go
@@ -18,13 +18,14 @@ package xgo
 
 import (
 	"fmt"
-	"go/token"
 	"io/fs"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/goplus/xgo/token"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func file(content string) *File {
@@ -34,7 +35,7 @@ func file(content string) *File {
 func TestNewProject(t *testing.T) {
 	t.Run("WithNilFileSet", func(t *testing.T) {
 		proj := NewProject(nil, nil, 0)
-		assert.NotNil(t, proj)
+		require.NotNil(t, proj)
 		assert.NotNil(t, proj.Fset)
 		assert.NotNil(t, proj.files)
 		assert.Len(t, proj.files, 0)
@@ -47,7 +48,7 @@ func TestNewProject(t *testing.T) {
 	t.Run("WithProvidedFileSet", func(t *testing.T) {
 		fset := token.NewFileSet()
 		proj := NewProject(fset, nil, 0)
-		assert.NotNil(t, proj)
+		require.NotNil(t, proj)
 		assert.Equal(t, fset, proj.Fset)
 	})
 
@@ -68,11 +69,11 @@ func TestNewProject(t *testing.T) {
 
 		// Verify files are copied
 		mainFile, ok := proj.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		testFile, ok := proj.files["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc test() {}"), testFile.Content)
 	})
 
@@ -110,11 +111,11 @@ func TestNewProject(t *testing.T) {
 		proj := NewProject(nil, files, 0)
 
 		snapshot := proj.filesSnapshot.Load()
-		assert.NotNil(t, snapshot)
+		require.NotNil(t, snapshot)
 		assert.Len(t, *snapshot, 1)
 
 		testFile, ok := (*snapshot)["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package test"), testFile.Content)
 	})
 }
@@ -128,7 +129,7 @@ func TestProjectSnapshot(t *testing.T) {
 		proj.PkgPath = "test/pkg"
 
 		snapshot := proj.Snapshot()
-		assert.NotNil(t, snapshot)
+		require.NotNil(t, snapshot)
 		assert.Equal(t, proj.PkgPath, snapshot.PkgPath)
 		assert.Equal(t, proj.Mod, snapshot.Mod)
 		assert.Equal(t, proj.Importer, snapshot.Importer)
@@ -147,11 +148,11 @@ func TestProjectSnapshot(t *testing.T) {
 		// Verify files are copied.
 		assert.Len(t, snapshot.files, 2)
 		mainFile, ok := snapshot.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		testFile, ok := snapshot.files["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package test"), testFile.Content)
 	})
 
@@ -170,7 +171,7 @@ func TestProjectSnapshot(t *testing.T) {
 		// Snapshot should be unchanged.
 		assert.Len(t, snapshot.files, 1)
 		_, ok := snapshot.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		_, ok = snapshot.files["new.go"]
 		assert.False(t, ok)
 	})
@@ -204,7 +205,7 @@ func TestProjectSnapshot(t *testing.T) {
 
 		// Build cache.
 		data, err := proj.Cache(testCacheKind{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "test-data", data)
 
 		snapshot := proj.Snapshot()
@@ -224,11 +225,11 @@ func TestProjectSnapshot(t *testing.T) {
 
 		// Verify snapshot has updated files snapshot.
 		snapshotFiles := snapshot.filesSnapshot.Load()
-		assert.NotNil(t, snapshotFiles)
+		require.NotNil(t, snapshotFiles)
 		assert.Len(t, *snapshotFiles, 1)
 
 		testFile, ok := (*snapshotFiles)["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package test"), testFile.Content)
 	})
 }
@@ -253,17 +254,17 @@ func TestProjectSnapshotWithOverlay(t *testing.T) {
 
 		// Verify overlay file is applied.
 		mainFile, ok := snapshot.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n// updated"), mainFile.Content)
 
 		// Verify new file is added.
 		newFile, ok := snapshot.files["new.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package new"), newFile.Content)
 
 		// Verify original file is preserved.
 		testFile, ok := snapshot.files["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package test"), testFile.Content)
 	})
 
@@ -278,7 +279,7 @@ func TestProjectSnapshotWithOverlay(t *testing.T) {
 		// Verify snapshot is equivalent to regular snapshot.
 		assert.Len(t, snapshot.files, 1)
 		mainFile, ok := snapshot.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 	})
 
@@ -293,7 +294,7 @@ func TestProjectSnapshotWithOverlay(t *testing.T) {
 		// Verify snapshot is equivalent to regular snapshot.
 		assert.Len(t, snapshot.files, 1)
 		mainFile, ok := snapshot.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 	})
 
@@ -311,12 +312,12 @@ func TestProjectSnapshotWithOverlay(t *testing.T) {
 
 		// Verify original project is unchanged.
 		mainFile, ok := proj.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		// Verify snapshot has overlay.
 		snapshotMainFile, ok := snapshot.files["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n// updated"), snapshotMainFile.Content)
 	})
 
@@ -334,11 +335,11 @@ func TestProjectSnapshotWithOverlay(t *testing.T) {
 
 		// Verify snapshot has updated files snapshot.
 		snapshotFiles := snapshot.filesSnapshot.Load()
-		assert.NotNil(t, snapshotFiles)
+		require.NotNil(t, snapshotFiles)
 		assert.Len(t, *snapshotFiles, 2)
 
 		newFile, ok := (*snapshotFiles)["new.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package new"), newFile.Content)
 	})
 }
@@ -470,13 +471,13 @@ func TestProjectFile(t *testing.T) {
 		proj := NewProject(nil, files, 0)
 
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
-		assert.NotNil(t, mainFile)
+		require.True(t, ok)
+		require.NotNil(t, mainFile)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		testFile, ok := proj.File("test.go")
-		assert.True(t, ok)
-		assert.NotNil(t, testFile)
+		require.True(t, ok)
+		require.NotNil(t, testFile)
 		assert.Equal(t, []byte("package main\n\nfunc test() {}"), testFile.Content)
 	})
 
@@ -520,8 +521,8 @@ func TestProjectFile(t *testing.T) {
 		file1, ok1 := proj.File("main.go")
 		file2, ok2 := proj.File("main.go")
 
-		assert.True(t, ok1)
-		assert.True(t, ok2)
+		require.True(t, ok1)
+		require.True(t, ok2)
 		assert.Equal(t, file1.Content, file2.Content)
 	})
 
@@ -552,15 +553,15 @@ func TestProjectPutFile(t *testing.T) {
 
 		// Verify file was added.
 		addedFile, ok := proj.File("main.go")
-		assert.True(t, ok)
-		assert.NotNil(t, addedFile)
+		require.True(t, ok)
+		require.NotNil(t, addedFile)
 		assert.Equal(t, []byte("package main"), addedFile.Content)
 
 		// Verify files snapshot is updated.
 		snapshot := proj.filesSnapshot.Load()
 		assert.Len(t, *snapshot, 1)
 		snapshotFile, ok := (*snapshot)["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), snapshotFile.Content)
 	})
 
@@ -575,7 +576,7 @@ func TestProjectPutFile(t *testing.T) {
 
 		// Verify file was overwritten.
 		updatedFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc main() {}"), updatedFile.Content)
 	})
 
@@ -594,15 +595,15 @@ func TestProjectPutFile(t *testing.T) {
 		assert.Equal(t, 3, count)
 
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		testFile, ok := proj.File("test.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc test() {}"), testFile.Content)
 
 		utilFile, ok := proj.File("util.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc util() {}"), utilFile.Content)
 	})
 
@@ -613,7 +614,7 @@ func TestProjectPutFile(t *testing.T) {
 
 		// Verify file with empty path was added.
 		emptyFile, ok := proj.File("")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("empty path"), emptyFile.Content)
 	})
 
@@ -624,7 +625,7 @@ func TestProjectPutFile(t *testing.T) {
 
 		// Verify nil file was added.
 		nilFile, ok := proj.File("nil.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Nil(t, nilFile)
 	})
 
@@ -653,7 +654,7 @@ func TestProjectDeleteFile(t *testing.T) {
 		proj := NewProject(nil, files, 0)
 
 		err := proj.DeleteFile("main.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify file was deleted.
 		_, ok := proj.File("main.go")
@@ -661,7 +662,7 @@ func TestProjectDeleteFile(t *testing.T) {
 
 		// Verify other file still exists.
 		testFile, ok := proj.File("test.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc test() {}"), testFile.Content)
 
 		// Verify files snapshot is updated.
@@ -670,7 +671,7 @@ func TestProjectDeleteFile(t *testing.T) {
 		_, ok = (*snapshot)["main.go"]
 		assert.False(t, ok)
 		_, ok = (*snapshot)["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 	})
 
 	t.Run("DeleteNonExistingFile", func(t *testing.T) {
@@ -685,7 +686,7 @@ func TestProjectDeleteFile(t *testing.T) {
 
 		// Verify existing file is unchanged.
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 	})
 
@@ -705,7 +706,7 @@ func TestProjectDeleteFile(t *testing.T) {
 		proj := NewProject(nil, files, 0)
 
 		err := proj.DeleteFile("")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify empty path file was deleted.
 		_, ok := proj.File("")
@@ -713,7 +714,7 @@ func TestProjectDeleteFile(t *testing.T) {
 
 		// Verify other file still exists.
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 	})
 
@@ -730,9 +731,9 @@ func TestProjectDeleteFile(t *testing.T) {
 		err2 := proj.DeleteFile("test.go")
 		err3 := proj.DeleteFile("util.go")
 
-		assert.NoError(t, err1)
-		assert.NoError(t, err2)
-		assert.NoError(t, err3)
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.NoError(t, err3)
 
 		// Verify all files are deleted.
 		var count int
@@ -754,7 +755,7 @@ func TestProjectDeleteFile(t *testing.T) {
 
 		// Delete file first time.
 		err1 := proj.DeleteFile("main.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 
 		// Delete same file second time.
 		err2 := proj.DeleteFile("main.go")
@@ -772,7 +773,7 @@ func TestProjectRenameFile(t *testing.T) {
 		proj := NewProject(nil, files, 0)
 
 		err := proj.RenameFile("old.go", "new.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify old file was removed.
 		_, ok := proj.File("old.go")
@@ -780,12 +781,12 @@ func TestProjectRenameFile(t *testing.T) {
 
 		// Verify new file exists with same content.
 		newFile, ok := proj.File("new.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), newFile.Content)
 
 		// Verify other file is unchanged.
 		testFile, ok := proj.File("test.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc test() {}"), testFile.Content)
 
 		// Verify files snapshot is updated.
@@ -794,7 +795,7 @@ func TestProjectRenameFile(t *testing.T) {
 		_, ok = (*snapshot)["old.go"]
 		assert.False(t, ok)
 		_, ok = (*snapshot)["new.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 	})
 
 	t.Run("RenameNonExistingFile", func(t *testing.T) {
@@ -809,7 +810,7 @@ func TestProjectRenameFile(t *testing.T) {
 
 		// Verify existing files are unchanged.
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		// Verify new file was not created.
@@ -830,11 +831,11 @@ func TestProjectRenameFile(t *testing.T) {
 
 		// Verify both files are unchanged.
 		oldFile, ok := proj.File("old.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), oldFile.Content)
 
 		existingFile, ok := proj.File("existing.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package existing"), existingFile.Content)
 	})
 
@@ -854,19 +855,19 @@ func TestProjectRenameFile(t *testing.T) {
 		proj := NewProject(nil, files, 0)
 
 		err := proj.RenameFile("", "named.go")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify empty path file was renamed.
 		_, ok := proj.File("")
 		assert.False(t, ok)
 
 		namedFile, ok := proj.File("named.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("empty path"), namedFile.Content)
 
 		// Verify other file is unchanged.
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 	})
 
@@ -877,7 +878,7 @@ func TestProjectRenameFile(t *testing.T) {
 		proj := NewProject(nil, files, 0)
 
 		err := proj.RenameFile("main.go", "")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify original file was removed.
 		_, ok := proj.File("main.go")
@@ -885,7 +886,7 @@ func TestProjectRenameFile(t *testing.T) {
 
 		// Verify file exists with empty path.
 		emptyFile, ok := proj.File("")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), emptyFile.Content)
 	})
 
@@ -897,7 +898,7 @@ func TestProjectRenameFile(t *testing.T) {
 
 		// Rename file first time.
 		err1 := proj.RenameFile("old.go", "new.go")
-		assert.NoError(t, err1)
+		require.NoError(t, err1)
 
 		// Try to rename the same old path again.
 		err2 := proj.RenameFile("old.go", "another.go")
@@ -909,7 +910,7 @@ func TestProjectRenameFile(t *testing.T) {
 		assert.False(t, ok)
 
 		newFile, ok := proj.File("new.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), newFile.Content)
 
 		_, ok = proj.File("another.go")
@@ -936,11 +937,11 @@ func TestProjectUpdateFiles(t *testing.T) {
 		assert.Equal(t, 2, count)
 
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		testFile, ok := proj.File("test.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc test() {}"), testFile.Content)
 	})
 
@@ -961,7 +962,7 @@ func TestProjectUpdateFiles(t *testing.T) {
 
 		// Verify file was updated due to different ModTime.
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc main() {}"), mainFile.Content)
 		assert.Equal(t, newTime, mainFile.ModTime)
 	})
@@ -982,7 +983,7 @@ func TestProjectUpdateFiles(t *testing.T) {
 
 		// Verify file was not updated due to same ModTime.
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content) // Original content preserved.
 		assert.Equal(t, sameTime, mainFile.ModTime)
 	})
@@ -1011,11 +1012,11 @@ func TestProjectUpdateFiles(t *testing.T) {
 		assert.Equal(t, 2, count)
 
 		mainFile, ok := proj.File("main.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 
 		newFile, ok := proj.File("new.go")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc new() {}"), newFile.Content)
 
 		// Verify removed files no longer exist.
@@ -1085,7 +1086,7 @@ func TestProjectUpdateFiles(t *testing.T) {
 		assert.NotEqual(t, snapshotBefore, snapshotAfter)
 
 		mainFile, ok := (*snapshotAfter)["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main"), mainFile.Content)
 	})
 }
@@ -1112,7 +1113,7 @@ func TestProjectUpdateFilesSnapshot(t *testing.T) {
 
 		// Verify new file is in snapshot.
 		testFile, ok := (*updatedSnapshot)["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, []byte("package main\n\nfunc test() {}"), testFile.Content)
 	})
 
@@ -1140,7 +1141,7 @@ func TestProjectUpdateFilesSnapshot(t *testing.T) {
 		// Verify new snapshot has updated content.
 		assert.Len(t, *snapshot2, 2)
 		_, ok = (*snapshot2)["test.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 
 		// Verify they are different objects.
 		assert.NotEqual(t, snapshot1, snapshot2)
@@ -1169,14 +1170,14 @@ func TestProjectUpdateFilesSnapshot(t *testing.T) {
 		proj := NewProject(nil, nil, 0)
 
 		snapshot := proj.filesSnapshot.Load()
-		assert.NotNil(t, snapshot)
+		require.NotNil(t, snapshot)
 		assert.Len(t, *snapshot, 0)
 
 		// Update snapshot on empty project.
 		proj.updateFilesSnapshot()
 
 		updatedSnapshot := proj.filesSnapshot.Load()
-		assert.NotNil(t, updatedSnapshot)
+		require.NotNil(t, updatedSnapshot)
 		assert.Len(t, *updatedSnapshot, 0)
 	})
 
@@ -1200,7 +1201,7 @@ func TestProjectUpdateFilesSnapshot(t *testing.T) {
 		assert.Len(t, *updatedSnapshot, 1)
 
 		_, ok := (*updatedSnapshot)["main.go"]
-		assert.True(t, ok)
+		require.True(t, ok)
 
 		_, ok = (*updatedSnapshot)["test.go"]
 		assert.False(t, ok)

--- a/xgo/typeinfo.go
+++ b/xgo/typeinfo.go
@@ -18,22 +18,22 @@ package xgo
 
 import (
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"maps"
 	"slices"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/x/typesutil"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/qiniu/x/errors"
 )
 
-// typeInfoCacheKind is a cache kind type for [xgotypes.Info].
+// typeInfoCacheKind is a cache kind type for [types.Info].
 type typeInfoCacheKind struct{}
 
-// typeInfoCache is a cache for [xgotypes.Info].
+// typeInfoCache is a cache for [types.Info].
 type typeInfoCache struct {
-	typeInfo   *xgotypes.Info
+	typeInfo   *types.Info
 	checkerErr error
 }
 
@@ -45,21 +45,21 @@ func buildTypeInfoCache(proj *Project) (any, error) {
 		return nil, fmt.Errorf("failed to retrieve AST package: %w", astErr)
 	}
 
-	typeInfo := &xgotypes.Info{
+	typeInfo := &types.Info{
 		Info: typesutil.Info{
-			Types:      make(map[ast.Expr]types.TypeAndValue),
-			Defs:       make(map[*ast.Ident]types.Object),
-			Uses:       make(map[*ast.Ident]types.Object),
-			Selections: make(map[*ast.SelectorExpr]*types.Selection),
-			Implicits:  make(map[ast.Node]types.Object),
-			Scopes:     make(map[ast.Node]*types.Scope),
+			Types:      make(map[ast.Expr]gotypes.TypeAndValue),
+			Defs:       make(map[*ast.Ident]gotypes.Object),
+			Uses:       make(map[*ast.Ident]gotypes.Object),
+			Selections: make(map[*ast.SelectorExpr]*gotypes.Selection),
+			Implicits:  make(map[ast.Node]gotypes.Object),
+			Scopes:     make(map[ast.Node]*gotypes.Scope),
 		},
-		Pkg: types.NewPackage(proj.PkgPath, astPkg.Name),
+		Pkg: gotypes.NewPackage(proj.PkgPath, astPkg.Name),
 	}
 
 	var checkerErrs errors.List
 	if err := typesutil.NewChecker(
-		&types.Config{
+		&gotypes.Config{
 			Error:    func(err error) { checkerErrs.Add(err) },
 			Importer: proj.Importer,
 		},
@@ -77,7 +77,7 @@ func buildTypeInfoCache(proj *Project) (any, error) {
 	// Build reverse mapping for O(1) object-to-identifier lookup. For
 	// identifiers that do not denote objects, the object is nil and they
 	// are excluded from this mapping.
-	typeInfo.ObjToDef = make(map[types.Object]*ast.Ident, len(typeInfo.Defs))
+	typeInfo.ObjToDef = make(map[gotypes.Object]*ast.Ident, len(typeInfo.Defs))
 	for ident, obj := range typeInfo.Defs {
 		if obj != nil {
 			typeInfo.ObjToDef[obj] = ident
@@ -87,12 +87,12 @@ func buildTypeInfoCache(proj *Project) (any, error) {
 	return &typeInfoCache{typeInfo, checkerErrs.ToError()}, nil
 }
 
-// TypeInfo retrieves the [xgotypes.Info] from the project. The returned
-// [xgotypes.Info] is nil only if building failed.
+// TypeInfo retrieves the [types.Info] from the project. The returned [types.Info]
+// is nil only if building failed.
 //
-// NOTE: Both the returned [xgotypes.Info] and error can be non-nil, which
+// NOTE: Both the returned [types.Info] and error can be non-nil, which
 // indicates that only part of the project was type checked successfully.
-func (p *Project) TypeInfo() (*xgotypes.Info, error) {
+func (p *Project) TypeInfo() (*types.Info, error) {
 	cacheIface, err := p.Cache(typeInfoCacheKind{})
 	if err != nil {
 		return nil, err

--- a/xgo/typeinfo_test.go
+++ b/xgo/typeinfo_test.go
@@ -17,7 +17,7 @@
 package xgo
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,7 +55,7 @@ func main() {
 
 		// Verify the type info structure.
 		typeInfo := typeInfoCache.typeInfo
-		assert.NotNil(t, typeInfo.Pkg)
+		require.NotNil(t, typeInfo.Pkg)
 		assert.Equal(t, proj.PkgPath, typeInfo.Pkg.Path())
 		assert.Equal(t, "main", typeInfo.Pkg.Name())
 		assert.NotEmpty(t, typeInfo.Defs)
@@ -75,6 +75,20 @@ func main() {
 			assert.Error(t, err)
 			assert.Nil(t, cache)
 		}
+	})
+
+	t.Run("ASTCacheUnavailable", func(t *testing.T) {
+		proj := NewProject(nil, map[string]*File{
+			"main.xgo": {
+				Content: []byte(`var x int`),
+			},
+		}, FeatTypeInfoCache)
+
+		cache, err := buildTypeInfoCache(proj)
+		require.Error(t, err)
+		assert.Nil(t, cache)
+		assert.Contains(t, err.Error(), "failed to retrieve AST package")
+		assert.Contains(t, err.Error(), ErrUnknownCacheKind.Error())
 	})
 
 	t.Run("TypeCheckingError", func(t *testing.T) {
@@ -104,7 +118,7 @@ func test() {
 
 		// But still should have some type information.
 		typeInfo := typeInfoCache.typeInfo
-		assert.NotNil(t, typeInfo.Pkg)
+		require.NotNil(t, typeInfo.Pkg)
 	})
 }
 
@@ -130,7 +144,7 @@ func getCounter() int {
 		require.NoError(t, err)
 		require.NotNil(t, typeInfo)
 
-		assert.NotNil(t, typeInfo.Pkg)
+		require.NotNil(t, typeInfo.Pkg)
 		assert.Equal(t, proj.PkgPath, typeInfo.Pkg.Path())
 		assert.Equal(t, "main", typeInfo.Pkg.Name())
 
@@ -139,7 +153,7 @@ func getCounter() int {
 		assert.NotEmpty(t, typeInfo.Uses)
 
 		// Check that counter variable is properly typed.
-		var counterObj types.Object
+		var counterObj gotypes.Object
 		for ident, obj := range typeInfo.Defs {
 			if ident.Name == "counter" {
 				counterObj = obj

--- a/xgo/types/info.go
+++ b/xgo/types/info.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"go/types"
+	gotypes "go/types"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/x/typesutil"
@@ -29,16 +29,16 @@ type Info struct {
 	typesutil.Info
 
 	// Pkg is the package associated with this type information.
-	Pkg *types.Package
+	Pkg *gotypes.Package
 
 	// ObjToDef is a reverse mapping for O(1) object-to-identifier lookup.
 	// For identifiers that do not denote objects, the object is nil and
 	// they are excluded from this mapping.
-	ObjToDef map[types.Object]*ast.Ident
+	ObjToDef map[gotypes.Object]*ast.Ident
 }
 
 // RefIdentsFor returns all identifiers where the given object is referenced.
-func (i *Info) RefIdentsFor(obj types.Object) []*ast.Ident {
+func (i *Info) RefIdentsFor(obj gotypes.Object) []*ast.Ident {
 	if obj == nil {
 		return nil
 	}

--- a/xgo/types/info_test.go
+++ b/xgo/types/info_test.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
@@ -27,8 +27,8 @@ import (
 )
 
 func TestInfoRefIdentsFor(t *testing.T) {
-	xVar := types.NewVar(0, nil, "x", types.Typ[types.Int])
-	yVar := types.NewVar(0, nil, "y", types.Typ[types.Int])
+	xVar := gotypes.NewVar(0, nil, "x", gotypes.Typ[gotypes.Int])
+	yVar := gotypes.NewVar(0, nil, "y", gotypes.Typ[gotypes.Int])
 
 	xDef := &ast.Ident{Name: "x"}
 	xUse1 := &ast.Ident{Name: "x"}
@@ -39,19 +39,19 @@ func TestInfoRefIdentsFor(t *testing.T) {
 
 	info := &Info{
 		Info: typesutil.Info{
-			Defs: map[*ast.Ident]types.Object{
+			Defs: map[*ast.Ident]gotypes.Object{
 				xDef: xVar,
 				yDef: yVar,
 			},
-			Uses: map[*ast.Ident]types.Object{
+			Uses: map[*ast.Ident]gotypes.Object{
 				xUse1: xVar,
 				xUse2: xVar,
 				xUse3: xVar,
 				yUse:  yVar,
 			},
 		},
-		Pkg: types.NewPackage("test", "test"),
-		ObjToDef: map[types.Object]*ast.Ident{
+		Pkg: gotypes.NewPackage("test", "test"),
+		ObjToDef: map[gotypes.Object]*ast.Ident{
 			xVar: xDef,
 			yVar: yDef,
 		},
@@ -71,7 +71,7 @@ func TestInfoRefIdentsFor(t *testing.T) {
 	})
 
 	t.Run("NoReferences", func(t *testing.T) {
-		zVar := types.NewVar(0, nil, "z", types.Typ[types.Int])
+		zVar := gotypes.NewVar(0, nil, "z", gotypes.Typ[gotypes.Int])
 		info.ObjToDef[zVar] = &ast.Ident{Name: "z"}
 
 		refs := info.RefIdentsFor(zVar)
@@ -83,7 +83,7 @@ func TestInfoRefIdentsFor(t *testing.T) {
 	})
 
 	t.Run("UnknownObject", func(t *testing.T) {
-		unknownObj := types.NewVar(0, nil, "unknown", types.Typ[types.Int])
+		unknownObj := gotypes.NewVar(0, nil, "unknown", gotypes.Typ[gotypes.Int])
 
 		refs := info.RefIdentsFor(unknownObj)
 		assert.Empty(t, refs)

--- a/xgo/xgoutil/call_expr.go
+++ b/xgo/xgoutil/call_expr.go
@@ -17,19 +17,19 @@
 package xgoutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"slices"
 
 	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 )
 
 // CreateCallExprFromBranchStmt attempts to create a call expression from a
 // branch statement. This handles cases in spx where the `Sprite.Goto` method is
 // intended to precede the goto statement.
-func CreateCallExprFromBranchStmt(typeInfo *xgotypes.Info, stmt *ast.BranchStmt) *ast.CallExpr {
+func CreateCallExprFromBranchStmt(typeInfo *types.Info, stmt *ast.BranchStmt) *ast.CallExpr {
 	if typeInfo == nil || stmt == nil {
 		return nil
 	}
@@ -41,7 +41,7 @@ func CreateCallExprFromBranchStmt(typeInfo *xgotypes.Info, stmt *ast.BranchStmt)
 	// Skip if this is a real branch statement with an actual label object.
 	if obj := typeInfo.ObjectOf(stmt.Label); obj == nil {
 		return nil
-	} else if _, ok := obj.(*types.Label); ok {
+	} else if _, ok := obj.(*gotypes.Label); ok {
 		return nil
 	}
 
@@ -51,7 +51,7 @@ func CreateCallExprFromBranchStmt(typeInfo *xgotypes.Info, stmt *ast.BranchStmt)
 	stmtTokEnd := stmt.TokPos + token.Pos(len(stmt.Tok.String()))
 	for ident, obj := range typeInfo.Uses {
 		if ident.Pos() == stmt.TokPos && ident.End() == stmtTokEnd {
-			if _, ok := obj.(*types.Func); ok {
+			if _, ok := obj.(*gotypes.Func); ok {
 				return &ast.CallExpr{
 					Fun:  ident,
 					Args: []ast.Expr{stmt.Label},
@@ -64,7 +64,7 @@ func CreateCallExprFromBranchStmt(typeInfo *xgotypes.Info, stmt *ast.BranchStmt)
 }
 
 // FuncFromCallExpr returns the function object from a call expression.
-func FuncFromCallExpr(typeInfo *xgotypes.Info, expr *ast.CallExpr) *types.Func {
+func FuncFromCallExpr(typeInfo *types.Info, expr *ast.CallExpr) *gotypes.Func {
 	if typeInfo == nil || expr == nil {
 		return nil
 	}
@@ -83,7 +83,7 @@ func FuncFromCallExpr(typeInfo *xgotypes.Info, expr *ast.CallExpr) *types.Func {
 	if obj == nil {
 		return nil
 	}
-	fun, _ := obj.(*types.Func)
+	fun, _ := obj.(*gotypes.Func)
 	return fun
 }
 
@@ -91,7 +91,7 @@ func FuncFromCallExpr(typeInfo *xgotypes.Info, expr *ast.CallExpr) *types.Func {
 // provided walkFn for each argument. It does nothing if the function is not
 // found or if the function is XGo FuncEx type. The walk stops if walkFn returns
 // false.
-func WalkCallExprArgs(typeInfo *xgotypes.Info, expr *ast.CallExpr, walkFn func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool) {
+func WalkCallExprArgs(typeInfo *types.Info, expr *ast.CallExpr, walkFn func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool) {
 	if typeInfo == nil || expr == nil {
 		return
 	}
@@ -109,13 +109,13 @@ func WalkCallExprArgs(typeInfo *xgotypes.Info, expr *ast.CallExpr, walkFn func(f
 	if IsMarkedAsXGoPackage(fun.Pkg()) {
 		_, methodName, ok := SplitXGotMethodName(fun.Name(), false)
 		if ok {
-			var vars []*types.Var
+			var vars []*gotypes.Var
 			if _, ok := SplitXGoxFuncName(methodName); ok {
 				typeParams := fun.Signature().TypeParams()
 				if typeParams != nil {
 					vars = slices.Grow(vars, typeParams.Len())
 					for typeParam := range typeParams.TypeParams() {
-						param := types.NewParam(token.NoPos, typeParam.Obj().Pkg(), typeParam.Obj().Name(), typeParam.Constraint().Underlying())
+						param := gotypes.NewParam(token.NoPos, typeParam.Obj().Pkg(), typeParam.Obj().Name(), typeParam.Constraint().Underlying())
 						vars = append(vars, param)
 					}
 				}
@@ -126,7 +126,7 @@ func WalkCallExprArgs(typeInfo *xgotypes.Info, expr *ast.CallExpr, walkFn func(f
 				vars = append(vars, params.At(i))
 			}
 
-			params = types.NewTuple(vars...)
+			params = gotypes.NewTuple(vars...)
 		}
 	}
 

--- a/xgo/xgoutil/call_expr_test.go
+++ b/xgo/xgoutil/call_expr_test.go
@@ -17,12 +17,14 @@
 package xgoutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
+	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateCallExprFromBranchStmt(t *testing.T) {
@@ -67,9 +69,9 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 			},
 		}
 
-		pkg := types.NewPackage("test", "test")
-		label := types.NewLabel(token.NoPos, pkg, "label")
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{
+		pkg := gotypes.NewPackage("test", "test")
+		label := gotypes.NewLabel(token.NoPos, pkg, "label")
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
 			stmt.Label: label,
 		}, nil)
 		assert.Nil(t, CreateCallExprFromBranchStmt(typeInfo, stmt))
@@ -86,9 +88,9 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 			Label:  labelIdent,
 		}
 
-		pkg := types.NewPackage("test", "test")
-		variable := types.NewVar(token.NoPos, pkg, "label", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{
+		pkg := gotypes.NewPackage("test", "test")
+		variable := gotypes.NewVar(token.NoPos, pkg, "label", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
 			labelIdent: variable, // Not a label, so it won't be skipped.
 		}, nil)
 		assert.Nil(t, CreateCallExprFromBranchStmt(typeInfo, stmt))
@@ -111,12 +113,12 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 			Name:    "goto",
 		}
 
-		pkg := types.NewPackage("test", "test")
-		labelVar := types.NewVar(token.NoPos, pkg, "label", types.Typ[types.Int])
-		gotoVar := types.NewVar(token.NoPos, pkg, "goto", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{
+		pkg := gotypes.NewPackage("test", "test")
+		labelVar := gotypes.NewVar(token.NoPos, pkg, "label", gotypes.Typ[gotypes.Int])
+		gotoVar := gotypes.NewVar(token.NoPos, pkg, "goto", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
 			labelIdent: labelVar, // Not a label.
-		}, map[*ast.Ident]types.Object{
+		}, map[*ast.Ident]gotypes.Object{
 			ident: gotoVar, // Not a function.
 		})
 
@@ -140,18 +142,18 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 			Name:    "goto",
 		}
 
-		pkg := types.NewPackage("test", "test")
-		labelVar := types.NewVar(token.NoPos, pkg, "label", types.Typ[types.Int])
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "goto", sig)
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{
+		pkg := gotypes.NewPackage("test", "test")
+		labelVar := gotypes.NewVar(token.NoPos, pkg, "label", gotypes.Typ[gotypes.Int])
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "goto", sig)
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
 			labelIdent: labelVar, // Not a label.
-		}, map[*ast.Ident]types.Object{
+		}, map[*ast.Ident]gotypes.Object{
 			ident: fun, // Is a function.
 		})
 
 		got := CreateCallExprFromBranchStmt(typeInfo, stmt)
-		assert.NotNil(t, got)
+		require.NotNil(t, got)
 		assert.Equal(t, ident, got.Fun)
 		assert.Len(t, got.Args, 1)
 		assert.Equal(t, stmt.Label, got.Args[0])
@@ -187,16 +189,16 @@ func TestFuncFromCallExpr(t *testing.T) {
 			Fun: ident,
 		}
 
-		pkg := types.NewPackage("test", "test")
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
 		got := FuncFromCallExpr(typeInfo, expr)
-		assert.NotNil(t, got)
+		require.NotNil(t, got)
 		assert.Equal(t, fun, got)
 	})
 
@@ -209,16 +211,16 @@ func TestFuncFromCallExpr(t *testing.T) {
 			},
 		}
 
-		pkg := types.NewPackage("test", "test")
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "Method", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "Method", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			sel: fun,
 		})
 
 		got := FuncFromCallExpr(typeInfo, expr)
-		assert.NotNil(t, got)
+		require.NotNil(t, got)
 		assert.Equal(t, fun, got)
 	})
 
@@ -228,10 +230,10 @@ func TestFuncFromCallExpr(t *testing.T) {
 			Fun: ident,
 		}
 
-		pkg := types.NewPackage("test", "test")
-		variable := types.NewVar(token.NoPos, pkg, "testVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("test", "test")
+		variable := gotypes.NewVar(token.NoPos, pkg, "testVar", gotypes.Typ[gotypes.Int])
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: variable,
 		})
 
@@ -253,7 +255,7 @@ func TestFuncFromCallExpr(t *testing.T) {
 func TestWalkCallExprArgs(t *testing.T) {
 	t.Run("NilCallExpr", func(t *testing.T) {
 		walkCalled := false
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCalled = true
 			return true
 		}
@@ -268,7 +270,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 		}
 
 		walkCalled := false
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCalled = true
 			return true
 		}
@@ -288,14 +290,14 @@ func TestWalkCallExprArgs(t *testing.T) {
 			Args: []ast.Expr{arg1, arg2},
 		}
 
-		pkg := types.NewPackage("test", "test")
-		param1 := types.NewParam(token.NoPos, pkg, "p1", types.Typ[types.Int])
-		param2 := types.NewParam(token.NoPos, pkg, "p2", types.Typ[types.String])
-		params := types.NewTuple(param1, param2)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		param2 := gotypes.NewParam(token.NoPos, pkg, "p2", gotypes.Typ[gotypes.String])
+		params := gotypes.NewTuple(param1, param2)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
@@ -305,7 +307,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 			arg        ast.Expr
 		}
 
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCalls = append(walkCalls, struct {
 				paramIndex int
 				argIndex   int
@@ -335,14 +337,14 @@ func TestWalkCallExprArgs(t *testing.T) {
 			Args: []ast.Expr{arg1, arg2, arg3},
 		}
 
-		pkg := types.NewPackage("test", "test")
-		param1 := types.NewParam(token.NoPos, pkg, "p1", types.Typ[types.Int])
-		variadicParam := types.NewParam(token.NoPos, pkg, "args", types.NewSlice(types.Typ[types.String]))
-		params := types.NewTuple(param1, variadicParam)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, true)
-		fun := types.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		variadicParam := gotypes.NewParam(token.NoPos, pkg, "args", gotypes.NewSlice(gotypes.Typ[gotypes.String]))
+		params := gotypes.NewTuple(param1, variadicParam)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, true)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
@@ -351,7 +353,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 			argIndex   int
 		}
 
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCalls = append(walkCalls, struct {
 				paramIndex int
 				argIndex   int
@@ -379,19 +381,19 @@ func TestWalkCallExprArgs(t *testing.T) {
 			Args: []ast.Expr{arg1, arg2},
 		}
 
-		pkg := types.NewPackage("test", "test")
-		param1 := types.NewParam(token.NoPos, pkg, "p1", types.Typ[types.Int])
-		param2 := types.NewParam(token.NoPos, pkg, "p2", types.Typ[types.String])
-		params := types.NewTuple(param1, param2)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		param2 := gotypes.NewParam(token.NoPos, pkg, "p2", gotypes.Typ[gotypes.String])
+		params := gotypes.NewTuple(param1, param2)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
 		walkCallCount := 0
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCallCount++
 			return false // Stop after first call.
 		}
@@ -408,16 +410,16 @@ func TestWalkCallExprArgs(t *testing.T) {
 			Args: []ast.Expr{arg1},
 		}
 
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		markAsXGoPackage(pkg)
 
-		recv := types.NewParam(token.NoPos, pkg, "recv", types.Typ[types.Int])
-		param1 := types.NewParam(token.NoPos, pkg, "p1", types.Typ[types.Int])
-		params := types.NewTuple(recv, param1)
-		sig := types.NewSignatureType(recv, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "XGot_Sprite_Move", sig)
+		recv := gotypes.NewParam(token.NoPos, pkg, "recv", gotypes.Typ[gotypes.Int])
+		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		params := gotypes.NewTuple(recv, param1)
+		sig := gotypes.NewSignatureType(recv, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "XGot_Sprite_Move", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
@@ -426,7 +428,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 			argIndex   int
 		}
 
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCalls = append(walkCalls, struct {
 				paramIndex int
 				argIndex   int
@@ -442,6 +444,82 @@ func TestWalkCallExprArgs(t *testing.T) {
 		assert.Equal(t, 0, walkCalls[0].argIndex)   // First arg.
 	})
 
+	t.Run("CallExprWithFuncExFunction", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		ident := &ast.Ident{Name: "testFunc"}
+		expr := &ast.CallExpr{
+			Fun:  ident,
+			Args: []ast.Expr{&ast.Ident{Name: "arg"}},
+		}
+		fun := gogen.NewOverloadFunc(token.NoPos, pkg, "testFunc",
+			gotypes.NewFunc(token.NoPos, pkg, "foo", gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)),
+		)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
+			ident: fun,
+		})
+
+		walkCalled := false
+		WalkCallExprArgs(typeInfo, expr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+			walkCalled = true
+			return true
+		})
+		assert.False(t, walkCalled)
+	})
+
+	t.Run("CallExprWithXGoPackageXGoxMethod", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		markAsXGoPackage(pkg)
+
+		constraint := gotypes.NewInterfaceType(nil, nil)
+		constraint.Complete()
+		typeParam := gotypes.NewTypeParam(gotypes.NewTypeName(token.NoPos, pkg, "T", nil), constraint)
+		recv := gotypes.NewParam(token.NoPos, pkg, "recv", gotypes.Typ[gotypes.Int])
+		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.String])
+		params := gotypes.NewTuple(recv, param1)
+		sig := gotypes.NewSignatureType(nil, nil, []*gotypes.TypeParam{typeParam}, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "XGot_Sprite_XGox_Move", sig)
+
+		ident := &ast.Ident{Name: "XGot_Sprite_XGox_Move"}
+		expr := &ast.CallExpr{
+			Fun: ident,
+			Args: []ast.Expr{
+				&ast.Ident{Name: "int"},
+				&ast.BasicLit{Kind: token.STRING, Value: `"ok"`},
+			},
+		}
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
+			ident: fun,
+		})
+
+		var walkCalls []struct {
+			paramName  string
+			paramIndex int
+			argIndex   int
+		}
+		WalkCallExprArgs(typeInfo, expr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+			walkCalls = append(walkCalls, struct {
+				paramName  string
+				paramIndex int
+				argIndex   int
+			}{
+				paramName:  params.At(paramIndex).Name(),
+				paramIndex: paramIndex,
+				argIndex:   argIndex,
+			})
+			return true
+		})
+
+		assert.Len(t, walkCalls, 2)
+		assert.Equal(t, "T", walkCalls[0].paramName)
+		assert.Equal(t, 0, walkCalls[0].paramIndex)
+		assert.Equal(t, 0, walkCalls[0].argIndex)
+		assert.Equal(t, "p1", walkCalls[1].paramName)
+		assert.Equal(t, 1, walkCalls[1].paramIndex)
+		assert.Equal(t, 1, walkCalls[1].argIndex)
+	})
+
 	t.Run("CallExprWithMoreArgsThanParams", func(t *testing.T) {
 		ident := &ast.Ident{Name: "testFunc"}
 		arg1 := &ast.Ident{Name: "arg1"}
@@ -452,13 +530,13 @@ func TestWalkCallExprArgs(t *testing.T) {
 			Args: []ast.Expr{arg1, arg2, arg3},
 		}
 
-		pkg := types.NewPackage("test", "test")
-		param1 := types.NewParam(token.NoPos, pkg, "p1", types.Typ[types.Int])
-		params := types.NewTuple(param1)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		params := gotypes.NewTuple(param1)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
@@ -467,7 +545,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 			argIndex   int
 		}
 
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCalls = append(walkCalls, struct {
 				paramIndex int
 				argIndex   int
@@ -491,17 +569,17 @@ func TestWalkCallExprArgs(t *testing.T) {
 			Args: []ast.Expr{arg1},
 		}
 
-		pkg := types.NewPackage("test", "test")
-		params := types.NewTuple()
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		params := gotypes.NewTuple()
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
 		walkCalled := false
-		walkFn := func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 			walkCalled = true
 			return true
 		}

--- a/xgo/xgoutil/file.go
+++ b/xgo/xgoutil/file.go
@@ -17,9 +17,8 @@
 package xgoutil
 
 import (
-	"go/token"
-
 	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 )
 
 // PosFilename returns the filename for the given position.

--- a/xgo/xgoutil/file_test.go
+++ b/xgo/xgoutil/file_test.go
@@ -17,10 +17,10 @@
 package xgoutil
 
 import (
-	"go/token"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,7 +76,7 @@ func TestPosTokenFile(t *testing.T) {
 
 		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
 		file := PosTokenFile(fset, xPos)
-		assert.NotNil(t, file)
+		require.NotNil(t, file)
 		assert.Equal(t, "main.xgo", file.Name())
 	})
 
@@ -99,7 +99,7 @@ func TestNodeTokenFile(t *testing.T) {
 
 		xDecl := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0]
 		file := NodeTokenFile(fset, xDecl)
-		assert.NotNil(t, file)
+		require.NotNil(t, file)
 		assert.Equal(t, "main.xgo", file.Name())
 	})
 

--- a/xgo/xgoutil/func.go
+++ b/xgo/xgoutil/func.go
@@ -17,7 +17,7 @@
 package xgoutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"regexp"
 	"strings"
 
@@ -87,21 +87,21 @@ func IsXGoOverloadedFuncName(name string) bool {
 }
 
 // IsXGoOverloadableFunc reports whether the given function is an XGo overloadable
-// function with a signature like `func(__gop_overload_args__ interface{_()})`.
-func IsXGoOverloadableFunc(fun *types.Func) bool {
-	typ, _ := gogen.CheckSigFuncExObjects(fun.Type().(*types.Signature))
+// function with a signature like `func(__xgo_overload_args__ interface{_()})`.
+func IsXGoOverloadableFunc(fun *gotypes.Func) bool {
+	typ, _ := gogen.CheckSigFuncExObjects(fun.Type().(*gotypes.Signature))
 	return typ != nil
 }
 
 // IsUnexpandableXGoOverloadableFunc reports whether the given function is a
 // Unexpandable-XGo-Overloadable-Func, which is a function that:
-//  1. is overloadable: has a signature like `func(__gop_overload_args__ interface{_()})`
+//  1. is overloadable: has a signature like `func(__xgo_overload_args__ interface{_()})`
 //  2. but not expandable: can not be expanded into overloads
 //
 // A typical example is method `GetWidget` on spx `Game`.
-func IsUnexpandableXGoOverloadableFunc(fun *types.Func) bool {
-	sig := fun.Type().(*types.Signature)
-	if _, ok := gogen.CheckSigFuncEx(sig); ok { // is `func(__gop_overload_args__ interface{_()})`
+func IsUnexpandableXGoOverloadableFunc(fun *gotypes.Func) bool {
+	sig := fun.Type().(*gotypes.Signature)
+	if _, ok := gogen.CheckSigFuncEx(sig); ok { // is `func(__xgo_overload_args__ interface{_()})`
 		if t, _ := gogen.CheckSigFuncExObjects(sig); t == nil { // not expandable
 			return true
 		}
@@ -110,16 +110,16 @@ func IsUnexpandableXGoOverloadableFunc(fun *types.Func) bool {
 }
 
 // ExpandXGoOverloadableFunc expands the given XGo function with a signature
-// like `func(__gop_overload_args__ interface{_()})` to all its overloads. It
+// like `func(__xgo_overload_args__ interface{_()})` to all its overloads. It
 // returns nil if the function is not qualified for overload expansion.
-func ExpandXGoOverloadableFunc(fun *types.Func) []*types.Func {
-	typ, objs := gogen.CheckSigFuncExObjects(fun.Type().(*types.Signature))
+func ExpandXGoOverloadableFunc(fun *gotypes.Func) []*gotypes.Func {
+	typ, objs := gogen.CheckSigFuncExObjects(fun.Type().(*gotypes.Signature))
 	if typ == nil {
 		return nil
 	}
-	overloads := make([]*types.Func, 0, len(objs))
+	overloads := make([]*gotypes.Func, 0, len(objs))
 	for _, obj := range objs {
-		overloads = append(overloads, obj.(*types.Func))
+		overloads = append(overloads, obj.(*gotypes.Func))
 	}
 	return overloads
 }

--- a/xgo/xgoutil/func_test.go
+++ b/xgo/xgoutil/func_test.go
@@ -17,11 +17,13 @@
 package xgoutil
 
 import (
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
+	"github.com/goplus/gogen"
+	"github.com/goplus/xgo/token"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsXgotMethodName(t *testing.T) {
@@ -61,21 +63,21 @@ func TestIsXgotMethodName(t *testing.T) {
 func TestSplitXGotMethodName(t *testing.T) {
 	t.Run("ValidXGotMethodName", func(t *testing.T) {
 		recvTypeName, methodName, ok := SplitXGotMethodName("XGot_Type_Method", false)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "Type", recvTypeName)
 		assert.Equal(t, "Method", methodName)
 	})
 
 	t.Run("ValidXGotMethodNameWithXGoxPrefix", func(t *testing.T) {
 		recvTypeName, methodName, ok := SplitXGotMethodName("XGot_Type_XGox_Method", false)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "Type", recvTypeName)
 		assert.Equal(t, "XGox_Method", methodName)
 	})
 
 	t.Run("ValidXGotMethodNameTrimXGox", func(t *testing.T) {
 		recvTypeName, methodName, ok := SplitXGotMethodName("XGot_Type_XGox_Method", true)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "Type", recvTypeName)
 		assert.Equal(t, "Method", methodName)
 	})
@@ -107,7 +109,7 @@ func TestSplitXGotMethodName(t *testing.T) {
 
 	t.Run("MultipleUnderscores", func(t *testing.T) {
 		recvTypeName, methodName, ok := SplitXGotMethodName("XGot_MyType_My_Method", false)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "MyType", recvTypeName)
 		assert.Equal(t, "My_Method", methodName)
 	})
@@ -116,13 +118,13 @@ func TestSplitXGotMethodName(t *testing.T) {
 func TestSplitXGoxFuncName(t *testing.T) {
 	t.Run("ValidXGoxFuncName", func(t *testing.T) {
 		funcName, ok := SplitXGoxFuncName("XGox_Method")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "Method", funcName)
 	})
 
 	t.Run("ValidXGoxFuncNameWithUnderscores", func(t *testing.T) {
 		funcName, ok := SplitXGoxFuncName("XGox_My_Method")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "My_Method", funcName)
 	})
 
@@ -138,7 +140,7 @@ func TestSplitXGoxFuncName(t *testing.T) {
 
 	t.Run("OnlyPrefix", func(t *testing.T) {
 		funcName, ok := SplitXGoxFuncName("XGox_")
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "", funcName)
 	})
 
@@ -158,21 +160,21 @@ func TestParseXGoFuncName(t *testing.T) {
 	t.Run("OverloadedFunctionName", func(t *testing.T) {
 		parsedName, overloadID := ParseXGoFuncName("MyFunction__a")
 		assert.Equal(t, "myFunction", parsedName)
-		assert.NotNil(t, overloadID)
+		require.NotNil(t, overloadID)
 		assert.Equal(t, "a", *overloadID)
 	})
 
 	t.Run("OverloadedFunctionNameWithNumber", func(t *testing.T) {
 		parsedName, overloadID := ParseXGoFuncName("MyFunction__1")
 		assert.Equal(t, "myFunction", parsedName)
-		assert.NotNil(t, overloadID)
+		require.NotNil(t, overloadID)
 		assert.Equal(t, "1", *overloadID)
 	})
 
 	t.Run("OverloadedFunctionNameWithZero", func(t *testing.T) {
 		parsedName, overloadID := ParseXGoFuncName("MyFunction__0")
 		assert.Equal(t, "myFunction", parsedName)
-		assert.NotNil(t, overloadID)
+		require.NotNil(t, overloadID)
 		assert.Equal(t, "0", *overloadID)
 	})
 
@@ -241,84 +243,110 @@ func TestIsXGoOverloadedFuncName(t *testing.T) {
 
 func TestIsXGoOverloadableFunc(t *testing.T) {
 	t.Run("RegularFunction", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.False(t, IsXGoOverloadableFunc(fun))
 	})
 
 	t.Run("FunctionWithIntParameter", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		params := types.NewTuple(types.NewParam(token.NoPos, pkg, "x", types.Typ[types.Int]))
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		params := gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.False(t, IsXGoOverloadableFunc(fun))
 	})
 
 	t.Run("FunctionWithMultipleParameters", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		params := types.NewTuple(
-			types.NewParam(token.NoPos, pkg, "x", types.Typ[types.Int]),
-			types.NewParam(token.NoPos, pkg, "y", types.Typ[types.String]),
+		pkg := gotypes.NewPackage("test", "test")
+		params := gotypes.NewTuple(
+			gotypes.NewParam(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int]),
+			gotypes.NewParam(token.NoPos, pkg, "y", gotypes.Typ[gotypes.String]),
 		)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.False(t, IsXGoOverloadableFunc(fun))
+	})
+
+	t.Run("OverloadFunction", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		overload1 := gotypes.NewFunc(token.NoPos, pkg, "foo", gotypes.NewSignatureType(nil, nil, nil, nil, nil, false))
+		overload2 := gotypes.NewFunc(token.NoPos, pkg, "bar", gotypes.NewSignatureType(nil, nil, nil, nil, nil, false))
+		fun := gogen.NewOverloadFunc(token.NoPos, pkg, "TestFunc", overload1, overload2)
+		assert.True(t, IsXGoOverloadableFunc(fun))
 	})
 }
 
 func TestIsUnexpandableXGoOverloadableFunc(t *testing.T) {
 	t.Run("RegularFunction", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.False(t, IsUnexpandableXGoOverloadableFunc(fun))
 	})
 
 	t.Run("FunctionWithIntParameter", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		params := types.NewTuple(types.NewParam(token.NoPos, pkg, "x", types.Typ[types.Int]))
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		params := gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.False(t, IsUnexpandableXGoOverloadableFunc(fun))
 	})
 
 	t.Run("FunctionWithMultipleParameters", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		params := types.NewTuple(
-			types.NewParam(token.NoPos, pkg, "x", types.Typ[types.Int]),
-			types.NewParam(token.NoPos, pkg, "y", types.Typ[types.String]),
+		pkg := gotypes.NewPackage("test", "test")
+		params := gotypes.NewTuple(
+			gotypes.NewParam(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int]),
+			gotypes.NewParam(token.NoPos, pkg, "y", gotypes.Typ[gotypes.String]),
 		)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.False(t, IsUnexpandableXGoOverloadableFunc(fun))
+	})
+
+	t.Run("UnexpandableFuncEx", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", newTestFuncExSignature(pkg, nil, gotypes.Typ[gotypes.Int]))
+		assert.True(t, IsUnexpandableXGoOverloadableFunc(fun))
 	})
 }
 
 func TestExpandXGoOverloadableFunc(t *testing.T) {
 	t.Run("RegularFunction", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.Nil(t, ExpandXGoOverloadableFunc(fun))
 	})
 
 	t.Run("FunctionWithIntParameter", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		params := types.NewTuple(types.NewParam(token.NoPos, pkg, "x", types.Typ[types.Int]))
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		pkg := gotypes.NewPackage("test", "test")
+		params := gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.Nil(t, ExpandXGoOverloadableFunc(fun))
 	})
 
 	t.Run("FunctionWithMultipleParameters", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		params := types.NewTuple(
-			types.NewParam(token.NoPos, pkg, "x", types.Typ[types.Int]),
-			types.NewParam(token.NoPos, pkg, "y", types.Typ[types.String]),
+		pkg := gotypes.NewPackage("test", "test")
+		params := gotypes.NewTuple(
+			gotypes.NewParam(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int]),
+			gotypes.NewParam(token.NoPos, pkg, "y", gotypes.Typ[gotypes.String]),
 		)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "TestFunc", sig)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "TestFunc", sig)
 		assert.Nil(t, ExpandXGoOverloadableFunc(fun))
+	})
+
+	t.Run("OverloadFunction", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		overload1 := gotypes.NewFunc(token.NoPos, pkg, "foo", gotypes.NewSignatureType(nil, nil, nil, nil, nil, false))
+		overload2 := gotypes.NewFunc(token.NoPos, pkg, "bar", gotypes.NewSignatureType(nil, nil, nil, nil, nil, false))
+		fun := gogen.NewOverloadFunc(token.NoPos, pkg, "TestFunc", overload1, overload2)
+
+		expanded := ExpandXGoOverloadableFunc(fun)
+		assert.Len(t, expanded, 2)
+		assert.Same(t, overload1, expanded[0])
+		assert.Same(t, overload2, expanded[1])
 	})
 }

--- a/xgo/xgoutil/ident.go
+++ b/xgo/xgoutil/ident.go
@@ -19,11 +19,11 @@ package xgoutil
 import (
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 )
 
 // IdentAtPosition returns the identifier at the given position in the given AST file.
-func IdentAtPosition(fset *token.FileSet, typeInfo *xgotypes.Info, astFile *ast.File, position token.Position) *ast.Ident {
+func IdentAtPosition(fset *token.FileSet, typeInfo *types.Info, astFile *ast.File, position token.Position) *ast.Ident {
 	if fset == nil || typeInfo == nil || astFile == nil {
 		return nil
 	}
@@ -110,7 +110,7 @@ func IsBlankIdent(ident *ast.Ident) bool {
 // receiver "this" that XGo inserts at the start of a classfile. It matches both
 // the defining identifier and any reference whose definition maps to that
 // synthetic receiver.
-func IsSyntheticThisIdent(fset *token.FileSet, typeInfo *xgotypes.Info, astPkg *ast.Package, ident *ast.Ident) bool {
+func IsSyntheticThisIdent(fset *token.FileSet, typeInfo *types.Info, astPkg *ast.Package, ident *ast.Ident) bool {
 	if fset == nil || typeInfo == nil || astPkg == nil || ident == nil || ident.Name != "this" {
 		return false
 	}
@@ -124,7 +124,7 @@ func IsSyntheticThisIdent(fset *token.FileSet, typeInfo *xgotypes.Info, astPkg *
 }
 
 // identToDef returns the defining identifier for ident if available.
-func identToDef(typeInfo *xgotypes.Info, ident *ast.Ident) *ast.Ident {
+func identToDef(typeInfo *types.Info, ident *ast.Ident) *ast.Ident {
 	if typeInfo == nil || ident == nil {
 		return nil
 	}

--- a/xgo/xgoutil/ident_test.go
+++ b/xgo/xgoutil/ident_test.go
@@ -17,7 +17,7 @@
 package xgoutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
@@ -36,11 +36,11 @@ func TestIdentAtPosition(t *testing.T) {
 		require.NotNil(t, longVarIdent)
 		require.NotNil(t, shortIdent)
 
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		typeInfo := newTestTypeInfo(
-			map[*ast.Ident]types.Object{
-				longVarIdent: types.NewVar(token.NoPos, pkg, "longVarName", types.Typ[types.Int]),
-				shortIdent:   types.NewVar(token.NoPos, pkg, "short", types.Typ[types.Int]),
+			map[*ast.Ident]gotypes.Object{
+				longVarIdent: gotypes.NewVar(token.NoPos, pkg, "longVarName", gotypes.Typ[gotypes.Int]),
+				shortIdent:   gotypes.NewVar(token.NoPos, pkg, "short", gotypes.Typ[gotypes.Int]),
 			},
 			nil,
 		)
@@ -66,14 +66,14 @@ func TestIdentAtPosition(t *testing.T) {
 		longVarNameIdent, longVarNamePos := findIdentWithPos(fset, astFile, "longVarName")
 		shortIdent, shortPos := findIdentWithPos(fset, astFile, "short")
 
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		typeInfo := newTestTypeInfo(
-			map[*ast.Ident]types.Object{
-				resultIdent: types.NewVar(token.NoPos, pkg, "result", types.Typ[types.Int]),
+			map[*ast.Ident]gotypes.Object{
+				resultIdent: gotypes.NewVar(token.NoPos, pkg, "result", gotypes.Typ[gotypes.Int]),
 			},
-			map[*ast.Ident]types.Object{
-				longVarNameIdent: types.NewVar(token.NoPos, pkg, "longVarName", types.Typ[types.Int]),
-				shortIdent:       types.NewVar(token.NoPos, pkg, "short", types.Typ[types.Int]),
+			map[*ast.Ident]gotypes.Object{
+				longVarNameIdent: gotypes.NewVar(token.NoPos, pkg, "longVarName", gotypes.Typ[gotypes.Int]),
+				shortIdent:       gotypes.NewVar(token.NoPos, pkg, "short", gotypes.Typ[gotypes.Int]),
 			},
 		)
 
@@ -108,6 +108,27 @@ func TestIdentAtPosition(t *testing.T) {
 		assert.Nil(t, ident)
 	})
 
+	t.Run("NilInputs", func(t *testing.T) {
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
+		require.NoError(t, err)
+
+		typeInfo := newTestTypeInfo(nil, nil)
+		pos := token.Position{Filename: "main.xgo", Line: 1, Column: 5}
+
+		assert.Nil(t, IdentAtPosition(nil, typeInfo, astFile, pos))
+		assert.Nil(t, IdentAtPosition(fset, nil, astFile, pos))
+		assert.Nil(t, IdentAtPosition(fset, typeInfo, nil, pos))
+	})
+
+	t.Run("TokenFileUnavailable", func(t *testing.T) {
+		fset := token.NewFileSet()
+		astFile := &ast.File{Name: &ast.Ident{Name: "main"}}
+		typeInfo := newTestTypeInfo(nil, nil)
+
+		ident := IdentAtPosition(fset, typeInfo, astFile, token.Position{})
+		assert.Nil(t, ident)
+	})
+
 	t.Run("BoundaryConditions", func(t *testing.T) {
 		fset, astFile, err := newTestFile("main.xgo", "var longVarName = 1")
 		require.NoError(t, err)
@@ -115,10 +136,10 @@ func TestIdentAtPosition(t *testing.T) {
 		longVarNameIdent := findIdent(astFile, "longVarName")
 		require.NotNil(t, longVarNameIdent)
 
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		typeInfo := newTestTypeInfo(
-			map[*ast.Ident]types.Object{
-				longVarNameIdent: types.NewVar(token.NoPos, pkg, "longVarName", types.Typ[types.Int]),
+			map[*ast.Ident]gotypes.Object{
+				longVarNameIdent: gotypes.NewVar(token.NoPos, pkg, "longVarName", gotypes.Typ[gotypes.Int]),
 			},
 			nil,
 		)
@@ -150,11 +171,11 @@ func TestIdentAtPosition(t *testing.T) {
 		iIdent, iPos := findIdentWithPos(fset, astFile, "i")
 		iiIdent, iiPos := findIdentWithPos(fset, astFile, "ii")
 
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		typeInfo := newTestTypeInfo(
-			map[*ast.Ident]types.Object{
-				iIdent:  types.NewVar(token.NoPos, pkg, "i", types.Typ[types.Int]),
-				iiIdent: types.NewVar(token.NoPos, pkg, "ii", types.Typ[types.Int]),
+			map[*ast.Ident]gotypes.Object{
+				iIdent:  gotypes.NewVar(token.NoPos, pkg, "i", gotypes.Typ[gotypes.Int]),
+				iiIdent: gotypes.NewVar(token.NoPos, pkg, "ii", gotypes.Typ[gotypes.Int]),
 			},
 			nil,
 		)
@@ -200,17 +221,30 @@ func TestIdentAtPosition(t *testing.T) {
 		fset, astFile, err := newTestFile("main.xgo", "package main")
 		require.NoError(t, err)
 
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		syntheticThis := &ast.Ident{NamePos: astFile.Pos(), Name: "this"}
-		obj := types.NewVar(syntheticThis.Pos(), pkg, "this", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{syntheticThis: obj}, nil)
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{obj: syntheticThis}
+		obj := gotypes.NewVar(syntheticThis.Pos(), pkg, "this", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{syntheticThis: obj}, nil)
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: syntheticThis}
 
 		ident := IdentAtPosition(fset, typeInfo, astFile, token.Position{
 			Filename: "main.xgo",
 			Line:     1,
 			Column:   1,
 		})
+		assert.Nil(t, ident)
+	})
+
+	t.Run("ImplicitIdentifierIsSkipped", func(t *testing.T) {
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
+		require.NoError(t, err)
+
+		implicitIdent := findIdent(astFile, "x")
+		require.NotNil(t, implicitIdent)
+		implicitIdent.Obj = &ast.Object{Kind: ast.ImplicitFun}
+
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{implicitIdent: nil}, nil)
+		ident := IdentAtPosition(fset, typeInfo, astFile, fset.Position(implicitIdent.Pos()))
 		assert.Nil(t, ident)
 	})
 
@@ -236,22 +270,43 @@ func f() {
 		})
 		require.Len(t, thisIdents, 2)
 
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewVar(token.NoPos, pkg, "this", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewVar(token.NoPos, pkg, "this", gotypes.Typ[gotypes.Int])
 		typeInfo := newTestTypeInfo(
-			map[*ast.Ident]types.Object{
+			map[*ast.Ident]gotypes.Object{
 				thisIdents[0]: obj,
 			},
-			map[*ast.Ident]types.Object{
+			map[*ast.Ident]gotypes.Object{
 				thisIdents[1]: obj,
 			},
 		)
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{obj: thisIdents[0]}
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: thisIdents[0]}
 
 		usePos := fset.Position(thisIdents[1].Pos())
 		ident := IdentAtPosition(fset, typeInfo, astFile, usePos)
 		require.NotNil(t, ident)
 		assert.Equal(t, thisIdents[1], ident)
+	})
+
+	t.Run("BestPossibleUseMatch", func(t *testing.T) {
+		fset, astFile, err := newTestFile("main.xgo", `
+func f() {
+	_ = y
+}
+`)
+		require.NoError(t, err)
+
+		yIdent := findIdent(astFile, "y")
+		require.NotNil(t, yIdent)
+
+		pkg := gotypes.NewPackage("main", "main")
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
+			yIdent: gotypes.NewVar(token.NoPos, pkg, "y", gotypes.Typ[gotypes.Int]),
+		})
+
+		ident := IdentAtPosition(fset, typeInfo, astFile, fset.Position(yIdent.Pos()))
+		require.NotNil(t, ident)
+		assert.Equal(t, yIdent, ident)
 	})
 }
 
@@ -262,20 +317,20 @@ func TestIsBlankIdent(t *testing.T) {
 }
 
 func TestIsSyntheticThisIdent(t *testing.T) {
-	newBase := func(t *testing.T) (*token.FileSet, *ast.File, *ast.Package, *types.Package) {
+	newBase := func(t *testing.T) (*token.FileSet, *ast.File, *ast.Package, *gotypes.Package) {
 		fset, astFile, err := newTestFile("main.xgo", "package main")
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		return fset, astFile, astPkg, pkg
 	}
 
 	t.Run("Definition", func(t *testing.T) {
 		fset, astFile, astPkg, pkg := newBase(t)
 		defIdent := &ast.Ident{NamePos: astFile.Pos(), Name: "this"}
-		obj := types.NewVar(defIdent.Pos(), pkg, "this", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{defIdent: obj}, nil)
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{obj: defIdent}
+		obj := gotypes.NewVar(defIdent.Pos(), pkg, "this", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{defIdent: obj}, nil)
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: defIdent}
 
 		assert.True(t, IsSyntheticThisIdent(fset, typeInfo, astPkg, defIdent))
 	})
@@ -284,9 +339,9 @@ func TestIsSyntheticThisIdent(t *testing.T) {
 		fset, astFile, astPkg, pkg := newBase(t)
 		defIdent := &ast.Ident{NamePos: astFile.Pos(), Name: "this"}
 		refIdent := &ast.Ident{NamePos: defIdent.Pos() + 10, Name: "this"}
-		obj := types.NewVar(defIdent.Pos(), pkg, "this", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{defIdent: obj}, map[*ast.Ident]types.Object{refIdent: obj})
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{obj: defIdent}
+		obj := gotypes.NewVar(defIdent.Pos(), pkg, "this", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{defIdent: obj}, map[*ast.Ident]gotypes.Object{refIdent: obj})
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: defIdent}
 
 		assert.True(t, IsSyntheticThisIdent(fset, typeInfo, astPkg, refIdent))
 	})
@@ -302,9 +357,9 @@ func TestIsSyntheticThisIdent(t *testing.T) {
 	t.Run("NonSyntheticPosition", func(t *testing.T) {
 		fset, astFile, astPkg, pkg := newBase(t)
 		defIdent := &ast.Ident{NamePos: astFile.Pos() + 5, Name: "this"}
-		obj := types.NewVar(defIdent.Pos(), pkg, "this", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{defIdent: obj}, nil)
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{obj: defIdent}
+		obj := gotypes.NewVar(defIdent.Pos(), pkg, "this", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{defIdent: obj}, nil)
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: defIdent}
 
 		assert.False(t, IsSyntheticThisIdent(fset, typeInfo, astPkg, defIdent))
 	})
@@ -312,14 +367,24 @@ func TestIsSyntheticThisIdent(t *testing.T) {
 	t.Run("NilInputs", func(t *testing.T) {
 		fset, astFile, astPkg, pkg := newBase(t)
 		defIdent := &ast.Ident{NamePos: astFile.Pos(), Name: "this"}
-		obj := types.NewVar(defIdent.Pos(), pkg, "this", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{defIdent: obj}, nil)
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{obj: defIdent}
+		obj := gotypes.NewVar(defIdent.Pos(), pkg, "this", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{defIdent: obj}, nil)
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: defIdent}
 
 		assert.False(t, IsSyntheticThisIdent(nil, typeInfo, astPkg, defIdent))
 		assert.False(t, IsSyntheticThisIdent(fset, nil, astPkg, defIdent))
 		assert.False(t, IsSyntheticThisIdent(fset, typeInfo, nil, defIdent))
 		assert.False(t, IsSyntheticThisIdent(fset, typeInfo, astPkg, nil))
+	})
+
+	t.Run("DefinitionOutsidePackage", func(t *testing.T) {
+		fset, astFile, astPkg, pkg := newBase(t)
+		defIdent := &ast.Ident{NamePos: astFile.End() + 10, Name: "this"}
+		obj := gotypes.NewVar(defIdent.Pos(), pkg, "this", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{defIdent: obj}, nil)
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: defIdent}
+
+		assert.False(t, IsSyntheticThisIdent(fset, typeInfo, astPkg, defIdent))
 	})
 }
 
@@ -341,20 +406,20 @@ func TestIdentToDef(t *testing.T) {
 	})
 
 	t.Run("ObjectWithoutDefinition", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "x"}
-		obj := types.NewVar(token.NoPos, pkg, "x", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]types.Object{ident: obj})
+		obj := gotypes.NewVar(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: obj})
 		assert.Equal(t, ident, identToDef(typeInfo, ident))
 	})
 
 	t.Run("ResolveDefinition", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		defIdent := &ast.Ident{Name: "x"}
 		useIdent := &ast.Ident{Name: "x"}
-		obj := types.NewVar(token.NoPos, pkg, "x", types.Typ[types.Int])
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{defIdent: obj}, map[*ast.Ident]types.Object{useIdent: obj})
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{obj: defIdent}
+		obj := gotypes.NewVar(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int])
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{defIdent: obj}, map[*ast.Ident]gotypes.Object{useIdent: obj})
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{obj: defIdent}
 		assert.Equal(t, defIdent, identToDef(typeInfo, useIdent))
 	})
 }

--- a/xgo/xgoutil/obj.go
+++ b/xgo/xgoutil/obj.go
@@ -16,33 +16,33 @@
 
 package xgoutil
 
-import "go/types"
+import gotypes "go/types"
 
 // IsInBuiltinPkg reports whether the given object is defined in the "builtin" package.
-func IsInBuiltinPkg(obj types.Object) bool {
+func IsInBuiltinPkg(obj gotypes.Object) bool {
 	return obj != nil && IsBuiltinPkg(obj.Pkg())
 }
 
 // IsInMainPkg reports whether the given object is defined in the "main" package.
-func IsInMainPkg(obj types.Object) bool {
+func IsInMainPkg(obj gotypes.Object) bool {
 	return obj != nil && IsMainPkg(obj.Pkg())
 }
 
 // IsExportedOrInMainPkg reports whether the given object is exported or
 // defined in the "main" package.
-func IsExportedOrInMainPkg(obj types.Object) bool {
+func IsExportedOrInMainPkg(obj gotypes.Object) bool {
 	return obj != nil && (obj.Exported() || IsInMainPkg(obj))
 }
 
 // IsRenameable reports whether the given object can be renamed.
-func IsRenameable(obj types.Object) bool {
-	if !IsInMainPkg(obj) || !obj.Pos().IsValid() || obj.Parent() == types.Universe {
+func IsRenameable(obj gotypes.Object) bool {
+	if !IsInMainPkg(obj) || !obj.Pos().IsValid() || obj.Parent() == gotypes.Universe {
 		return false
 	}
 	switch obj.(type) {
-	case *types.Var, *types.Const, *types.TypeName, *types.Func, *types.Label:
+	case *gotypes.Var, *gotypes.Const, *gotypes.TypeName, *gotypes.Func, *gotypes.Label:
 		return true
-	case *types.PkgName:
+	case *gotypes.PkgName:
 		return false
 	}
 	return false

--- a/xgo/xgoutil/obj_test.go
+++ b/xgo/xgoutil/obj_test.go
@@ -17,10 +17,10 @@
 package xgoutil
 
 import (
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
+	"github.com/goplus/xgo/token"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,31 +30,31 @@ func TestIsInBuiltinPkg(t *testing.T) {
 	})
 
 	t.Run("ObjectInBuiltinPackage", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("", "builtin")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsInBuiltinPkg(obj))
 	})
 
 	t.Run("ObjectInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInBuiltinPkg(obj))
 	})
 
 	t.Run("ObjectInStandardLibraryPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("fmt", "fmt")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInBuiltinPkg(obj))
 	})
 
 	t.Run("ObjectInThirdPartyPackage", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/pkg", "pkg")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInBuiltinPkg(obj))
 	})
 
 	t.Run("ObjectWithNilPackage", func(t *testing.T) {
-		obj := types.NewVar(token.NoPos, nil, "test", types.Typ[types.Int])
+		obj := gotypes.NewVar(token.NoPos, nil, "test", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsInBuiltinPkg(obj))
 	})
 }
@@ -65,37 +65,37 @@ func TestIsInMainPkg(t *testing.T) {
 	})
 
 	t.Run("ObjectInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsInMainPkg(obj))
 	})
 
 	t.Run("ObjectInBuiltinPackage", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("", "builtin")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInMainPkg(obj))
 	})
 
 	t.Run("ObjectInStandardLibraryPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("fmt", "fmt")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInMainPkg(obj))
 	})
 
 	t.Run("ObjectInThirdPartyPackage", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/pkg", "pkg")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInMainPkg(obj))
 	})
 
 	t.Run("ObjectWithNilPackage", func(t *testing.T) {
-		obj := types.NewVar(token.NoPos, nil, "test", types.Typ[types.Int])
+		obj := gotypes.NewVar(token.NoPos, nil, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInMainPkg(obj))
 	})
 
 	t.Run("ObjectInPackageNamedMainButDifferentPath", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/main", "main")
-		obj := types.NewVar(token.NoPos, pkg, "test", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("example.com/main", "main")
+		obj := gotypes.NewVar(token.NoPos, pkg, "test", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsInMainPkg(obj))
 	})
 }
@@ -106,43 +106,43 @@ func TestIsExportedOrInMainPkg(t *testing.T) {
 	})
 
 	t.Run("ExportedObjectInNonMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
-		obj := types.NewVar(token.NoPos, pkg, "ExportedVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("fmt", "fmt")
+		obj := gotypes.NewVar(token.NoPos, pkg, "ExportedVar", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsExportedOrInMainPkg(obj))
 	})
 
 	t.Run("UnexportedObjectInNonMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
-		obj := types.NewVar(token.NoPos, pkg, "unexportedVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("fmt", "fmt")
+		obj := gotypes.NewVar(token.NoPos, pkg, "unexportedVar", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsExportedOrInMainPkg(obj))
 	})
 
 	t.Run("ExportedObjectInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewVar(token.NoPos, pkg, "ExportedVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewVar(token.NoPos, pkg, "ExportedVar", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsExportedOrInMainPkg(obj))
 	})
 
 	t.Run("UnexportedObjectInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewVar(token.NoPos, pkg, "unexportedVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewVar(token.NoPos, pkg, "unexportedVar", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsExportedOrInMainPkg(obj))
 	})
 
 	t.Run("ExportedObjectInBuiltinPackage", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
-		obj := types.NewVar(token.NoPos, pkg, "ExportedVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("", "builtin")
+		obj := gotypes.NewVar(token.NoPos, pkg, "ExportedVar", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsExportedOrInMainPkg(obj))
 	})
 
 	t.Run("UnexportedObjectInBuiltinPackage", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
-		obj := types.NewVar(token.NoPos, pkg, "unexportedVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("", "builtin")
+		obj := gotypes.NewVar(token.NoPos, pkg, "unexportedVar", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsExportedOrInMainPkg(obj))
 	})
 
 	t.Run("ObjectWithNilPackage", func(t *testing.T) {
-		obj := types.NewVar(token.NoPos, nil, "ExportedVar", types.Typ[types.Int])
+		obj := gotypes.NewVar(token.NoPos, nil, "ExportedVar", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsExportedOrInMainPkg(obj))
 	})
 }
@@ -153,67 +153,67 @@ func TestIsRenameable(t *testing.T) {
 	})
 
 	t.Run("VariableInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewVar(token.Pos(1), pkg, "testVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewVar(token.Pos(1), pkg, "testVar", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsRenameable(obj))
 	})
 
 	t.Run("ConstantInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewConst(token.Pos(1), pkg, "testConst", types.Typ[types.Int], nil)
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewConst(token.Pos(1), pkg, "testConst", gotypes.Typ[gotypes.Int], nil)
 		assert.True(t, IsRenameable(obj))
 	})
 
 	t.Run("TypeNameInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewTypeName(token.Pos(1), pkg, "TestType", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewTypeName(token.Pos(1), pkg, "TestType", gotypes.Typ[gotypes.Int])
 		assert.True(t, IsRenameable(obj))
 	})
 
 	t.Run("FunctionInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		obj := types.NewFunc(token.Pos(1), pkg, "testFunc", sig)
+		pkg := gotypes.NewPackage("main", "main")
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		obj := gotypes.NewFunc(token.Pos(1), pkg, "testFunc", sig)
 		assert.True(t, IsRenameable(obj))
 	})
 
 	t.Run("LabelInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewLabel(token.Pos(1), pkg, "testLabel")
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewLabel(token.Pos(1), pkg, "testLabel")
 		assert.True(t, IsRenameable(obj))
 	})
 
 	t.Run("PackageNameInMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewPkgName(token.Pos(1), pkg, "testPkg", nil)
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewPkgName(token.Pos(1), pkg, "testPkg", nil)
 		assert.False(t, IsRenameable(obj))
 	})
 
 	t.Run("VariableInNonMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
-		obj := types.NewVar(token.Pos(1), pkg, "testVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("fmt", "fmt")
+		obj := gotypes.NewVar(token.Pos(1), pkg, "testVar", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsRenameable(obj))
 	})
 
 	t.Run("VariableWithInvalidPosition", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		obj := types.NewVar(token.NoPos, pkg, "testVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		obj := gotypes.NewVar(token.NoPos, pkg, "testVar", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsRenameable(obj))
 	})
 
 	t.Run("VariableInUniverseScope", func(t *testing.T) {
-		obj := types.Universe.Lookup("int")
+		obj := gotypes.Universe.Lookup("int")
 		assert.False(t, IsRenameable(obj))
 	})
 
 	t.Run("BuiltinVariable", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
-		obj := types.NewVar(token.Pos(1), pkg, "testVar", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("", "builtin")
+		obj := gotypes.NewVar(token.Pos(1), pkg, "testVar", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsRenameable(obj))
 	})
 
 	t.Run("ObjectWithNilPackage", func(t *testing.T) {
-		obj := types.NewVar(token.Pos(1), nil, "testVar", types.Typ[types.Int])
+		obj := gotypes.NewVar(token.Pos(1), nil, "testVar", gotypes.Typ[gotypes.Int])
 		assert.False(t, IsRenameable(obj))
 	})
 }

--- a/xgo/xgoutil/pkg.go
+++ b/xgo/xgoutil/pkg.go
@@ -18,14 +18,14 @@ package xgoutil
 
 import (
 	"go/constant"
-	"go/types"
+	gotypes "go/types"
 )
 
 // XGoPackage indicates an XGo package.
 const XGoPackage = "GopPackage"
 
 // IsMarkedAsXGoPackage reports whether the given package is marked as an XGo package.
-func IsMarkedAsXGoPackage(pkg *types.Package) bool {
+func IsMarkedAsXGoPackage(pkg *gotypes.Package) bool {
 	if pkg == nil {
 		return false
 	}
@@ -37,11 +37,11 @@ func IsMarkedAsXGoPackage(pkg *types.Package) bool {
 	if obj == nil {
 		return false
 	}
-	cnst, ok := obj.(*types.Const)
+	cnst, ok := obj.(*gotypes.Const)
 	if !ok {
 		return false
 	}
-	if cnst.Type() != types.Typ[types.UntypedBool] {
+	if cnst.Type() != gotypes.Typ[gotypes.UntypedBool] {
 		return false
 	}
 	cnstVal := cnst.Val()
@@ -50,7 +50,7 @@ func IsMarkedAsXGoPackage(pkg *types.Package) bool {
 
 // PkgPath returns the package path of the given pkg. It returns "builtin" if
 // the pkg is nil.
-func PkgPath(pkg *types.Package) string {
+func PkgPath(pkg *gotypes.Package) string {
 	if pkg == nil {
 		return "builtin"
 	}
@@ -64,11 +64,11 @@ func PkgPath(pkg *types.Package) string {
 }
 
 // IsBuiltinPkg reports whether the given package is the "builtin" package.
-func IsBuiltinPkg(pkg *types.Package) bool {
+func IsBuiltinPkg(pkg *gotypes.Package) bool {
 	return PkgPath(pkg) == "builtin"
 }
 
 // IsMainPkg reports whether the given package is the "main" package.
-func IsMainPkg(pkg *types.Package) bool {
+func IsMainPkg(pkg *gotypes.Package) bool {
 	return PkgPath(pkg) == "main"
 }

--- a/xgo/xgoutil/pkg_test.go
+++ b/xgo/xgoutil/pkg_test.go
@@ -18,7 +18,7 @@ package xgoutil
 
 import (
 	"go/constant"
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,40 +29,52 @@ func TestIsMarkedAsXGoPackage(t *testing.T) {
 		assert.False(t, IsMarkedAsXGoPackage(nil))
 	})
 
+	t.Run("PackageWithNilScope", func(t *testing.T) {
+		pkg := new(gotypes.Package)
+		assert.False(t, IsMarkedAsXGoPackage(pkg))
+	})
+
 	t.Run("PackageWithEmptyScope", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		assert.False(t, IsMarkedAsXGoPackage(pkg))
 	})
 
 	t.Run("PackageWithoutXGoPackageMarker", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		assert.False(t, IsMarkedAsXGoPackage(pkg))
 	})
 
 	t.Run("PackageWithXGoPackageMarker", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		markAsXGoPackage(pkg)
 		assert.True(t, IsMarkedAsXGoPackage(pkg))
 	})
 
 	t.Run("PackageWithWrongTypeXGoPackageMarker", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		scope := pkg.Scope()
-		scope.Insert(types.NewConst(0, pkg, XGoPackage, types.Typ[types.Int], constant.MakeInt64(1)))
+		scope.Insert(gotypes.NewConst(0, pkg, XGoPackage, gotypes.Typ[gotypes.Int], constant.MakeInt64(1)))
 		assert.False(t, IsMarkedAsXGoPackage(pkg))
 	})
 
 	t.Run("PackageWithWrongValueXGoPackageMarker", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		scope := pkg.Scope()
-		scope.Insert(types.NewConst(0, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(false)))
+		scope.Insert(gotypes.NewConst(0, pkg, XGoPackage, gotypes.Typ[gotypes.UntypedBool], constant.MakeBool(false)))
+		assert.False(t, IsMarkedAsXGoPackage(pkg))
+	})
+
+	t.Run("PackageWithNilValueXGoPackageMarker", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		scope := pkg.Scope()
+		scope.Insert(gotypes.NewConst(0, pkg, XGoPackage, gotypes.Typ[gotypes.UntypedBool], nil))
 		assert.False(t, IsMarkedAsXGoPackage(pkg))
 	})
 
 	t.Run("PackageWithNonConstXGoPackageMarker", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		scope := pkg.Scope()
-		scope.Insert(types.NewVar(0, pkg, XGoPackage, types.Typ[types.UntypedBool]))
+		scope.Insert(gotypes.NewVar(0, pkg, XGoPackage, gotypes.Typ[gotypes.UntypedBool]))
 		assert.False(t, IsMarkedAsXGoPackage(pkg))
 	})
 }
@@ -73,27 +85,27 @@ func TestPkgPath(t *testing.T) {
 	})
 
 	t.Run("PackageWithEmptyPath", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
+		pkg := gotypes.NewPackage("", "builtin")
 		assert.Equal(t, "builtin", PkgPath(pkg))
 	})
 
 	t.Run("PackageWithValidPath", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/pkg", "pkg")
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
 		assert.Equal(t, "example.com/pkg", PkgPath(pkg))
 	})
 
 	t.Run("MainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		assert.Equal(t, "main", PkgPath(pkg))
 	})
 
 	t.Run("StandardLibraryPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
+		pkg := gotypes.NewPackage("fmt", "fmt")
 		assert.Equal(t, "fmt", PkgPath(pkg))
 	})
 
 	t.Run("NestedPackagePath", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/deep/nested/pkg", "pkg")
+		pkg := gotypes.NewPackage("example.com/deep/nested/pkg", "pkg")
 		assert.Equal(t, "example.com/deep/nested/pkg", PkgPath(pkg))
 	})
 }
@@ -104,22 +116,22 @@ func TestIsBuiltinPkg(t *testing.T) {
 	})
 
 	t.Run("BuiltinPackageWithEmptyPath", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
+		pkg := gotypes.NewPackage("", "builtin")
 		assert.True(t, IsBuiltinPkg(pkg))
 	})
 
 	t.Run("NonBuiltinPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
+		pkg := gotypes.NewPackage("fmt", "fmt")
 		assert.False(t, IsBuiltinPkg(pkg))
 	})
 
 	t.Run("MainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		assert.False(t, IsBuiltinPkg(pkg))
 	})
 
 	t.Run("ThirdPartyPackage", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/pkg", "pkg")
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
 		assert.False(t, IsBuiltinPkg(pkg))
 	})
 }
@@ -130,27 +142,27 @@ func TestIsMainPkg(t *testing.T) {
 	})
 
 	t.Run("MainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		assert.True(t, IsMainPkg(pkg))
 	})
 
 	t.Run("NonMainPackage", func(t *testing.T) {
-		pkg := types.NewPackage("fmt", "fmt")
+		pkg := gotypes.NewPackage("fmt", "fmt")
 		assert.False(t, IsMainPkg(pkg))
 	})
 
 	t.Run("BuiltinPackage", func(t *testing.T) {
-		pkg := types.NewPackage("", "builtin")
+		pkg := gotypes.NewPackage("", "builtin")
 		assert.False(t, IsMainPkg(pkg))
 	})
 
 	t.Run("ThirdPartyPackage", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/pkg", "pkg")
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
 		assert.False(t, IsMainPkg(pkg))
 	})
 
 	t.Run("PackageNamedMainButDifferentPath", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/main", "main")
+		pkg := gotypes.NewPackage("example.com/main", "main")
 		assert.False(t, IsMainPkg(pkg))
 	})
 }

--- a/xgo/xgoutil/scope.go
+++ b/xgo/xgoutil/scope.go
@@ -17,16 +17,16 @@
 package xgoutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 )
 
 // InnermostScopeAt returns the innermost scope that contains the given
 // position. It returns nil if not found.
-func InnermostScopeAt(fset *token.FileSet, typeInfo *xgotypes.Info, astPkg *ast.Package, pos token.Pos) *types.Scope {
+func InnermostScopeAt(fset *token.FileSet, typeInfo *types.Info, astPkg *ast.Package, pos token.Pos) *gotypes.Scope {
 	if fset == nil || typeInfo == nil || astPkg == nil || !pos.IsValid() {
 		return nil
 	}
@@ -36,7 +36,7 @@ func InnermostScopeAt(fset *token.FileSet, typeInfo *xgotypes.Info, astPkg *ast.
 		return nil
 	}
 
-	var scope *types.Scope
+	var scope *gotypes.Scope
 	WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
 		scope = typeInfo.Scopes[node]
 		if scope == nil {

--- a/xgo/xgoutil/scope_test.go
+++ b/xgo/xgoutil/scope_test.go
@@ -17,7 +17,7 @@
 package xgoutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
@@ -51,13 +51,13 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		pkg := types.NewPackage("main", "main")
-		packageScope := types.NewScope(types.Universe, token.NoPos, token.NoPos, "package")
-		xVar := types.NewVar(token.NoPos, pkg, "x", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		packageScope := gotypes.NewScope(gotypes.Universe, token.NoPos, token.NoPos, "package")
+		xVar := gotypes.NewVar(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int])
 		packageScope.Insert(xVar)
 
 		typeInfo := newTestTypeInfo(nil, nil)
-		typeInfo.Scopes = map[ast.Node]*types.Scope{
+		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile: packageScope,
 		}
 
@@ -73,16 +73,16 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		pkg := types.NewPackage("main", "main")
-		packageScope := types.NewScope(types.Universe, token.NoPos, token.NoPos, "package")
-		functionScope := types.NewScope(packageScope, token.NoPos, token.NoPos, "function")
+		pkg := gotypes.NewPackage("main", "main")
+		packageScope := gotypes.NewScope(gotypes.Universe, token.NoPos, token.NoPos, "package")
+		functionScope := gotypes.NewScope(packageScope, token.NoPos, token.NoPos, "function")
 
-		yVar := types.NewVar(token.NoPos, pkg, "y", types.Typ[types.Int])
+		yVar := gotypes.NewVar(token.NoPos, pkg, "y", gotypes.Typ[gotypes.Int])
 		functionScope.Insert(yVar)
 
 		typeInfo := newTestTypeInfo(nil, nil)
 		funcDecl := astFile.Decls[0].(*ast.FuncDecl)
-		typeInfo.Scopes = map[ast.Node]*types.Scope{
+		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile:       packageScope,
 			funcDecl.Body: functionScope,
 		}
@@ -98,12 +98,12 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		pkg := types.NewPackage("main", "main")
-		packageScope := types.NewScope(types.Universe, token.NoPos, token.NoPos, "package")
-		functionScope := types.NewScope(packageScope, token.NoPos, token.NoPos, "function")
-		blockScope := types.NewScope(functionScope, token.NoPos, token.NoPos, "block")
+		pkg := gotypes.NewPackage("main", "main")
+		packageScope := gotypes.NewScope(gotypes.Universe, token.NoPos, token.NoPos, "package")
+		functionScope := gotypes.NewScope(packageScope, token.NoPos, token.NoPos, "function")
+		blockScope := gotypes.NewScope(functionScope, token.NoPos, token.NoPos, "block")
 
-		zVar := types.NewVar(token.NoPos, pkg, "z", types.Typ[types.Int])
+		zVar := gotypes.NewVar(token.NoPos, pkg, "z", gotypes.Typ[gotypes.Int])
 		blockScope.Insert(zVar)
 
 		// Find the if statement body.
@@ -118,7 +118,7 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NotNil(t, ifBody)
 
 		typeInfo := newTestTypeInfo(nil, nil)
-		typeInfo.Scopes = map[ast.Node]*types.Scope{
+		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile:       packageScope,
 			funcDecl.Body: functionScope,
 			ifBody:        blockScope,
@@ -135,16 +135,16 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		pkg := types.NewPackage("main", "main")
-		packageScope := types.NewScope(types.Universe, token.NoPos, token.NoPos, "package")
-		functionScope := types.NewScope(packageScope, token.NoPos, token.NoPos, "function")
+		pkg := gotypes.NewPackage("main", "main")
+		packageScope := gotypes.NewScope(gotypes.Universe, token.NoPos, token.NoPos, "package")
+		functionScope := gotypes.NewScope(packageScope, token.NoPos, token.NoPos, "function")
 
-		paramVar := types.NewVar(token.NoPos, pkg, "param", types.Typ[types.Int])
+		paramVar := gotypes.NewVar(token.NoPos, pkg, "param", gotypes.Typ[gotypes.Int])
 		functionScope.Insert(paramVar)
 
 		funcDecl := astFile.Decls[0].(*ast.FuncDecl)
 		typeInfo := newTestTypeInfo(nil, nil)
-		typeInfo.Scopes = map[ast.Node]*types.Scope{
+		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile:       packageScope,
 			funcDecl.Type: functionScope, // Scope for function parameters.
 		}
@@ -160,11 +160,11 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		pkg := types.NewPackage("main", "main")
-		packageScope := types.NewScope(types.Universe, token.NoPos, token.NoPos, "package")
-		functionScope := types.NewScope(packageScope, token.NoPos, token.NoPos, "function")
+		pkg := gotypes.NewPackage("main", "main")
+		packageScope := gotypes.NewScope(gotypes.Universe, token.NoPos, token.NoPos, "package")
+		functionScope := gotypes.NewScope(packageScope, token.NoPos, token.NoPos, "function")
 
-		paramVar := types.NewVar(token.NoPos, pkg, "param", types.Typ[types.String])
+		paramVar := gotypes.NewVar(token.NoPos, pkg, "param", gotypes.Typ[gotypes.String])
 		functionScope.Insert(paramVar)
 
 		// Extract the function literal from the variable declaration.
@@ -173,7 +173,7 @@ func TestInnermostScopeAt(t *testing.T) {
 		funcLit := valueSpec.Values[0].(*ast.FuncLit)
 
 		typeInfo := newTestTypeInfo(nil, nil)
-		typeInfo.Scopes = map[ast.Node]*types.Scope{
+		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile:      packageScope,
 			funcLit.Type: functionScope, // Scope from FuncType for parameters.
 		}
@@ -189,11 +189,11 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		pkg := types.NewPackage("main", "main")
-		packageScope := types.NewScope(types.Universe, token.NoPos, token.NoPos, "package")
-		functionScope := types.NewScope(packageScope, token.NoPos, token.NoPos, "function")
+		pkg := gotypes.NewPackage("main", "main")
+		packageScope := gotypes.NewScope(gotypes.Universe, token.NoPos, token.NoPos, "package")
+		functionScope := gotypes.NewScope(packageScope, token.NoPos, token.NoPos, "function")
 
-		localVar := types.NewVar(token.NoPos, pkg, "local", types.Typ[types.Int])
+		localVar := gotypes.NewVar(token.NoPos, pkg, "local", gotypes.Typ[gotypes.Int])
 		functionScope.Insert(localVar)
 
 		// Extract the function literal from the variable declaration.
@@ -202,7 +202,7 @@ func TestInnermostScopeAt(t *testing.T) {
 		funcLit := valueSpec.Values[0].(*ast.FuncLit)
 
 		typeInfo := newTestTypeInfo(nil, nil)
-		typeInfo.Scopes = map[ast.Node]*types.Scope{
+		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile:      packageScope,
 			funcLit.Body: functionScope, // Scope from Body for local variables.
 		}
@@ -213,6 +213,41 @@ func TestInnermostScopeAt(t *testing.T) {
 		require.NotNil(t, scope)
 
 		assert.NotNil(t, scope.Lookup("local"))
+	})
+
+	t.Run("FuncLitFallbackToBodyScope", func(t *testing.T) {
+		fset, astFile, err := newTestFile("main.xgo", "var f = func() { local := 42; println(local) }")
+		require.NoError(t, err)
+		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
+
+		pkg := gotypes.NewPackage("main", "main")
+		packageScope := gotypes.NewScope(gotypes.Universe, token.NoPos, token.NoPos, "package")
+		functionScope := gotypes.NewScope(packageScope, token.NoPos, token.NoPos, "function")
+		functionScope.Insert(gotypes.NewVar(token.NoPos, pkg, "local", gotypes.Typ[gotypes.Int]))
+
+		genDecl := astFile.Decls[0].(*ast.GenDecl)
+		valueSpec := genDecl.Specs[0].(*ast.ValueSpec)
+		funcLit := valueSpec.Values[0].(*ast.FuncLit)
+
+		typeInfo := newTestTypeInfo(nil, nil)
+		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
+			astFile:      packageScope,
+			funcLit.Body: functionScope,
+		}
+
+		scope := InnermostScopeAt(fset, typeInfo, astPkg, funcLit.Pos())
+		require.NotNil(t, scope)
+		assert.NotNil(t, scope.Lookup("local"))
+	})
+
+	t.Run("PositionOutsidePackage", func(t *testing.T) {
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
+		require.NoError(t, err)
+		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
+		typeInfo := newTestTypeInfo(nil, nil)
+
+		scope := InnermostScopeAt(fset, typeInfo, astPkg, astFile.End()+10)
+		assert.Nil(t, scope)
 	})
 
 	t.Run("NilPackage", func(t *testing.T) {

--- a/xgo/xgoutil/struct.go
+++ b/xgo/xgoutil/struct.go
@@ -16,19 +16,19 @@
 
 package xgoutil
 
-import "go/types"
+import gotypes "go/types"
 
 // IsNamedStructType reports whether the given named type is a struct type.
-func IsNamedStructType(named *types.Named) bool {
+func IsNamedStructType(named *gotypes.Named) bool {
 	if named == nil {
 		return false
 	}
-	_, ok := named.Underlying().(*types.Struct)
+	_, ok := named.Underlying().(*gotypes.Struct)
 	return ok
 }
 
 // IsXGoClassStructType reports whether the given named type is an XGo class struct type.
-func IsXGoClassStructType(named *types.Named) bool {
+func IsXGoClassStructType(named *gotypes.Named) bool {
 	if named == nil {
 		return false
 	}
@@ -54,20 +54,20 @@ func IsXGoClassStructType(named *types.Named) bool {
 
 // WalkStruct walks a struct and calls the given onMember for each field and
 // method. If onMember returns false, the walk is stopped.
-func WalkStruct(named *types.Named, onMember func(member types.Object, selector *types.Named) bool) {
+func WalkStruct(named *gotypes.Named, onMember func(member gotypes.Object, selector *gotypes.Named) bool) {
 	if named == nil {
 		return
 	}
-	walked := make(map[*types.Named]struct{})
+	walked := make(map[*gotypes.Named]struct{})
 	seenMembers := make(map[string]struct{})
-	var walk func(named *types.Named, namedPath []*types.Named) bool
-	walk = func(named *types.Named, namedPath []*types.Named) bool {
+	var walk func(named *gotypes.Named, namedPath []*gotypes.Named) bool
+	walk = func(named *gotypes.Named, namedPath []*gotypes.Named) bool {
 		if _, ok := walked[named]; ok {
 			return true
 		}
 		walked[named] = struct{}{}
 
-		st, ok := named.Underlying().(*types.Struct)
+		st, ok := named.Underlying().(*gotypes.Struct)
 		if !ok {
 			return true
 		}
@@ -108,7 +108,7 @@ func WalkStruct(named *types.Named, onMember func(member types.Object, selector 
 				continue
 			}
 			fieldType := DerefType(field.Type())
-			namedField, ok := fieldType.(*types.Named)
+			namedField, ok := fieldType.(*gotypes.Named)
 			if !ok || !IsNamedStructType(namedField) {
 				continue
 			}
@@ -119,5 +119,5 @@ func WalkStruct(named *types.Named, onMember func(member types.Object, selector 
 		}
 		return true
 	}
-	walk(named, []*types.Named{named})
+	walk(named, []*gotypes.Named{named})
 }

--- a/xgo/xgoutil/struct_test.go
+++ b/xgo/xgoutil/struct_test.go
@@ -17,10 +17,10 @@
 package xgoutil
 
 import (
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
+	"github.com/goplus/xgo/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,144 +29,144 @@ const spxPkgPath = "github.com/goplus/spx/v2"
 
 func TestIsNamedStructType(t *testing.T) {
 	t.Run("NilNamedType", func(t *testing.T) {
-		var named *types.Named
+		var named *gotypes.Named
 		assert.False(t, IsNamedStructType(named))
 	})
 
 	t.Run("StructType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		structType := types.NewStruct([]*types.Var{
-			types.NewField(token.NoPos, pkg, "field1", types.Typ[types.String], false),
-			types.NewField(token.NoPos, pkg, "field2", types.Typ[types.Int], false),
+		pkg := gotypes.NewPackage("test", "test")
+		structType := gotypes.NewStruct([]*gotypes.Var{
+			gotypes.NewField(token.NoPos, pkg, "field1", gotypes.Typ[gotypes.String], false),
+			gotypes.NewField(token.NoPos, pkg, "field2", gotypes.Typ[gotypes.Int], false),
 		}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.True(t, IsNamedStructType(named))
 	})
 
 	t.Run("EmptyStructType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "EmptyStruct", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "EmptyStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.True(t, IsNamedStructType(named))
 	})
 
 	t.Run("InterfaceType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		interfaceType := types.NewInterfaceType([]*types.Func{}, []types.Type{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestInterface", interfaceType)
-		named := types.NewNamed(typeName, interfaceType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		interfaceType := gotypes.NewInterfaceType([]*gotypes.Func{}, []gotypes.Type{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestInterface", interfaceType)
+		named := gotypes.NewNamed(typeName, interfaceType, nil)
 		assert.False(t, IsNamedStructType(named))
 	})
 
 	t.Run("BasicType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestInt", types.Typ[types.Int])
-		named := types.NewNamed(typeName, types.Typ[types.Int], nil)
+		pkg := gotypes.NewPackage("test", "test")
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestInt", gotypes.Typ[gotypes.Int])
+		named := gotypes.NewNamed(typeName, gotypes.Typ[gotypes.Int], nil)
 		assert.False(t, IsNamedStructType(named))
 	})
 
 	t.Run("SliceType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		sliceType := types.NewSlice(types.Typ[types.String])
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestSlice", sliceType)
-		named := types.NewNamed(typeName, sliceType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		sliceType := gotypes.NewSlice(gotypes.Typ[gotypes.String])
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestSlice", sliceType)
+		named := gotypes.NewNamed(typeName, sliceType, nil)
 		assert.False(t, IsNamedStructType(named))
 	})
 
 	t.Run("PointerType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		pointerType := types.NewPointer(types.Typ[types.Int])
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestPointer", pointerType)
-		named := types.NewNamed(typeName, pointerType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		pointerType := gotypes.NewPointer(gotypes.Typ[gotypes.Int])
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestPointer", pointerType)
+		named := gotypes.NewNamed(typeName, pointerType, nil)
 		assert.False(t, IsNamedStructType(named))
 	})
 
 	t.Run("FunctionType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		signature := types.NewSignatureType(nil, nil, nil,
-			types.NewTuple(types.NewParam(token.NoPos, pkg, "x", types.Typ[types.Int])),
-			types.NewTuple(types.NewParam(token.NoPos, pkg, "", types.Typ[types.String])),
+		pkg := gotypes.NewPackage("test", "test")
+		signature := gotypes.NewSignatureType(nil, nil, nil,
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int])),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", gotypes.Typ[gotypes.String])),
 			false)
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestFunc", signature)
-		named := types.NewNamed(typeName, signature, nil)
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestFunc", signature)
+		named := gotypes.NewNamed(typeName, signature, nil)
 		assert.False(t, IsNamedStructType(named))
 	})
 }
 
 func TestIsXGoClassStructType(t *testing.T) {
 	t.Run("NilNamedType", func(t *testing.T) {
-		var named *types.Named
+		var named *gotypes.Named
 		assert.False(t, IsXGoClassStructType(named))
 	})
 
 	t.Run("NamedTypeWithNilObject", func(t *testing.T) {
-		named := &types.Named{}
+		named := &gotypes.Named{}
 		assert.False(t, IsXGoClassStructType(named))
 	})
 
 	t.Run("NonXGoPackage", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "Game", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "Game", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.False(t, IsXGoClassStructType(named))
 	})
 
 	t.Run("XGoPackageWithNonClassType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 
 		// Mark package as XGo package.
 		markAsXGoPackage(pkg)
 
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "SomeOtherType", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "SomeOtherType", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.False(t, IsXGoClassStructType(named))
 	})
 
 	t.Run("SpxGameType", func(t *testing.T) {
-		pkg := types.NewPackage(spxPkgPath, "spx")
+		pkg := gotypes.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
 		markAsXGoPackage(pkg)
 
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "Game", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "Game", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.True(t, IsXGoClassStructType(named))
 	})
 
 	t.Run("SpxSpriteImplType", func(t *testing.T) {
-		pkg := types.NewPackage(spxPkgPath, "spx")
+		pkg := gotypes.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
 		markAsXGoPackage(pkg)
 
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "SpriteImpl", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "SpriteImpl", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.True(t, IsXGoClassStructType(named))
 	})
 
 	t.Run("SpxGameTypeInNonXGoPackage", func(t *testing.T) {
-		pkg := types.NewPackage(spxPkgPath, "spx")
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "Game", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage(spxPkgPath, "spx")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "Game", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.False(t, IsXGoClassStructType(named))
 	})
 
 	t.Run("XGoPackageWithDifferentSpxType", func(t *testing.T) {
-		pkg := types.NewPackage(spxPkgPath, "spx")
+		pkg := gotypes.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
 		markAsXGoPackage(pkg)
 
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "Sprite", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "Sprite", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 		assert.False(t, IsXGoClassStructType(named))
 	})
 }
@@ -174,10 +174,10 @@ func TestIsXGoClassStructType(t *testing.T) {
 func TestWalkStruct(t *testing.T) {
 	t.Run("NilNamedType", func(t *testing.T) {
 		var (
-			named  *types.Named
+			named  *gotypes.Named
 			called bool
 		)
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			called = true
 			return true
 		})
@@ -185,12 +185,12 @@ func TestWalkStruct(t *testing.T) {
 	})
 
 	t.Run("NonStructType", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestInt", types.Typ[types.Int])
-		named := types.NewNamed(typeName, types.Typ[types.Int], nil)
+		pkg := gotypes.NewPackage("test", "test")
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestInt", gotypes.Typ[gotypes.Int])
+		named := gotypes.NewNamed(typeName, gotypes.Typ[gotypes.Int], nil)
 
 		var called bool
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			called = true
 			return true
 		})
@@ -198,13 +198,13 @@ func TestWalkStruct(t *testing.T) {
 	})
 
 	t.Run("EmptyStruct", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "EmptyStruct", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "EmptyStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 
 		var called bool
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			called = true
 			return true
 		})
@@ -212,18 +212,18 @@ func TestWalkStruct(t *testing.T) {
 	})
 
 	t.Run("SimpleStructWithFields", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		field1 := types.NewField(token.NoPos, pkg, "Field1", types.Typ[types.String], false)
-		field2 := types.NewField(token.NoPos, pkg, "Field2", types.Typ[types.Int], false)
-		structType := types.NewStruct([]*types.Var{field1, field2}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		field1 := gotypes.NewField(token.NoPos, pkg, "Field1", gotypes.Typ[gotypes.String], false)
+		field2 := gotypes.NewField(token.NoPos, pkg, "Field2", gotypes.Typ[gotypes.Int], false)
+		structType := gotypes.NewStruct([]*gotypes.Var{field1, field2}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 
 		var (
-			members   []types.Object
-			selectors []*types.Named
+			members   []gotypes.Object
+			selectors []*gotypes.Named
 		)
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			members = append(members, member)
 			selectors = append(selectors, selector)
 			return true
@@ -236,45 +236,85 @@ func TestWalkStruct(t *testing.T) {
 	})
 
 	t.Run("StructWithMethods", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 
 		// Add a method to the named type.
-		signature := types.NewSignatureType(nil, nil, nil,
-			types.NewTuple(),
-			types.NewTuple(types.NewParam(token.NoPos, pkg, "", types.Typ[types.String])),
+		signature := gotypes.NewSignatureType(nil, nil, nil,
+			gotypes.NewTuple(),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", gotypes.Typ[gotypes.String])),
 			false)
-		method := types.NewFunc(token.NoPos, pkg, "Method1", signature)
+		method := gotypes.NewFunc(token.NoPos, pkg, "Method1", signature)
 		named.AddMethod(method)
 
-		var members []types.Object
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		var members []gotypes.Object
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			members = append(members, member)
 			return true
 		})
 		require.Len(t, members, 1)
 		assert.Equal(t, "Method1", members[0].Name())
 	})
+
+	t.Run("MethodEarlyTermination", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
+
+		signature := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "Method1", signature))
+		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "Method2", signature))
+
+		var members []gotypes.Object
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
+			members = append(members, member)
+			return false
+		})
+
+		require.Len(t, members, 1)
+		assert.Equal(t, "Method1", members[0].Name())
+	})
+
+	t.Run("UnexportedMethodSkipped", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
+
+		signature := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "ExportedMethod", signature))
+		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "unexportedMethod", signature))
+
+		var members []gotypes.Object
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
+			members = append(members, member)
+			return true
+		})
+
+		require.Len(t, members, 1)
+		assert.Equal(t, "ExportedMethod", members[0].Name())
+	})
 	t.Run("StructWithEmbeddedStruct", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 
 		// Create embedded struct.
-		embeddedField := types.NewField(token.NoPos, pkg, "EmbeddedField", types.Typ[types.String], false)
-		embeddedStructType := types.NewStruct([]*types.Var{embeddedField}, []string{})
-		embeddedTypeName := types.NewTypeName(token.NoPos, pkg, "EmbeddedStruct", embeddedStructType)
-		embeddedNamed := types.NewNamed(embeddedTypeName, embeddedStructType, nil)
+		embeddedField := gotypes.NewField(token.NoPos, pkg, "EmbeddedField", gotypes.Typ[gotypes.String], false)
+		embeddedStructType := gotypes.NewStruct([]*gotypes.Var{embeddedField}, []string{})
+		embeddedTypeName := gotypes.NewTypeName(token.NoPos, pkg, "EmbeddedStruct", embeddedStructType)
+		embeddedNamed := gotypes.NewNamed(embeddedTypeName, embeddedStructType, nil)
 
 		// Create main struct with embedded field.
-		mainField := types.NewField(token.NoPos, pkg, "MainField", types.Typ[types.Int], false)
-		embeddedFieldVar := types.NewField(token.NoPos, pkg, "EmbeddedStruct", embeddedNamed, true) // embedded
-		mainStructType := types.NewStruct([]*types.Var{mainField, embeddedFieldVar}, []string{})
-		mainTypeName := types.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
-		mainNamed := types.NewNamed(mainTypeName, mainStructType, nil)
+		mainField := gotypes.NewField(token.NoPos, pkg, "MainField", gotypes.Typ[gotypes.Int], false)
+		embeddedFieldVar := gotypes.NewField(token.NoPos, pkg, "EmbeddedStruct", embeddedNamed, true) // embedded
+		mainStructType := gotypes.NewStruct([]*gotypes.Var{mainField, embeddedFieldVar}, []string{})
+		mainTypeName := gotypes.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
+		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
-		var members []types.Object
-		WalkStruct(mainNamed, func(member types.Object, selector *types.Named) bool {
+		var members []gotypes.Object
+		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
 			members = append(members, member)
 			return true
 		})
@@ -289,15 +329,15 @@ func TestWalkStruct(t *testing.T) {
 	})
 
 	t.Run("EarlyTermination", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		field1 := types.NewField(token.NoPos, pkg, "Field1", types.Typ[types.String], false)
-		field2 := types.NewField(token.NoPos, pkg, "Field2", types.Typ[types.Int], false)
-		structType := types.NewStruct([]*types.Var{field1, field2}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		field1 := gotypes.NewField(token.NoPos, pkg, "Field1", gotypes.Typ[gotypes.String], false)
+		field2 := gotypes.NewField(token.NoPos, pkg, "Field2", gotypes.Typ[gotypes.Int], false)
+		structType := gotypes.NewStruct([]*gotypes.Var{field1, field2}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 
-		var members []types.Object
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		var members []gotypes.Object
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			members = append(members, member)
 			return len(members) < 1 // Stop after first member.
 		})
@@ -306,30 +346,30 @@ func TestWalkStruct(t *testing.T) {
 	})
 
 	t.Run("CircularReferenceAvoidance", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 
 		// Create type names first.
-		typeNameA := types.NewTypeName(token.NoPos, pkg, "StructA", nil)
-		typeNameB := types.NewTypeName(token.NoPos, pkg, "StructB", nil)
+		typeNameA := gotypes.NewTypeName(token.NoPos, pkg, "StructA", nil)
+		typeNameB := gotypes.NewTypeName(token.NoPos, pkg, "StructB", nil)
 
 		// Create placeholder named types.
-		namedA := types.NewNamed(typeNameA, nil, nil)
-		namedB := types.NewNamed(typeNameB, nil, nil)
+		namedA := gotypes.NewNamed(typeNameA, nil, nil)
+		namedB := gotypes.NewNamed(typeNameB, nil, nil)
 
 		// Create fields that reference each other.
-		fieldAToB := types.NewField(token.NoPos, pkg, "StructB", namedB, true)
-		fieldBToA := types.NewField(token.NoPos, pkg, "StructA", namedA, true)
+		fieldAToB := gotypes.NewField(token.NoPos, pkg, "StructB", namedB, true)
+		fieldBToA := gotypes.NewField(token.NoPos, pkg, "StructA", namedA, true)
 
 		// Create struct types with circular references.
-		structATypeWithB := types.NewStruct([]*types.Var{fieldAToB}, []string{})
-		structBTypeWithA := types.NewStruct([]*types.Var{fieldBToA}, []string{})
+		structATypeWithB := gotypes.NewStruct([]*gotypes.Var{fieldAToB}, []string{})
+		structBTypeWithA := gotypes.NewStruct([]*gotypes.Var{fieldBToA}, []string{})
 
 		// Set the underlying types.
 		namedA.SetUnderlying(structATypeWithB)
 		namedB.SetUnderlying(structBTypeWithA)
 
 		var callCount int
-		WalkStruct(namedA, func(member types.Object, selector *types.Named) bool {
+		WalkStruct(namedA, func(member gotypes.Object, selector *gotypes.Named) bool {
 			callCount++
 			return true
 		})
@@ -337,15 +377,15 @@ func TestWalkStruct(t *testing.T) {
 	})
 
 	t.Run("UnexportedFieldsAndMethods", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
-		exportedField := types.NewField(token.NoPos, pkg, "ExportedField", types.Typ[types.String], false)
-		unexportedField := types.NewField(token.NoPos, pkg, "unexportedField", types.Typ[types.Int], false)
-		structType := types.NewStruct([]*types.Var{exportedField, unexportedField}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		pkg := gotypes.NewPackage("test", "test")
+		exportedField := gotypes.NewField(token.NoPos, pkg, "ExportedField", gotypes.Typ[gotypes.String], false)
+		unexportedField := gotypes.NewField(token.NoPos, pkg, "unexportedField", gotypes.Typ[gotypes.Int], false)
+		structType := gotypes.NewStruct([]*gotypes.Var{exportedField, unexportedField}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 
-		var members []types.Object
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		var members []gotypes.Object
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			members = append(members, member)
 			return true
 		})
@@ -355,23 +395,23 @@ func TestWalkStruct(t *testing.T) {
 		assert.Equal(t, "ExportedField", members[0].Name())
 	})
 	t.Run("DuplicateMemberNames", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 
 		// Create embedded struct with a field.
-		embeddedField := types.NewField(token.NoPos, pkg, "SameName", types.Typ[types.String], false)
-		embeddedStructType := types.NewStruct([]*types.Var{embeddedField}, []string{})
-		embeddedTypeName := types.NewTypeName(token.NoPos, pkg, "EmbeddedStruct", embeddedStructType)
-		embeddedNamed := types.NewNamed(embeddedTypeName, embeddedStructType, nil)
+		embeddedField := gotypes.NewField(token.NoPos, pkg, "SameName", gotypes.Typ[gotypes.String], false)
+		embeddedStructType := gotypes.NewStruct([]*gotypes.Var{embeddedField}, []string{})
+		embeddedTypeName := gotypes.NewTypeName(token.NoPos, pkg, "EmbeddedStruct", embeddedStructType)
+		embeddedNamed := gotypes.NewNamed(embeddedTypeName, embeddedStructType, nil)
 
 		// Create main struct with same field name.
-		mainField := types.NewField(token.NoPos, pkg, "SameName", types.Typ[types.Int], false)
-		embeddedFieldVar := types.NewField(token.NoPos, pkg, "EmbeddedStruct", embeddedNamed, true)
-		mainStructType := types.NewStruct([]*types.Var{mainField, embeddedFieldVar}, []string{})
-		mainTypeName := types.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
-		mainNamed := types.NewNamed(mainTypeName, mainStructType, nil)
+		mainField := gotypes.NewField(token.NoPos, pkg, "SameName", gotypes.Typ[gotypes.Int], false)
+		embeddedFieldVar := gotypes.NewField(token.NoPos, pkg, "EmbeddedStruct", embeddedNamed, true)
+		mainStructType := gotypes.NewStruct([]*gotypes.Var{mainField, embeddedFieldVar}, []string{})
+		mainTypeName := gotypes.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
+		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
-		var members []types.Object
-		WalkStruct(mainNamed, func(member types.Object, selector *types.Named) bool {
+		var members []gotypes.Object
+		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
 			members = append(members, member)
 			return true
 		})
@@ -379,7 +419,7 @@ func TestWalkStruct(t *testing.T) {
 		// Should see SameName (first occurrence) and EmbeddedStruct, but not the duplicate SameName.
 		require.Len(t, members, 2)
 		memberNames := make([]string, len(members))
-		memberTypes := make([]types.Type, len(members))
+		memberTypes := make([]gotypes.Type, len(members))
 		for i, member := range members {
 			memberNames[i] = member.Name()
 			memberTypes[i] = member.Type()
@@ -395,23 +435,44 @@ func TestWalkStruct(t *testing.T) {
 			}
 		}
 		assert.NotEqual(t, -1, sameNameIndex)
-		assert.Equal(t, types.Typ[types.Int], memberTypes[sameNameIndex])
+		assert.Equal(t, gotypes.Typ[gotypes.Int], memberTypes[sameNameIndex])
+	})
+
+	t.Run("FieldAndMethodWithSameName", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		field := gotypes.NewField(token.NoPos, pkg, "SameName", gotypes.Typ[gotypes.Int], false)
+		structType := gotypes.NewStruct([]*gotypes.Var{field}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "TestStruct", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
+
+		signature := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "SameName", signature))
+
+		var members []gotypes.Object
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
+			members = append(members, member)
+			return true
+		})
+
+		require.Len(t, members, 1)
+		assert.Equal(t, "SameName", members[0].Name())
+		assert.Equal(t, gotypes.Typ[gotypes.Int], members[0].Type())
 	})
 
 	t.Run("XGoClassStructSelector", func(t *testing.T) {
-		pkg := types.NewPackage(spxPkgPath, "spx")
+		pkg := gotypes.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
 		markAsXGoPackage(pkg)
 
 		// Create XGo class struct.
-		field := types.NewField(token.NoPos, pkg, "TestField", types.Typ[types.String], false)
-		structType := types.NewStruct([]*types.Var{field}, []string{})
-		typeName := types.NewTypeName(token.NoPos, pkg, "Game", structType)
-		named := types.NewNamed(typeName, structType, nil)
+		field := gotypes.NewField(token.NoPos, pkg, "TestField", gotypes.Typ[gotypes.String], false)
+		structType := gotypes.NewStruct([]*gotypes.Var{field}, []string{})
+		typeName := gotypes.NewTypeName(token.NoPos, pkg, "Game", structType)
+		named := gotypes.NewNamed(typeName, structType, nil)
 
-		var selectors []*types.Named
-		WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+		var selectors []*gotypes.Named
+		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 			selectors = append(selectors, selector)
 			return true
 		})
@@ -419,24 +480,24 @@ func TestWalkStruct(t *testing.T) {
 		assert.Equal(t, named, selectors[0])
 	})
 	t.Run("EmbeddedPointerStruct", func(t *testing.T) {
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 
 		// Create embedded struct.
-		embeddedField := types.NewField(token.NoPos, pkg, "EmbeddedField", types.Typ[types.String], false)
-		embeddedStructType := types.NewStruct([]*types.Var{embeddedField}, []string{})
-		embeddedTypeName := types.NewTypeName(token.NoPos, pkg, "EmbeddedStruct", embeddedStructType)
-		embeddedNamed := types.NewNamed(embeddedTypeName, embeddedStructType, nil)
+		embeddedField := gotypes.NewField(token.NoPos, pkg, "EmbeddedField", gotypes.Typ[gotypes.String], false)
+		embeddedStructType := gotypes.NewStruct([]*gotypes.Var{embeddedField}, []string{})
+		embeddedTypeName := gotypes.NewTypeName(token.NoPos, pkg, "EmbeddedStruct", embeddedStructType)
+		embeddedNamed := gotypes.NewNamed(embeddedTypeName, embeddedStructType, nil)
 
 		// Create main struct with embedded pointer field.
-		mainField := types.NewField(token.NoPos, pkg, "MainField", types.Typ[types.Int], false)
-		embeddedPointerType := types.NewPointer(embeddedNamed)
-		embeddedFieldVar := types.NewField(token.NoPos, pkg, "EmbeddedStruct", embeddedPointerType, true)
-		mainStructType := types.NewStruct([]*types.Var{mainField, embeddedFieldVar}, []string{})
-		mainTypeName := types.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
-		mainNamed := types.NewNamed(mainTypeName, mainStructType, nil)
+		mainField := gotypes.NewField(token.NoPos, pkg, "MainField", gotypes.Typ[gotypes.Int], false)
+		embeddedPointerType := gotypes.NewPointer(embeddedNamed)
+		embeddedFieldVar := gotypes.NewField(token.NoPos, pkg, "EmbeddedStruct", embeddedPointerType, true)
+		mainStructType := gotypes.NewStruct([]*gotypes.Var{mainField, embeddedFieldVar}, []string{})
+		mainTypeName := gotypes.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
+		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
-		var members []types.Object
-		WalkStruct(mainNamed, func(member types.Object, selector *types.Named) bool {
+		var members []gotypes.Object
+		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
 			members = append(members, member)
 			return true
 		})
@@ -448,5 +509,76 @@ func TestWalkStruct(t *testing.T) {
 		assert.Contains(t, memberNames, "MainField")
 		assert.Contains(t, memberNames, "EmbeddedStruct")
 		assert.Contains(t, memberNames, "EmbeddedField")
+	})
+
+	t.Run("SelectorStopsAtUnexportedEmbeddedType", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+
+		innerField := gotypes.NewField(token.NoPos, pkg, "ExportedField", gotypes.Typ[gotypes.String], false)
+		innerStructType := gotypes.NewStruct([]*gotypes.Var{innerField}, []string{})
+		innerTypeName := gotypes.NewTypeName(token.NoPos, pkg, "embeddedStruct", innerStructType)
+		innerNamed := gotypes.NewNamed(innerTypeName, innerStructType, nil)
+
+		embeddedFieldVar := gotypes.NewField(token.NoPos, pkg, "embeddedStruct", innerNamed, true)
+		mainStructType := gotypes.NewStruct([]*gotypes.Var{embeddedFieldVar}, []string{})
+		mainTypeName := gotypes.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
+		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
+
+		var selectorForInnerField *gotypes.Named
+		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
+			if member.Name() == "ExportedField" {
+				selectorForInnerField = selector
+			}
+			return true
+		})
+
+		require.NotNil(t, selectorForInnerField)
+		assert.Equal(t, mainNamed, selectorForInnerField)
+	})
+
+	t.Run("EmbeddedNamedNonStructIsIgnored", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+
+		namedInt := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "EmbeddedInt", gotypes.Typ[gotypes.Int]),
+			gotypes.Typ[gotypes.Int],
+			nil,
+		)
+		embeddedFieldVar := gotypes.NewField(token.NoPos, pkg, "EmbeddedInt", namedInt, true)
+		mainStructType := gotypes.NewStruct([]*gotypes.Var{embeddedFieldVar}, []string{})
+		mainTypeName := gotypes.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
+		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
+
+		var members []gotypes.Object
+		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
+			members = append(members, member)
+			return true
+		})
+
+		require.Len(t, members, 1)
+		assert.Equal(t, "EmbeddedInt", members[0].Name())
+	})
+
+	t.Run("EmbeddedWalkEarlyTermination", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+
+		embeddedField := gotypes.NewField(token.NoPos, pkg, "EmbeddedField", gotypes.Typ[gotypes.String], false)
+		embeddedStructType := gotypes.NewStruct([]*gotypes.Var{embeddedField}, []string{})
+		embeddedTypeName := gotypes.NewTypeName(token.NoPos, pkg, "EmbeddedStruct", embeddedStructType)
+		embeddedNamed := gotypes.NewNamed(embeddedTypeName, embeddedStructType, nil)
+
+		mainField := gotypes.NewField(token.NoPos, pkg, "MainField", gotypes.Typ[gotypes.Int], false)
+		embeddedFieldVar := gotypes.NewField(token.NoPos, pkg, "EmbeddedStruct", embeddedNamed, true)
+		mainStructType := gotypes.NewStruct([]*gotypes.Var{mainField, embeddedFieldVar}, []string{})
+		mainTypeName := gotypes.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
+		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
+
+		var members []string
+		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
+			members = append(members, member.Name())
+			return member.Name() != "EmbeddedField"
+		})
+
+		assert.Equal(t, []string{"MainField", "EmbeddedStruct", "EmbeddedField"}, members)
 	})
 }

--- a/xgo/xgoutil/type.go
+++ b/xgo/xgoutil/type.go
@@ -16,50 +16,50 @@
 
 package xgoutil
 
-import "go/types"
+import gotypes "go/types"
 
 // DerefType returns the underlying type of t. For pointer types, it returns
 // the element type that the pointer points to. For non-pointer types, it
 // returns the type unchanged.
-func DerefType(t types.Type) types.Type {
-	if ptr, ok := t.(*types.Pointer); ok {
+func DerefType(t gotypes.Type) gotypes.Type {
+	if ptr, ok := t.(*gotypes.Pointer); ok {
 		return ptr.Elem()
 	}
 	return t
 }
 
 // IsValidType reports whether typ is non-nil and not the invalid type sentinel.
-func IsValidType(typ types.Type) bool {
-	return typ != nil && typ != types.Typ[types.Invalid]
+func IsValidType(typ gotypes.Type) bool {
+	return typ != nil && typ != gotypes.Typ[gotypes.Invalid]
 }
 
 // IsTypesCompatible reports whether two types are compatible.
-func IsTypesCompatible(got, want types.Type) bool {
+func IsTypesCompatible(got, want gotypes.Type) bool {
 	if got == nil || want == nil {
 		return false
 	}
 
-	if types.AssignableTo(got, want) {
+	if gotypes.AssignableTo(got, want) {
 		return true
 	}
 
 	switch want := want.(type) {
-	case *types.Interface:
-		return types.Implements(got, want)
-	case *types.Pointer:
-		if gotPtr, ok := got.(*types.Pointer); ok {
-			return types.Identical(want.Elem(), gotPtr.Elem())
+	case *gotypes.Interface:
+		return gotypes.Implements(got, want)
+	case *gotypes.Pointer:
+		if gotPtr, ok := got.(*gotypes.Pointer); ok {
+			return gotypes.Identical(want.Elem(), gotPtr.Elem())
 		}
-		return types.Identical(got, want.Elem())
-	case *types.Slice:
-		gotSlice, ok := got.(*types.Slice)
-		return ok && types.Identical(want.Elem(), gotSlice.Elem())
-	case *types.Chan:
-		gotCh, ok := got.(*types.Chan)
-		return ok && types.Identical(want.Elem(), gotCh.Elem()) &&
-			(want.Dir() == types.SendRecv || want.Dir() == gotCh.Dir())
-	case *types.Signature:
-		gotSig, ok := got.(*types.Signature)
+		return gotypes.Identical(got, want.Elem())
+	case *gotypes.Slice:
+		gotSlice, ok := got.(*gotypes.Slice)
+		return ok && gotypes.Identical(want.Elem(), gotSlice.Elem())
+	case *gotypes.Chan:
+		gotCh, ok := got.(*gotypes.Chan)
+		return ok && gotypes.Identical(want.Elem(), gotCh.Elem()) &&
+			(want.Dir() == gotypes.SendRecv || want.Dir() == gotCh.Dir())
+	case *gotypes.Signature:
+		gotSig, ok := got.(*gotypes.Signature)
 		if !ok {
 			return false
 		}
@@ -72,51 +72,39 @@ func IsTypesCompatible(got, want types.Type) bool {
 		return IsTypesCompatible(gotSig.Results().At(0).Type(), want.Results().At(0).Type())
 	}
 
-	if gotSig, ok := got.(*types.Signature); ok {
+	if gotSig, ok := got.(*gotypes.Signature); ok {
 		if gotSig.Results().Len() != 1 {
 			return false
 		}
 		return IsTypesCompatible(gotSig.Results().At(0).Type(), want)
 	}
 
-	if _, ok := got.(*types.Named); ok {
-		return types.Identical(got, want)
+	if _, ok := got.(*gotypes.Named); ok {
+		return gotypes.Identical(got, want)
 	}
 
 	return false
 }
 
 // IsTypesConvertible reports whether a type can be explicitly converted to another.
-func IsTypesConvertible(from, to types.Type) bool {
+func IsTypesConvertible(from, to gotypes.Type) bool {
 	if from == nil || to == nil {
 		return false
 	}
 
-	if !types.ConvertibleTo(from, to) {
+	if !gotypes.ConvertibleTo(from, to) {
 		return false
 	}
 
 	fromUnderlying := from.Underlying()
 	toUnderlying := to.Underlying()
 
-	fromBasic, fromIsBasic := fromUnderlying.(*types.Basic)
-	toBasic, toIsBasic := toUnderlying.(*types.Basic)
+	fromBasic, fromIsBasic := fromUnderlying.(*gotypes.Basic)
+	toBasic, toIsBasic := toUnderlying.(*gotypes.Basic)
 
 	if fromIsBasic && toIsBasic {
 		// Exclude numeric to string conversions.
-		if (fromBasic.Info()&types.IsNumeric) != 0 && toBasic.Kind() == types.String {
-			return false
-		}
-		// Exclude string to numeric conversions.
-		if fromBasic.Kind() == types.String && (toBasic.Info()&types.IsNumeric) != 0 {
-			return false
-		}
-		// Exclude bool to numeric or string conversions.
-		if fromBasic.Kind() == types.Bool && toBasic.Kind() != types.Bool {
-			return false
-		}
-		// Exclude numeric or string to bool conversions.
-		if fromBasic.Kind() != types.Bool && toBasic.Kind() == types.Bool {
+		if (fromBasic.Info()&gotypes.IsNumeric) != 0 && toBasic.Kind() == gotypes.String {
 			return false
 		}
 	}

--- a/xgo/xgoutil/type_test.go
+++ b/xgo/xgoutil/type_test.go
@@ -17,7 +17,7 @@
 package xgoutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,42 +25,42 @@ import (
 
 func TestDerefType(t *testing.T) {
 	t.Run("PointerTypes", func(t *testing.T) {
-		intPtr := types.NewPointer(types.Typ[types.Int])
-		assert.Equal(t, types.Typ[types.Int], DerefType(intPtr))
+		intPtr := gotypes.NewPointer(gotypes.Typ[gotypes.Int])
+		assert.Equal(t, gotypes.Typ[gotypes.Int], DerefType(intPtr))
 
-		stringPtr := types.NewPointer(types.Typ[types.String])
-		assert.Equal(t, types.Typ[types.String], DerefType(stringPtr))
+		stringPtr := gotypes.NewPointer(gotypes.Typ[gotypes.String])
+		assert.Equal(t, gotypes.Typ[gotypes.String], DerefType(stringPtr))
 
-		intPtrPtr := types.NewPointer(intPtr)
+		intPtrPtr := gotypes.NewPointer(intPtr)
 		assert.Equal(t, intPtr, DerefType(intPtrPtr))
 	})
 
 	t.Run("NonPointerTypes", func(t *testing.T) {
-		assert.Equal(t, types.Typ[types.Int], DerefType(types.Typ[types.Int]))
-		assert.Equal(t, types.Typ[types.String], DerefType(types.Typ[types.String]))
-		assert.Equal(t, types.Typ[types.Bool], DerefType(types.Typ[types.Bool]))
+		assert.Equal(t, gotypes.Typ[gotypes.Int], DerefType(gotypes.Typ[gotypes.Int]))
+		assert.Equal(t, gotypes.Typ[gotypes.String], DerefType(gotypes.Typ[gotypes.String]))
+		assert.Equal(t, gotypes.Typ[gotypes.Bool], DerefType(gotypes.Typ[gotypes.Bool]))
 
-		intSlice := types.NewSlice(types.Typ[types.Int])
+		intSlice := gotypes.NewSlice(gotypes.Typ[gotypes.Int])
 		assert.Equal(t, intSlice, DerefType(intSlice))
 
-		structType := types.NewStruct([]*types.Var{}, []string{})
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
 		assert.Equal(t, structType, DerefType(structType))
 
-		interfaceType := types.NewInterfaceType([]*types.Func{}, []types.Type{})
+		interfaceType := gotypes.NewInterfaceType([]*gotypes.Func{}, []gotypes.Type{})
 		assert.Equal(t, interfaceType, DerefType(interfaceType))
 	})
 
 	t.Run("ComplexTypes", func(t *testing.T) {
-		structType := types.NewStruct([]*types.Var{types.NewField(0, nil, "field", types.Typ[types.String], false)}, []string{})
-		structPtr := types.NewPointer(structType)
+		structType := gotypes.NewStruct([]*gotypes.Var{gotypes.NewField(0, nil, "field", gotypes.Typ[gotypes.String], false)}, []string{})
+		structPtr := gotypes.NewPointer(structType)
 		assert.Equal(t, structType, DerefType(structPtr))
 
-		sliceType := types.NewSlice(types.Typ[types.Int])
-		slicePtr := types.NewPointer(sliceType)
+		sliceType := gotypes.NewSlice(gotypes.Typ[gotypes.Int])
+		slicePtr := gotypes.NewPointer(sliceType)
 		assert.Equal(t, sliceType, DerefType(slicePtr))
 
-		chanType := types.NewChan(types.SendRecv, types.Typ[types.Int])
-		chanPtr := types.NewPointer(chanType)
+		chanType := gotypes.NewChan(gotypes.SendRecv, gotypes.Typ[gotypes.Int])
+		chanPtr := gotypes.NewPointer(chanType)
 		assert.Equal(t, chanType, DerefType(chanPtr))
 	})
 
@@ -76,58 +76,58 @@ func TestIsValidType(t *testing.T) {
 	})
 
 	t.Run("InvalidTypeSentinel", func(t *testing.T) {
-		assert.False(t, IsValidType(types.Typ[types.Invalid]))
+		assert.False(t, IsValidType(gotypes.Typ[gotypes.Invalid]))
 	})
 
 	t.Run("NamedType", func(t *testing.T) {
-		named := types.NewNamed(types.NewTypeName(0, nil, "MyInt", nil), types.Typ[types.Int], nil)
+		named := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "MyInt", nil), gotypes.Typ[gotypes.Int], nil)
 		assert.True(t, IsValidType(named))
 	})
 
 	t.Run("BasicTypes", func(t *testing.T) {
-		assert.True(t, IsValidType(types.Typ[types.Int]))
-		assert.True(t, IsValidType(types.Typ[types.String]))
-		assert.True(t, IsValidType(types.Typ[types.Bool]))
+		assert.True(t, IsValidType(gotypes.Typ[gotypes.Int]))
+		assert.True(t, IsValidType(gotypes.Typ[gotypes.String]))
+		assert.True(t, IsValidType(gotypes.Typ[gotypes.Bool]))
 	})
 
 	t.Run("CompositeTypes", func(t *testing.T) {
-		assert.True(t, IsValidType(types.NewSlice(types.Typ[types.String])))
-		assert.True(t, IsValidType(types.NewPointer(types.Typ[types.Int])))
-		assert.True(t, IsValidType(types.NewStruct(nil, nil)))
+		assert.True(t, IsValidType(gotypes.NewSlice(gotypes.Typ[gotypes.String])))
+		assert.True(t, IsValidType(gotypes.NewPointer(gotypes.Typ[gotypes.Int])))
+		assert.True(t, IsValidType(gotypes.NewStruct(nil, nil)))
 	})
 }
 
 func TestIsTypesCompatible(t *testing.T) {
 	t.Run("NilTypes", func(t *testing.T) {
 		assert.False(t, IsTypesCompatible(nil, nil))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], nil))
-		assert.False(t, IsTypesCompatible(nil, types.Typ[types.Int]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], nil))
+		assert.False(t, IsTypesCompatible(nil, gotypes.Typ[gotypes.Int]))
 	})
 
 	t.Run("AssignableTypes", func(t *testing.T) {
-		assert.True(t, IsTypesCompatible(types.Typ[types.Int], types.Typ[types.Int]))
-		assert.True(t, IsTypesCompatible(types.Typ[types.String], types.Typ[types.String]))
+		assert.True(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.Int]))
+		assert.True(t, IsTypesCompatible(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.String]))
 
 		// Untyped constants are assignable to typed values.
-		assert.True(t, IsTypesCompatible(types.Typ[types.UntypedInt], types.Typ[types.Int]))
-		assert.True(t, IsTypesCompatible(types.Typ[types.UntypedString], types.Typ[types.String]))
+		assert.True(t, IsTypesCompatible(gotypes.Typ[gotypes.UntypedInt], gotypes.Typ[gotypes.Int]))
+		assert.True(t, IsTypesCompatible(gotypes.Typ[gotypes.UntypedString], gotypes.Typ[gotypes.String]))
 	})
 
 	t.Run("InterfaceTypes", func(t *testing.T) {
-		stringMethod := types.NewFunc(0, nil, "String", types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.String])), false))
-		stringerIface := types.NewInterfaceType([]*types.Func{stringMethod}, nil)
+		stringMethod := gotypes.NewFunc(0, nil, "String", gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.String])), false))
+		stringerIface := gotypes.NewInterfaceType([]*gotypes.Func{stringMethod}, nil)
 
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		namedStruct := types.NewNamed(types.NewTypeName(0, nil, "TestStruct", nil), structType, nil)
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		namedStruct := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "TestStruct", nil), structType, nil)
 		namedStruct.AddMethod(stringMethod)
 
 		assert.True(t, IsTypesCompatible(namedStruct, stringerIface))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], stringerIface))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], stringerIface))
 	})
 
 	t.Run("PointerTypes", func(t *testing.T) {
-		intPtr := types.NewPointer(types.Typ[types.Int])
-		stringPtr := types.NewPointer(types.Typ[types.String])
+		intPtr := gotypes.NewPointer(gotypes.Typ[gotypes.Int])
+		stringPtr := gotypes.NewPointer(gotypes.Typ[gotypes.String])
 
 		// Both pointers with same element type.
 		assert.True(t, IsTypesCompatible(intPtr, intPtr))
@@ -136,15 +136,15 @@ func TestIsTypesCompatible(t *testing.T) {
 		assert.False(t, IsTypesCompatible(intPtr, stringPtr))
 
 		// Non-pointer to pointer with same element type.
-		assert.True(t, IsTypesCompatible(types.Typ[types.Int], intPtr))
+		assert.True(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], intPtr))
 
 		// Non-pointer to pointer with different element type.
-		assert.False(t, IsTypesCompatible(types.Typ[types.String], intPtr))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.String], intPtr))
 	})
 
 	t.Run("SliceTypes", func(t *testing.T) {
-		intSlice := types.NewSlice(types.Typ[types.Int])
-		stringSlice := types.NewSlice(types.Typ[types.String])
+		intSlice := gotypes.NewSlice(gotypes.Typ[gotypes.Int])
+		stringSlice := gotypes.NewSlice(gotypes.Typ[gotypes.String])
 
 		// Same slice element types.
 		assert.True(t, IsTypesCompatible(intSlice, intSlice))
@@ -153,14 +153,14 @@ func TestIsTypesCompatible(t *testing.T) {
 		assert.False(t, IsTypesCompatible(intSlice, stringSlice))
 
 		// Non-slice to slice.
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], intSlice))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], intSlice))
 	})
 
 	t.Run("ChannelTypes", func(t *testing.T) {
-		intChanSendRecv := types.NewChan(types.SendRecv, types.Typ[types.Int])
-		intChanSend := types.NewChan(types.SendOnly, types.Typ[types.Int])
-		intChanRecv := types.NewChan(types.RecvOnly, types.Typ[types.Int])
-		stringChanSendRecv := types.NewChan(types.SendRecv, types.Typ[types.String])
+		intChanSendRecv := gotypes.NewChan(gotypes.SendRecv, gotypes.Typ[gotypes.Int])
+		intChanSend := gotypes.NewChan(gotypes.SendOnly, gotypes.Typ[gotypes.Int])
+		intChanRecv := gotypes.NewChan(gotypes.RecvOnly, gotypes.Typ[gotypes.Int])
+		stringChanSendRecv := gotypes.NewChan(gotypes.SendRecv, gotypes.Typ[gotypes.String])
 
 		// Compatible channel directions.
 		assert.True(t, IsTypesCompatible(intChanSendRecv, intChanSendRecv))
@@ -183,45 +183,64 @@ func TestIsTypesCompatible(t *testing.T) {
 		assert.False(t, IsTypesCompatible(intChanSendRecv, stringChanSendRecv))
 
 		// Non-channel to channel.
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], intChanSendRecv))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], intChanSendRecv))
 	})
 
 	t.Run("SignatureTypes", func(t *testing.T) {
-		noResultWant := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(), false)
-		noResultGot := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(), false)
+		noResultWant := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(), false)
+		noResultGot := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(), false)
 		assert.True(t, IsTypesCompatible(noResultGot, noResultWant))
 
-		intResultVar := types.NewVar(0, nil, "", types.Typ[types.Int])
-		intResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(intResultVar), false)
-		otherIntResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)
+		noResultIntParamSig := gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.Int])),
+			gotypes.NewTuple(),
+			false,
+		)
+		noResultStringParamSig := gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.String])),
+			gotypes.NewTuple(),
+			false,
+		)
+		assert.True(t, IsTypesCompatible(noResultIntParamSig, noResultStringParamSig))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], noResultWant))
+
+		intResultVar := gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.Int])
+		intResultSig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(intResultVar), false)
+		otherIntResultSig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.Int])), false)
 		assert.True(t, IsTypesCompatible(otherIntResultSig, intResultSig))
 
-		stringResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.String])), false)
+		stringResultSig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.String])), false)
 		assert.False(t, IsTypesCompatible(otherIntResultSig, stringResultSig))
 
-		twoResultsSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(
-			types.NewVar(0, nil, "", types.Typ[types.Int]),
-			types.NewVar(0, nil, "", types.Typ[types.Int]),
+		twoResultsSig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(
+			gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.Int]),
+			gotypes.NewVar(0, nil, "", gotypes.Typ[gotypes.Int]),
 		), false)
 		assert.False(t, IsTypesCompatible(twoResultsSig, intResultSig))
 
-		ptrToInt := types.NewPointer(types.Typ[types.Int])
-		ptrResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", ptrToInt)), false)
-		ptrWantSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", ptrToInt)), false)
+		ptrToInt := gotypes.NewPointer(gotypes.Typ[gotypes.Int])
+		ptrResultSig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(gotypes.NewVar(0, nil, "", ptrToInt)), false)
+		ptrWantSig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(gotypes.NewVar(0, nil, "", ptrToInt)), false)
 		assert.True(t, IsTypesCompatible(ptrResultSig, ptrWantSig))
 
-		ptrToString := types.NewPointer(types.Typ[types.String])
-		ptrStringSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", ptrToString)), false)
+		ptrToString := gotypes.NewPointer(gotypes.Typ[gotypes.String])
+		ptrStringSig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(gotypes.NewVar(0, nil, "", ptrToString)), false)
 		assert.False(t, IsTypesCompatible(ptrResultSig, ptrStringSig))
 
-		assert.True(t, IsTypesCompatible(otherIntResultSig, types.Typ[types.Int]))
-		assert.False(t, IsTypesCompatible(twoResultsSig, types.Typ[types.Int]))
-		assert.False(t, IsTypesCompatible(stringResultSig, types.Typ[types.Int]))
+		assert.True(t, IsTypesCompatible(otherIntResultSig, gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesCompatible(twoResultsSig, gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesCompatible(stringResultSig, gotypes.Typ[gotypes.Int]))
 	})
 
 	t.Run("NamedTypes", func(t *testing.T) {
-		namedInt1 := types.NewNamed(types.NewTypeName(0, nil, "MyInt1", nil), types.Typ[types.Int], nil)
-		namedInt2 := types.NewNamed(types.NewTypeName(0, nil, "MyInt2", nil), types.Typ[types.Int], nil)
+		namedInt1 := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "MyInt1", nil), gotypes.Typ[gotypes.Int], nil)
+		namedInt2 := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "MyInt2", nil), gotypes.Typ[gotypes.Int], nil)
 
 		// Same named type.
 		assert.True(t, IsTypesCompatible(namedInt1, namedInt1))
@@ -230,105 +249,140 @@ func TestIsTypesCompatible(t *testing.T) {
 		assert.False(t, IsTypesCompatible(namedInt1, namedInt2))
 
 		// Named type to underlying type.
-		assert.False(t, IsTypesCompatible(namedInt1, types.Typ[types.Int]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], namedInt1))
+		assert.False(t, IsTypesCompatible(namedInt1, gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], namedInt1))
 	})
 
 	t.Run("TypeConversions", func(t *testing.T) {
 		// Named types are convertible to their underlying types.
-		userIDType := types.NewNamed(types.NewTypeName(0, nil, "UserID", nil), types.Typ[types.Int], nil)
-		orderIDType := types.NewNamed(types.NewTypeName(0, nil, "OrderID", nil), types.Typ[types.Int], nil)
+		userIDType := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "UserID", nil), gotypes.Typ[gotypes.Int], nil)
+		orderIDType := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "OrderID", nil), gotypes.Typ[gotypes.Int], nil)
 
 		// Named int types are NOT compatible with int (need conversion).
-		assert.False(t, IsTypesCompatible(userIDType, types.Typ[types.Int]))
-		assert.False(t, IsTypesCompatible(orderIDType, types.Typ[types.Int]))
+		assert.False(t, IsTypesCompatible(userIDType, gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesCompatible(orderIDType, gotypes.Typ[gotypes.Int]))
 
 		// Named string type is NOT compatible with string.
-		namedString := types.NewNamed(types.NewTypeName(0, nil, "MyString", nil), types.Typ[types.String], nil)
-		assert.False(t, IsTypesCompatible(namedString, types.Typ[types.String]))
+		namedString := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "MyString", nil), gotypes.Typ[gotypes.String], nil)
+		assert.False(t, IsTypesCompatible(namedString, gotypes.Typ[gotypes.String]))
 
 		// But int to string conversions are excluded (impractical).
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], types.Typ[types.String]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.String], types.Typ[types.Int]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.String]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Int]))
 
 		// Bool conversions are excluded.
-		assert.False(t, IsTypesCompatible(types.Typ[types.Bool], types.Typ[types.Int]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], types.Typ[types.Bool]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Bool], types.Typ[types.String]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.String], types.Typ[types.Bool]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.Bool]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.String]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Bool]))
 
 		// Numeric conversions within same category are NOT compatible (need conversion).
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int32], types.Typ[types.Int64]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Float32], types.Typ[types.Float64]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], types.Typ[types.Float64]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int32], gotypes.Typ[gotypes.Int64]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Float32], gotypes.Typ[gotypes.Float64]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.Float64]))
+	})
+
+	t.Run("UntypedBoolAssignments", func(t *testing.T) {
+		namedBool := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "MyBool", nil), gotypes.Typ[gotypes.Bool], nil)
+
+		assert.True(t, gotypes.AssignableTo(gotypes.Typ[gotypes.UntypedBool], gotypes.Typ[gotypes.Bool]))
+		assert.True(t, IsTypesCompatible(gotypes.Typ[gotypes.UntypedBool], gotypes.Typ[gotypes.Bool]))
+
+		assert.True(t, gotypes.AssignableTo(gotypes.Typ[gotypes.UntypedBool], namedBool))
+		assert.True(t, IsTypesCompatible(gotypes.Typ[gotypes.UntypedBool], namedBool))
 	})
 
 	t.Run("IncompatibleTypes", func(t *testing.T) {
 		// Basic incompatible types.
-		assert.False(t, IsTypesCompatible(types.Typ[types.Int], types.Typ[types.String]))
-		assert.False(t, IsTypesCompatible(types.Typ[types.Bool], types.Typ[types.Float64]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.String]))
+		assert.False(t, IsTypesCompatible(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.Float64]))
 
 		// Complex incompatible types.
-		intSlice := types.NewSlice(types.Typ[types.Int])
-		stringPtr := types.NewPointer(types.Typ[types.String])
+		intSlice := gotypes.NewSlice(gotypes.Typ[gotypes.Int])
+		stringPtr := gotypes.NewPointer(gotypes.Typ[gotypes.String])
 		assert.False(t, IsTypesCompatible(intSlice, stringPtr))
 	})
 }
 
 func TestIsTypesConvertible(t *testing.T) {
+	t.Run("NilTypes", func(t *testing.T) {
+		assert.False(t, IsTypesConvertible(nil, gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Int], nil))
+		assert.False(t, IsTypesConvertible(nil, nil))
+	})
+
 	t.Run("AllowedConversions", func(t *testing.T) {
 		// Named types to underlying types.
-		namedInt := types.NewNamed(types.NewTypeName(0, nil, "MyInt", nil), types.Typ[types.Int], nil)
-		assert.True(t, IsTypesConvertible(namedInt, types.Typ[types.Int]))
-		assert.True(t, IsTypesConvertible(types.Typ[types.Int], namedInt))
+		namedInt := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "MyInt", nil), gotypes.Typ[gotypes.Int], nil)
+		assert.True(t, IsTypesConvertible(namedInt, gotypes.Typ[gotypes.Int]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.Int], namedInt))
 
 		// Numeric conversions within same category.
-		assert.True(t, IsTypesConvertible(types.Typ[types.Int32], types.Typ[types.Int64]))
-		assert.True(t, IsTypesConvertible(types.Typ[types.Int], types.Typ[types.Int32]))
-		assert.True(t, IsTypesConvertible(types.Typ[types.Float32], types.Typ[types.Float64]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.Int32], gotypes.Typ[gotypes.Int64]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.Int32]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.Float32], gotypes.Typ[gotypes.Float64]))
 
 		// Numeric conversions between int and float.
-		assert.True(t, IsTypesConvertible(types.Typ[types.Int], types.Typ[types.Float64]))
-		assert.True(t, IsTypesConvertible(types.Typ[types.Float32], types.Typ[types.Int]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.Float64]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.Float32], gotypes.Typ[gotypes.Int]))
 
 		// Untyped constants.
-		assert.True(t, IsTypesConvertible(types.Typ[types.UntypedInt], types.Typ[types.Int]))
-		assert.True(t, IsTypesConvertible(types.Typ[types.UntypedFloat], types.Typ[types.Float64]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.UntypedInt], gotypes.Typ[gotypes.Int]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.UntypedFloat], gotypes.Typ[gotypes.Float64]))
+	})
+
+	t.Run("UntypedBoolConversions", func(t *testing.T) {
+		namedBool := gotypes.NewNamed(gotypes.NewTypeName(0, nil, "MyBool", nil), gotypes.Typ[gotypes.Bool], nil)
+
+		assert.True(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.UntypedBool], gotypes.Typ[gotypes.Bool]))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.UntypedBool], gotypes.Typ[gotypes.Bool]))
+
+		assert.True(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.UntypedBool], namedBool))
+		assert.True(t, IsTypesConvertible(gotypes.Typ[gotypes.UntypedBool], namedBool))
 	})
 
 	t.Run("ExcludedConversions", func(t *testing.T) {
 		// Numeric to string conversions.
-		assert.False(t, IsTypesConvertible(types.Typ[types.Int], types.Typ[types.String]))
-		assert.False(t, IsTypesConvertible(types.Typ[types.Int32], types.Typ[types.String]))
-		assert.False(t, IsTypesConvertible(types.Typ[types.Float64], types.Typ[types.String]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.String]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Int32], gotypes.Typ[gotypes.String]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Float64], gotypes.Typ[gotypes.String]))
 
 		// String to numeric conversions.
-		assert.False(t, IsTypesConvertible(types.Typ[types.String], types.Typ[types.Int]))
-		assert.False(t, IsTypesConvertible(types.Typ[types.String], types.Typ[types.Float64]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Float64]))
 
 		// Bool to numeric conversions.
-		assert.False(t, IsTypesConvertible(types.Typ[types.Bool], types.Typ[types.Int]))
-		assert.False(t, IsTypesConvertible(types.Typ[types.Bool], types.Typ[types.Float64]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.Int]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.Float64]))
 
 		// Numeric to bool conversions.
-		assert.False(t, IsTypesConvertible(types.Typ[types.Int], types.Typ[types.Bool]))
-		assert.False(t, IsTypesConvertible(types.Typ[types.Float64], types.Typ[types.Bool]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.Bool]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Float64], gotypes.Typ[gotypes.Bool]))
 
 		// Bool to string conversions.
-		assert.False(t, IsTypesConvertible(types.Typ[types.Bool], types.Typ[types.String]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.String]))
 
 		// String to bool conversions.
-		assert.False(t, IsTypesConvertible(types.Typ[types.String], types.Typ[types.Bool]))
+		assert.False(t, IsTypesConvertible(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Bool]))
+	})
+
+	t.Run("GoTypesRejectedConversions", func(t *testing.T) {
+		assert.False(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Int]))
+		assert.False(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Float64]))
+		assert.False(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.Int]))
+		assert.False(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.Bool], gotypes.Typ[gotypes.String]))
+		assert.False(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.Bool]))
+		assert.False(t, gotypes.ConvertibleTo(gotypes.Typ[gotypes.Float64], gotypes.Typ[gotypes.Bool]))
 	})
 
 	t.Run("NonConvertibleTypes", func(t *testing.T) {
 		// Types that are not convertible at all.
-		intSlice := types.NewSlice(types.Typ[types.Int])
-		stringSlice := types.NewSlice(types.Typ[types.String])
+		intSlice := gotypes.NewSlice(gotypes.Typ[gotypes.Int])
+		stringSlice := gotypes.NewSlice(gotypes.Typ[gotypes.String])
 		assert.False(t, IsTypesConvertible(intSlice, stringSlice))
 
-		structType1 := types.NewStruct([]*types.Var{types.NewField(0, nil, "a", types.Typ[types.Int], false)}, []string{})
-		structType2 := types.NewStruct([]*types.Var{types.NewField(0, nil, "b", types.Typ[types.String], false)}, []string{})
+		structType1 := gotypes.NewStruct([]*gotypes.Var{gotypes.NewField(0, nil, "a", gotypes.Typ[gotypes.Int], false)}, []string{})
+		structType2 := gotypes.NewStruct([]*gotypes.Var{gotypes.NewField(0, nil, "b", gotypes.Typ[gotypes.String], false)}, []string{})
 		assert.False(t, IsTypesConvertible(structType1, structType2))
 	})
 }

--- a/xgo/xgoutil/xgoutil.go
+++ b/xgo/xgoutil/xgoutil.go
@@ -18,14 +18,14 @@ package xgoutil
 
 import (
 	"go/constant"
-	"go/types"
+	gotypes "go/types"
 	"iter"
 	"slices"
 	"strconv"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 )
 
 // RangeASTSpecs iterates all XGo AST specs.
@@ -46,7 +46,7 @@ func RangeASTSpecs(astPkg *ast.Package, tok token.Token, f func(spec ast.Spec)) 
 
 // IsDefinedInClassFieldsDecl reports whether the given object is defined in the
 // class fields declaration of an AST file.
-func IsDefinedInClassFieldsDecl(fset *token.FileSet, typeInfo *xgotypes.Info, astPkg *ast.Package, obj types.Object) bool {
+func IsDefinedInClassFieldsDecl(fset *token.FileSet, typeInfo *types.Info, astPkg *ast.Package, obj gotypes.Object) bool {
 	if fset == nil || typeInfo == nil || astPkg == nil || obj == nil {
 		return false
 	}
@@ -86,7 +86,7 @@ func WalkPathEnclosingInterval(root *ast.File, start, end token.Pos, backward bo
 // EnclosingFuncSignature returns the function signature enclosing the AST path.
 // It searches from the innermost node outward and supports both function
 // declarations and literals. It returns nil if not found.
-func EnclosingFuncSignature(typeInfo *xgotypes.Info, path []ast.Node) *types.Signature {
+func EnclosingFuncSignature(typeInfo *types.Info, path []ast.Node) *gotypes.Signature {
 	if typeInfo == nil {
 		return nil
 	}
@@ -94,7 +94,7 @@ func EnclosingFuncSignature(typeInfo *xgotypes.Info, path []ast.Node) *types.Sig
 		switch node := node.(type) {
 		case *ast.FuncLit:
 			if typ := typeInfo.TypeOf(node); IsValidType(typ) {
-				if sig, ok := typ.(*types.Signature); ok {
+				if sig, ok := typ.(*gotypes.Signature); ok {
 					return sig
 				}
 			}
@@ -103,11 +103,11 @@ func EnclosingFuncSignature(typeInfo *xgotypes.Info, path []ast.Node) *types.Sig
 			if obj == nil {
 				continue
 			}
-			fun, ok := obj.(*types.Func)
+			fun, ok := obj.(*gotypes.Func)
 			if !ok {
 				continue
 			}
-			sig, ok := fun.Type().(*types.Signature)
+			sig, ok := fun.Type().(*gotypes.Signature)
 			if ok {
 				return sig
 			}
@@ -169,7 +169,7 @@ func ToLowerCamelCase(s string) string {
 // constant. It returns the string value and true if successful, or empty string
 // and false if the expression is not a string literal or constant, or if the
 // value cannot be determined.
-func StringLitOrConstValue(expr ast.Expr, tv types.TypeAndValue) (string, bool) {
+func StringLitOrConstValue(expr ast.Expr, tv gotypes.TypeAndValue) (string, bool) {
 	switch e := expr.(type) {
 	case *ast.BasicLit:
 		if e.Kind != token.STRING {

--- a/xgo/xgoutil/xgoutil_test.go
+++ b/xgo/xgoutil/xgoutil_test.go
@@ -18,7 +18,7 @@ package xgoutil
 
 import (
 	"go/constant"
-	"go/types"
+	gotypes "go/types"
 	"path"
 	"slices"
 	"testing"
@@ -27,7 +27,7 @@ import (
 	"github.com/goplus/xgo/parser"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgo/x/typesutil"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,23 +52,33 @@ func newTestPackage(files map[string]*ast.File) *ast.Package {
 	}
 }
 
-func newTestTypeInfo(defs map[*ast.Ident]types.Object, uses map[*ast.Ident]types.Object) *xgotypes.Info {
+func newTestTypeInfo(defs map[*ast.Ident]gotypes.Object, uses map[*ast.Ident]gotypes.Object) *types.Info {
 	if defs == nil {
-		defs = make(map[*ast.Ident]types.Object)
+		defs = make(map[*ast.Ident]gotypes.Object)
 	}
 	if uses == nil {
-		uses = make(map[*ast.Ident]types.Object)
+		uses = make(map[*ast.Ident]gotypes.Object)
 	}
-	return &xgotypes.Info{
+	return &types.Info{
 		Info: typesutil.Info{
-			Types:      make(map[ast.Expr]types.TypeAndValue),
+			Types:      make(map[ast.Expr]gotypes.TypeAndValue),
 			Defs:       defs,
 			Uses:       uses,
-			Selections: make(map[*ast.SelectorExpr]*types.Selection),
-			Implicits:  make(map[ast.Node]types.Object),
-			Scopes:     make(map[ast.Node]*types.Scope),
+			Selections: make(map[*ast.SelectorExpr]*gotypes.Selection),
+			Implicits:  make(map[ast.Node]gotypes.Object),
+			Scopes:     make(map[ast.Node]*gotypes.Scope),
 		},
 	}
+}
+
+func newTestFuncExSignature(pkg *gotypes.Package, recv *gotypes.Var, typ gotypes.Type) *gotypes.Signature {
+	methodSig := gotypes.NewSignatureType(gotypes.NewVar(token.NoPos, nil, "", typ), nil, nil, nil, nil, false)
+	paramType := gotypes.NewInterfaceType([]*gotypes.Func{
+		gotypes.NewFunc(token.NoPos, nil, "_", methodSig),
+	}, nil)
+	paramType.Complete()
+	param := gotypes.NewVar(token.NoPos, pkg, "__xgo_overload_args__", paramType)
+	return gotypes.NewSignatureType(recv, nil, nil, gotypes.NewTuple(param), nil, false)
 }
 
 func findIdent(astFile *ast.File, name string) *ast.Ident {
@@ -100,8 +110,8 @@ func findIdentWithPos(fset *token.FileSet, astFile *ast.File, name string) (*ast
 	return nil, token.Position{}
 }
 
-func markAsXGoPackage(pkg *types.Package) {
-	cnst := types.NewConst(token.NoPos, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true))
+func markAsXGoPackage(pkg *gotypes.Package) {
+	cnst := gotypes.NewConst(token.NoPos, pkg, XGoPackage, gotypes.Typ[gotypes.UntypedBool], constant.MakeBool(true))
 	pkg.Scope().Insert(cnst)
 }
 
@@ -330,13 +340,13 @@ var (
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.gox": astFile})
 
-		pkg := types.NewPackage("main", "main")
-		xVar := types.NewVar(token.NoPos, pkg, "x", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		xVar := gotypes.NewVar(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int])
 		xIdent := findIdent(astFile, "x")
 		require.NotNil(t, xIdent)
 
 		typeInfo := newTestTypeInfo(nil, nil)
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{
 			xVar: xIdent,
 		}
 
@@ -355,12 +365,12 @@ func test() {
 
 		astPkg := newTestPackage(map[string]*ast.File{"main.gox": astFile})
 
-		zVar := types.NewVar(token.NoPos, types.NewPackage("main", "main"), "z", types.Typ[types.Int])
+		zVar := gotypes.NewVar(token.NoPos, gotypes.NewPackage("main", "main"), "z", gotypes.Typ[gotypes.Int])
 		zIdent := findIdent(astFile, "z")
 		require.NotNil(t, zIdent)
 
 		typeInfo := newTestTypeInfo(nil, nil)
-		typeInfo.ObjToDef = map[types.Object]*ast.Ident{
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{
 			zVar: zIdent,
 		}
 
@@ -383,10 +393,37 @@ func test() {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.gox": astFile})
 		typeInfo := newTestTypeInfo(nil, nil)
-		pkg := types.NewPackage("main", "main")
-		xVar := types.NewVar(token.NoPos, pkg, "x", types.Typ[types.Int])
+		pkg := gotypes.NewPackage("main", "main")
+		xVar := gotypes.NewVar(token.NoPos, pkg, "x", gotypes.Typ[gotypes.Int])
 
 		result := IsDefinedInClassFieldsDecl(nil, typeInfo, astPkg, xVar)
+		assert.False(t, result)
+	})
+
+	t.Run("ObjectWithoutDefinition", func(t *testing.T) {
+		fset, astFile, err := newTestFile("main.gox", "var x int")
+		require.NoError(t, err)
+
+		astPkg := newTestPackage(map[string]*ast.File{"main.gox": astFile})
+		typeInfo := newTestTypeInfo(nil, nil)
+		xVar := gotypes.NewVar(token.NoPos, gotypes.NewPackage("main", "main"), "x", gotypes.Typ[gotypes.Int])
+
+		result := IsDefinedInClassFieldsDecl(fset, typeInfo, astPkg, xVar)
+		assert.False(t, result)
+	})
+
+	t.Run("DefinitionOutsidePackage", func(t *testing.T) {
+		fset, astFile, err := newTestFile("main.gox", "var x int")
+		require.NoError(t, err)
+
+		astPkg := newTestPackage(map[string]*ast.File{"main.gox": astFile})
+		typeInfo := newTestTypeInfo(nil, nil)
+		xVar := gotypes.NewVar(token.NoPos, gotypes.NewPackage("main", "main"), "x", gotypes.Typ[gotypes.Int])
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{
+			xVar: {NamePos: astFile.End() + 10, Name: "x"},
+		}
+
+		result := IsDefinedInClassFieldsDecl(fset, typeInfo, astPkg, xVar)
 		assert.False(t, result)
 	})
 }
@@ -518,13 +555,13 @@ func foo() string {
 `)
 		require.NoError(t, err)
 
-		pkg := types.NewPackage("main", "main")
-		sig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(token.NoPos, pkg, "", types.Typ[types.String])), false)
-		fun := types.NewFunc(token.NoPos, pkg, "foo", sig)
+		pkg := gotypes.NewPackage("main", "main")
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(gotypes.NewVar(token.NoPos, pkg, "", gotypes.Typ[gotypes.String])), false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "foo", sig)
 
 		nameIdent := findIdent(astFile, "foo")
 		require.NotNil(t, nameIdent)
-		typeInfo := newTestTypeInfo(map[*ast.Ident]types.Object{nameIdent: fun}, nil)
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{nameIdent: fun}, nil)
 
 		var ret *ast.ReturnStmt
 		ast.Inspect(astFile, func(n ast.Node) bool {
@@ -554,14 +591,14 @@ func outer() {
 `)
 		require.NoError(t, err)
 
-		pkg := types.NewPackage("main", "main")
-		errorObj := types.Universe.Lookup("error")
+		pkg := gotypes.NewPackage("main", "main")
+		errorObj := gotypes.Universe.Lookup("error")
 		require.NotNil(t, errorObj)
-		retTuple := types.NewTuple(
-			types.NewVar(token.NoPos, pkg, "", types.Typ[types.Int]),
-			types.NewVar(token.NoPos, pkg, "", errorObj.Type()),
+		retTuple := gotypes.NewTuple(
+			gotypes.NewVar(token.NoPos, pkg, "", gotypes.Typ[gotypes.Int]),
+			gotypes.NewVar(token.NoPos, pkg, "", errorObj.Type()),
 		)
-		sig := types.NewSignatureType(nil, nil, nil, nil, retTuple, false)
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, retTuple, false)
 
 		typeInfo := newTestTypeInfo(nil, nil)
 
@@ -580,7 +617,7 @@ func outer() {
 		})
 		require.NotNil(t, ret)
 		require.NotNil(t, lit)
-		typeInfo.Types[lit] = types.TypeAndValue{Type: sig}
+		typeInfo.Types[lit] = gotypes.TypeAndValue{Type: sig}
 
 		basic := ret.Results[0]
 		path, _ := PathEnclosingInterval(astFile, basic.Pos(), basic.End())
@@ -594,6 +631,34 @@ func outer() {
 		require.NoError(t, err)
 		path, _ := PathEnclosingInterval(astFile, astFile.Pos(), astFile.End())
 		assert.Nil(t, EnclosingFuncSignature(nil, path))
+	})
+
+	t.Run("FuncDeclWithoutFunctionObject", func(t *testing.T) {
+		_, astFile, err := newTestFile("main.xgo", `
+func foo() string {
+	return "ok"
+}
+`)
+		require.NoError(t, err)
+
+		nameIdent := findIdent(astFile, "foo")
+		require.NotNil(t, nameIdent)
+
+		var ret *ast.ReturnStmt
+		ast.Inspect(astFile, func(n ast.Node) bool {
+			if r, ok := n.(*ast.ReturnStmt); ok {
+				ret = r
+				return false
+			}
+			return true
+		})
+		require.NotNil(t, ret)
+
+		path, _ := PathEnclosingInterval(astFile, ret.Results[0].Pos(), ret.Results[0].End())
+		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
+			nameIdent: gotypes.NewVar(token.NoPos, gotypes.NewPackage("main", "main"), "foo", gotypes.Typ[gotypes.String]),
+		}, nil)
+		assert.Nil(t, EnclosingFuncSignature(typeInfo, path))
 	})
 }
 
@@ -894,6 +959,49 @@ func foo() (string, string) {
 		assert.Equal(t, 0, ReturnValueIndex(ret, leftLit))
 		assert.Equal(t, 1, ReturnValueIndex(ret, rightLit))
 	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, astFile, err := newTestFile("main.xgo", `
+func foo() string {
+	return "ok"
+}
+`)
+		require.NoError(t, err)
+
+		var ret *ast.ReturnStmt
+		ast.Inspect(astFile, func(n ast.Node) bool {
+			if r, ok := n.(*ast.ReturnStmt); ok {
+				ret = r
+				return false
+			}
+			return true
+		})
+		require.NotNil(t, ret)
+
+		target := &ast.BasicLit{
+			ValuePos: ret.End() + 1,
+			Kind:     token.STRING,
+			Value:    `"other"`,
+		}
+		assert.Equal(t, -1, ReturnValueIndex(ret, target))
+	})
+
+	t.Run("NilResultExprIsSkipped", func(t *testing.T) {
+		target := &ast.BasicLit{
+			ValuePos: token.Pos(10),
+			Kind:     token.STRING,
+			Value:    `"right"`,
+		}
+		ret := &ast.ReturnStmt{
+			Return: token.Pos(1),
+			Results: []ast.Expr{
+				nil,
+				target,
+			},
+		}
+
+		assert.Equal(t, 1, ReturnValueIndex(ret, target))
+	})
 }
 
 func TestToLowerCamelCase(t *testing.T) {
@@ -937,24 +1045,24 @@ func TestStringLitOrConstValue(t *testing.T) {
 			Value: `"literal"`,
 		}
 
-		tv := types.TypeAndValue{}
+		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(strLit, tv)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "literal", value)
 	})
 
 	t.Run("StringConstant", func(t *testing.T) {
 		ident := &ast.Ident{Name: "strConst"}
-		tv := types.TypeAndValue{Value: constant.MakeString("constant value")}
+		tv := gotypes.TypeAndValue{Value: constant.MakeString("constant value")}
 
 		value, ok := StringLitOrConstValue(ident, tv)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "constant value", value)
 	})
 
 	t.Run("StringVariable", func(t *testing.T) {
 		ident := &ast.Ident{Name: "strVar"}
-		tv := types.TypeAndValue{Value: nil} // Variables don't have constant values
+		tv := gotypes.TypeAndValue{Value: nil} // Variables don't have constant values
 
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
@@ -967,7 +1075,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 			Value: "42",
 		}
 
-		tv := types.TypeAndValue{}
+		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(intLit, tv)
 		assert.False(t, ok)
 		assert.Equal(t, "", value)
@@ -975,7 +1083,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 
 	t.Run("NonStringConstant", func(t *testing.T) {
 		ident := &ast.Ident{Name: "intConst"}
-		tv := types.TypeAndValue{Value: constant.MakeInt64(42)}
+		tv := gotypes.TypeAndValue{Value: constant.MakeInt64(42)}
 
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
@@ -988,7 +1096,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 			Value: `"invalid\x"`, // Invalid escape sequence.
 		}
 
-		tv := types.TypeAndValue{}
+		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(invalidLit, tv)
 		assert.False(t, ok)
 		assert.Equal(t, "", value)
@@ -1001,7 +1109,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 			Y:  &ast.BasicLit{Kind: token.STRING, Value: `"world"`},
 		}
 
-		tv := types.TypeAndValue{}
+		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(binExpr, tv)
 		assert.False(t, ok)
 		assert.Equal(t, "", value)
@@ -1009,7 +1117,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 
 	t.Run("IdentWithNilValue", func(t *testing.T) {
 		ident := &ast.Ident{Name: "test"}
-		tv := types.TypeAndValue{Value: nil}
+		tv := gotypes.TypeAndValue{Value: nil}
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
 		assert.Equal(t, "", value)
@@ -1017,7 +1125,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 
 	t.Run("IdentWithNonStringConstant", func(t *testing.T) {
 		ident := &ast.Ident{Name: "test"}
-		tv := types.TypeAndValue{Value: constant.MakeInt64(42)}
+		tv := gotypes.TypeAndValue{Value: constant.MakeInt64(42)}
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
 		assert.Equal(t, "", value)


### PR DESCRIPTION
Fold the additional `xgoutil` coverage cases into the existing test files so overload handling, call argument traversal, and related edge cases are covered without introducing ad hoc white-box test files.

Normalize `xgo` package imports in `xgo/` to match the test-side conventions and document that rule in `AGENTS.md` so future test updates stay consistent.