### PR TITLE
refactor: align import aliases with project conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,22 +11,34 @@ features (completion, diagnostics, hover, etc.) for XGo source files.
 
 ### Import alias conventions
 
-In `xgo` and its subpackages, prefer the XGo package when a corresponding package exists for a standard library `go/*`
-import. When these packages are needed under `xgo/`, keep the XGo package as the simple name.
+When a `github.com/goplus/xgo/*` package corresponds to a standard library `go/*` package, prefer the XGo package and
+keep it as the simple package name.
 
 - Use `ast` for `github.com/goplus/xgo/ast`
+- Use `doc` for `github.com/goplus/xgo/doc`
 - Use `format` for `github.com/goplus/xgo/format`
 - Use `parser` for `github.com/goplus/xgo/parser`
 - Use `printer` for `github.com/goplus/xgo/printer`
 - Use `scanner` for `github.com/goplus/xgo/scanner`
 - Use `token` for `github.com/goplus/xgo/token`
-- Use `types` for `github.com/goplus/xgolsw/xgo/types`
+
+Use `types` for the project-local XGo type wrapper `github.com/goplus/xgolsw/xgo/types`. It is not a
+`github.com/goplus/xgo/*` package, but it represents XGo type information and follows the same simple-name preference.
 
 Only import the standard library counterpart when it is genuinely required. In that case, use a `go` prefix alias such
-as `goast`, `goformat`, `goparser`, `goprinter`, `goscanner`, `gotoken`, or `gotypes`.
+as `goast`, `godoc`, `goformat`, `goparser`, `goprinter`, `goscanner`, `gotoken`, or `gotypes`, even when the XGo
+counterpart is not imported in the same file.
 
-Do not use aliases such as `xgoast`, `xgotoken`, or `xgotypes` in `xgo/`. Apply the same convention in both production
-code and unit tests.
+For `go/doc`, use `godoc` when standard library APIs such as `New` or `Synopsis` are required, because
+`github.com/goplus/xgo/doc` does not provide those APIs.
+
+For `go/token`, prefer `github.com/goplus/xgo/token` for source positions and file sets such as `Pos`, `NoPos`,
+`FileSet`, and `NewFileSet`, because those are aliases of the standard library types. Use `gotoken` only when the
+standard library `go/token.Token` type is genuinely required, such as when switching on token values from a `go/ast`
+node. `github.com/goplus/xgo/token.Token` is a distinct XGo token type.
+
+Do not use aliases such as `xgoast`, `xgotoken`, or `xgotypes`. Apply the same convention in both production code and
+unit tests.
 
 ## Testing conventions
 

--- a/cmd/pkgdatagen/main.go
+++ b/cmd/pkgdatagen/main.go
@@ -22,11 +22,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"go/ast"
+	goast "go/ast"
 	"go/build"
-	"go/parser"
-	"go/token"
-	"go/types"
+	goparser "go/parser"
+	gotoken "go/token"
+	gotypes "go/types"
 	"os"
 	"os/exec"
 	"path"
@@ -179,7 +179,7 @@ func generate(pkgPaths []string, outputFile string) error {
 
 		var pkgDoc *pkgdoc.PkgDoc
 		if pkgPath == "builtin" {
-			astFile, err := parser.ParseFile(token.NewFileSet(), path.Join(buildPkg.Dir, "builtin.go"), nil, parser.ParseComments)
+			astFile, err := goparser.ParseFile(gotoken.NewFileSet(), path.Join(buildPkg.Dir, "builtin.go"), nil, goparser.ParseComments)
 			if err != nil {
 				return fmt.Errorf("failed to parse builtin.go: %w", err)
 			}
@@ -194,12 +194,12 @@ func generate(pkgPaths []string, outputFile string) error {
 			}
 			for _, decl := range astFile.Decls {
 				switch decl := decl.(type) {
-				case *ast.GenDecl:
+				case *goast.GenDecl:
 					switch decl.Tok {
-					case token.VAR:
+					case gotoken.VAR:
 						for _, spec := range decl.Specs {
 							switch spec := spec.(type) {
-							case *ast.ValueSpec:
+							case *goast.ValueSpec:
 								for _, name := range spec.Names {
 									doc := spec.Doc.Text()
 									if doc == "" {
@@ -211,10 +211,10 @@ func generate(pkgPaths []string, outputFile string) error {
 								return fmt.Errorf("unknown builtin gen decl spec: %T", spec)
 							}
 						}
-					case token.CONST:
+					case gotoken.CONST:
 						for _, spec := range decl.Specs {
 							switch spec := spec.(type) {
-							case *ast.ValueSpec:
+							case *goast.ValueSpec:
 								for _, name := range spec.Names {
 									doc := spec.Doc.Text()
 									if doc == "" {
@@ -226,11 +226,11 @@ func generate(pkgPaths []string, outputFile string) error {
 								return fmt.Errorf("unknown builtin gen decl spec: %T", spec)
 							}
 						}
-					case token.IMPORT:
-					case token.TYPE:
+					case gotoken.IMPORT:
+					case gotoken.TYPE:
 						for _, spec := range decl.Specs {
 							switch spec := spec.(type) {
-							case *ast.TypeSpec:
+							case *goast.TypeSpec:
 								doc := spec.Doc.Text()
 								if doc == "" {
 									doc = decl.Doc.Text()
@@ -245,7 +245,7 @@ func generate(pkgPaths []string, outputFile string) error {
 					default:
 						return fmt.Errorf("unknown builtin gen decl token: %s", decl.Tok)
 					}
-				case *ast.FuncDecl:
+				case *goast.FuncDecl:
 					pkgDoc.Funcs[decl.Name.Name] = decl.Doc.Text()
 				default:
 					return fmt.Errorf("unknown builtin decl: %T", decl)
@@ -272,8 +272,8 @@ func generate(pkgPaths []string, outputFile string) error {
 				return fmt.Errorf("failed to create package export reader: %w", err)
 			}
 
-			exportFSet := token.NewFileSet()
-			typesPkg, err := gcexportdata.Read(r, exportFSet, make(map[string]*types.Package), pkgPath)
+			exportFSet := gotoken.NewFileSet()
+			typesPkg, err := gcexportdata.Read(r, exportFSet, make(map[string]*gotypes.Package), pkgPath)
 			if err != nil {
 				return fmt.Errorf("failed to read package export data: %w", err)
 			}
@@ -283,11 +283,11 @@ func generate(pkgPaths []string, outputFile string) error {
 				return fmt.Errorf("failed to write optimized package export data: %w", err)
 			}
 
-			parseFSet := token.NewFileSet()
-			astFiles := make(map[string]*ast.File, len(buildPkg.GoFiles)+len(buildPkg.CgoFiles))
+			parseFSet := gotoken.NewFileSet()
+			astFiles := make(map[string]*goast.File, len(buildPkg.GoFiles)+len(buildPkg.CgoFiles))
 			for _, fileName := range slices.Concat(buildPkg.GoFiles, buildPkg.CgoFiles) {
 				fullPath := filepath.Join(buildPkg.Dir, fileName)
-				astFile, err := parser.ParseFile(parseFSet, fullPath, nil, parser.ParseComments)
+				astFile, err := goparser.ParseFile(parseFSet, fullPath, nil, goparser.ParseComments)
 				if err != nil {
 					return fmt.Errorf("failed to parse %q: %w", fileName, err)
 				}
@@ -300,7 +300,7 @@ func generate(pkgPaths []string, outputFile string) error {
 				continue
 			}
 
-			astPkg := &ast.Package{
+			astPkg := &goast.Package{
 				Files: astFiles,
 				Name:  pkgName,
 			}

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -1,122 +1,122 @@
 package i18n
 
 import (
-	gotoken "go/token"
 	"strings"
 	"testing"
 
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTranslator_Translate(t *testing.T) {
+func TestTranslatorTranslate(t *testing.T) {
 	translator := NewTranslator()
 
 	tests := []struct {
-		name     string
-		msg      string
-		lang     Language
-		expected string
+		name string
+		msg  string
+		lang Language
+		want string
 	}{
 		// English - should return original
 		{
-			name:     "English original",
-			msg:      `cannot use "Hi" (type untyped string) as type int`,
-			lang:     LanguageEN,
-			expected: `cannot use "Hi" (type untyped string) as type int`,
+			name: "EnglishOriginal",
+			msg:  `cannot use "Hi" (type untyped string) as type int`,
+			lang: LanguageEN,
+			want: `cannot use "Hi" (type untyped string) as type int`,
 		},
 
 		// Type mismatch errors
 		{
-			name:     "Type mismatch basic",
-			msg:      `cannot use "Hi" (type untyped string) as type int`,
-			lang:     LanguageCN,
-			expected: `无法将 "Hi" (类型 untyped string) 用作类型 int`,
+			name: "TypeMismatchBasic",
+			msg:  `cannot use "Hi" (type untyped string) as type int`,
+			lang: LanguageCN,
+			want: `无法将 "Hi" (类型 untyped string) 用作类型 int`,
 		},
 		{
-			name:     "Type mismatch with context",
-			msg:      `cannot use x (type int) as type string in assignment`,
-			lang:     LanguageCN,
-			expected: `无法将 x (类型 int) 用作类型 string 在 assignment 中`,
+			name: "TypeMismatchWithContext",
+			msg:  `cannot use x (type int) as type string in assignment`,
+			lang: LanguageCN,
+			want: `无法将 x (类型 int) 用作类型 string 在 assignment 中`,
 		},
 
 		// Type conversion errors
 		{
-			name:     "Type conversion",
-			msg:      `cannot convert 1<<127 to type Int128`,
-			lang:     LanguageCN,
-			expected: `无法将 1<<127 转换为类型 Int128`,
+			name: "TypeConversion",
+			msg:  `cannot convert 1<<127 to type Int128`,
+			lang: LanguageCN,
+			want: `无法将 1<<127 转换为类型 Int128`,
 		},
 
 		// Undefined identifiers
 		{
-			name:     "Undefined identifier",
-			msg:      `undefined: foo`,
-			lang:     LanguageCN,
-			expected: `未定义: foo`,
+			name: "UndefinedIdentifier",
+			msg:  `undefined: foo`,
+			lang: LanguageCN,
+			want: `未定义: foo`,
 		},
 
 		// Redeclaration errors
 		{
-			name:     "Redeclaration",
-			msg:      `a redeclared in this block`,
-			lang:     LanguageCN,
-			expected: `a 在此代码块中重复声明`,
+			name: "Redeclaration",
+			msg:  `a redeclared in this block`,
+			lang: LanguageCN,
+			want: `a 在此代码块中重复声明`,
 		},
 
 		// Assignment errors
 		{
-			name:     "Assignment mismatch",
-			msg:      `assignment mismatch: 1 variables but bar returns 2 values`,
-			lang:     LanguageCN,
-			expected: `赋值不匹配: 1 个变量但 bar 返回 2 个值`,
+			name: "AssignmentMismatch",
+			msg:  `assignment mismatch: 1 variables but bar returns 2 values`,
+			lang: LanguageCN,
+			want: `赋值不匹配: 1 个变量但 bar 返回 2 个值`,
 		},
 		{
-			name:     "Cannot use underscore",
-			msg:      `cannot use _ as value`,
-			lang:     LanguageCN,
-			expected: `无法将 _ 用作值`,
+			name: "CannotUseUnderscore",
+			msg:  `cannot use _ as value`,
+			lang: LanguageCN,
+			want: `无法将 _ 用作值`,
 		},
 
 		// Function call errors
 		{
-			name:     "Not enough arguments",
-			msg:      "not enough arguments in call to Ls\n\thave ()\n\twant (int)",
-			lang:     LanguageCN,
-			expected: "调用 Ls 的参数不足\n\t现有 ()\n\t需要 (int)",
+			name: "NotEnoughArguments",
+			msg:  "not enough arguments in call to Ls\n\thave ()\n\twant (int)",
+			lang: LanguageCN,
+			want: "调用 Ls 的参数不足\n\t现有 ()\n\t需要 (int)",
 		},
 
 		// Array errors
 		{
-			name:     "Array index out of bounds",
-			msg:      `array index 5 out of bounds [0:3]`,
-			lang:     LanguageCN,
-			expected: `数组索引 5 超出范围 [0:3]`,
+			name: "ArrayIndexOutOfBounds",
+			msg:  `array index 5 out of bounds [0:3]`,
+			lang: LanguageCN,
+			want: `数组索引 5 超出范围 [0:3]`,
 		},
 
 		// No match - should return original
 		{
-			name:     "No pattern match",
-			msg:      `some random error message`,
-			lang:     LanguageCN,
-			expected: `some random error message`,
+			name: "NoPatternMatch",
+			msg:  `some random error message`,
+			lang: LanguageCN,
+			want: `some random error message`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := translator.Translate(tt.msg, tt.lang)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }
 
-func TestTranslate_GlobalFunction(t *testing.T) {
+func TestTranslateGlobalFunction(t *testing.T) {
 	// Test the global convenience function
 	result := Translate(`undefined: foo`, LanguageCN)
-	expected := `未定义: foo`
+	want := `未定义: foo`
 
-	assert.Equal(t, expected, result)
+	assert.Equal(t, want, result)
 }
 
 // TestCodeBasedErrorTranslation tests error translation using actual xgo code compilation
@@ -130,422 +130,422 @@ func TestTranslate_GlobalFunction(t *testing.T) {
 // - Real compilation errors ensure patterns stay relevant as xgo evolves
 func TestCodeBasedErrorTranslation(t *testing.T) {
 	tests := []struct {
-		name          string
-		code          string
-		expectEnError string // Expected complete English error message
-		expectCnError string // Expected complete Chinese translation
+		name        string
+		code        string
+		wantEnError string // Want complete English error message
+		wantCnError string // Want complete Chinese translation
 	}{
 		// 1. Type System Errors
 		{
-			name:          "Type mismatch string to int",
-			code:          `var a int = "Hi"`,
-			expectEnError: `cannot use "Hi" (type untyped string) as type int in assignment`,
-			expectCnError: `无法将 "Hi" (类型 untyped string) 用作类型 int 在 assignment 中`,
+			name:        "TypeMismatchStringToInt",
+			code:        `var a int = "Hi"`,
+			wantEnError: `cannot use "Hi" (type untyped string) as type int in assignment`,
+			wantCnError: `无法将 "Hi" (类型 untyped string) 用作类型 int 在 assignment 中`,
 		},
 		{
-			name:          "Type mismatch slice to string",
-			code:          `var a string = []string{}`,
-			expectEnError: `cannot use []string{} (type []string) as type string in assignment`,
-			expectCnError: `无法将 []string{} (类型 []string) 用作类型 string 在 assignment 中`,
+			name:        "TypeMismatchSliceToString",
+			code:        `var a string = []string{}`,
+			wantEnError: `cannot use []string{} (type []string) as type string in assignment`,
+			wantCnError: `无法将 []string{} (类型 []string) 用作类型 string 在 assignment 中`,
 		},
 		{
-			name:          "Type mismatch array to string",
-			code:          `var a string = [2]string{}`,
-			expectEnError: `cannot use [2]string{} (type [2]string) as type string in assignment`,
-			expectCnError: `无法将 [2]string{} (类型 [2]string) 用作类型 string 在 assignment 中`,
+			name:        "TypeMismatchArrayToString",
+			code:        `var a string = [2]string{}`,
+			wantEnError: `cannot use [2]string{} (type [2]string) as type string in assignment`,
+			wantCnError: `无法将 [2]string{} (类型 [2]string) 用作类型 string 在 assignment 中`,
 		},
 		{
-			name:          "Type mismatch map to string",
-			code:          `var a string = map[int]string{}`,
-			expectEnError: `cannot use map[int]string{} (type map[int]string) as type string in assignment`,
-			expectCnError: `无法将 map[int]string{} (类型 map[int]string) 用作类型 string 在 assignment 中`,
+			name:        "TypeMismatchMapToString",
+			code:        `var a string = map[int]string{}`,
+			wantEnError: `cannot use map[int]string{} (type map[int]string) as type string in assignment`,
+			wantCnError: `无法将 map[int]string{} (类型 map[int]string) 用作类型 string 在 assignment 中`,
 		},
 		{
-			name:          "Type mismatch function to string",
-			code:          `var a string = func(){}`,
-			expectEnError: `cannot use func(){} (type func()) as type string in assignment`,
-			expectCnError: `无法将 func(){} (类型 func()) 用作类型 string 在 assignment 中`,
+			name:        "TypeMismatchFunctionToString",
+			code:        `var a string = func(){}`,
+			wantEnError: `cannot use func(){} (type func()) as type string in assignment`,
+			wantCnError: `无法将 func(){} (类型 func()) 用作类型 string 在 assignment 中`,
 		},
 		{
-			name:          "Type mismatch struct to string",
-			code:          `type T struct{}; var a string = T{}`,
-			expectEnError: `cannot use T{} (type main.T) as type string in assignment`,
-			expectCnError: `无法将 T{} (类型 main.T) 用作类型 string 在 assignment 中`,
+			name:        "TypeMismatchStructToString",
+			code:        `type T struct{}; var a string = T{}`,
+			wantEnError: `cannot use T{} (type main.T) as type string in assignment`,
+			wantCnError: `无法将 T{} (类型 main.T) 用作类型 string 在 assignment 中`,
 		},
 		{
-			name:          "Return type mismatch",
-			code:          `func foo() (int, error) { return 1, "Hi" }`,
-			expectEnError: `cannot use "Hi" (type untyped string) as type error in return argument`,
-			expectCnError: `无法将 "Hi" (类型 untyped string) 用作类型 error 在 return argument 中`,
+			name:        "ReturnTypeMismatch",
+			code:        `func foo() (int, error) { return 1, "Hi" }`,
+			wantEnError: `cannot use "Hi" (type untyped string) as type error in return argument`,
+			wantCnError: `无法将 "Hi" (类型 untyped string) 用作类型 error 在 return argument 中`,
 		},
 
 		// 2. Variable & Constant Errors
 		{
-			name:          "Undefined identifier",
-			code:          `func main() { println(foo) }`,
-			expectEnError: `undefined: foo`,
-			expectCnError: `未定义: foo`,
+			name:        "UndefinedIdentifier",
+			code:        `func main() { println(foo) }`,
+			wantEnError: `undefined: foo`,
+			wantCnError: `未定义: foo`,
 		},
 		{
-			name:          "Undefined struct field access",
-			code:          `func main() { foo.x = 1 }`,
-			expectEnError: `undefined: foo`,
-			expectCnError: `未定义: foo`,
+			name:        "UndefinedStructFieldAccess",
+			code:        `func main() { foo.x = 1 }`,
+			wantEnError: `undefined: foo`,
+			wantCnError: `未定义: foo`,
 		},
 		{
-			name:          "Builtin used incorrectly",
-			code:          `func main() { len.x = 1 }`,
-			expectEnError: `use of builtin len not in function call`,
-			expectCnError: `内建函数 len 的使用不在函数调用中`,
+			name:        "BuiltinUsedIncorrectly",
+			code:        `func main() { len.x = 1 }`,
+			wantEnError: `use of builtin len not in function call`,
+			wantCnError: `内建函数 len 的使用不在函数调用中`,
 		},
 		{
-			name: "Variable redeclaration",
+			name: "VariableRedeclaration",
 			code: `var a int; var a string`,
-			expectEnError: `a redeclared in this block
+			wantEnError: `a redeclared in this block
 	previous declaration at main.xgo:1:5`,
-			expectCnError: `a 在此代码块中重复声明
+			wantCnError: `a 在此代码块中重复声明
 	先前声明位于 main.xgo:1:5`,
 		},
 		{
-			name: "Const redeclaration",
+			name: "ConstRedeclaration",
 			code: `var a int; const a = 1`,
-			expectEnError: `a redeclared in this block
+			wantEnError: `a redeclared in this block
 	previous declaration at main.xgo:1:5`,
-			expectCnError: `a 在此代码块中重复声明
+			wantCnError: `a 在此代码块中重复声明
 	先前声明位于 main.xgo:1:5`,
 		},
 		{
-			name:          "Missing const value",
-			code:          `const (a = iota; b, c)`,
-			expectEnError: `missing value in const declaration`,
-			expectCnError: `const 声明中缺少值`,
+			name:        "MissingConstValue",
+			code:        `const (a = iota; b, c)`,
+			wantEnError: `missing value in const declaration`,
+			wantCnError: `const 声明中缺少值`,
 		},
 		{
-			name: "No new variables in :=",
+			name: "NoNewVariablesInDefine",
 			code: `a := 1; a := "Hi"`,
-			expectEnError: `no new variables on left side of :=
+			wantEnError: `no new variables on left side of :=
 main.xgo:1:14: cannot use "Hi" (type untyped string) as type int in assignment`,
-			expectCnError: `:= 左侧没有新变量
+			wantCnError: `:= 左侧没有新变量
 main.xgo:1:14: 无法将 "Hi" (类型 untyped string) 用作类型 int 在 assignment 中`,
 		},
 		{
-			name:          "Cannot use underscore as value",
-			code:          `var a = _`,
-			expectEnError: `cannot use _ as value`,
-			expectCnError: `无法将 _ 用作值`,
+			name:        "CannotUseUnderscoreAsValue",
+			code:        `var a = _`,
+			wantEnError: `cannot use _ as value`,
+			wantCnError: `无法将 _ 用作值`,
 		},
 		{
-			name:          "Is not a variable",
-			code:          `println = 1`,
-			expectEnError: `println is not a variable`,
-			expectCnError: `println 不是一个变量`,
+			name:        "IsNotAVariable",
+			code:        `println = 1`,
+			wantEnError: `println is not a variable`,
+			wantCnError: `println 不是一个变量`,
 		},
 
 		// 3. Assignment Errors
 		{
-			name: "Assignment mismatch multiple return",
+			name: "AssignmentMismatchMultipleReturn",
 			code: `func bar() (int, error) { return 1, nil }
 func main() {
 	x := 1
 	x = bar()
 }`,
-			expectEnError: `assignment mismatch: 1 variables but bar returns 2 values`,
-			expectCnError: `赋值不匹配: 1 个变量但 bar 返回 2 个值`,
+			wantEnError: `assignment mismatch: 1 variables but bar returns 2 values`,
+			wantCnError: `赋值不匹配: 1 个变量但 bar 返回 2 个值`,
 		},
 		{
-			name:          "Assignment mismatch multiple values",
-			code:          `x := 1; x = 1, "Hi"`,
-			expectEnError: `assignment mismatch: 1 variables but 2 values`,
-			expectCnError: `赋值不匹配: 1 个变量但有 2 个值`,
+			name:        "AssignmentMismatchMultipleValues",
+			code:        `x := 1; x = 1, "Hi"`,
+			wantEnError: `assignment mismatch: 1 variables but 2 values`,
+			wantCnError: `赋值不匹配: 1 个变量但有 2 个值`,
 		},
 
 		// 4. Function & Method Errors
 		{
-			name: "Not enough arguments",
+			name: "NotEnoughArguments",
 			code: `func Ls(int) {}; func main() { Ls() }`,
-			expectEnError: `not enough arguments in call to Ls
+			wantEnError: `not enough arguments in call to Ls
 	have ()
 	want (int)`,
-			expectCnError: `调用 Ls 的参数不足
+			wantCnError: `调用 Ls 的参数不足
 	现有 ()
 	需要 (int)`,
 		},
 		{
-			name: "Too few return arguments",
+			name: "TooFewReturnArguments",
 			code: `func foo() (int, error) { return 1 }`,
-			expectEnError: `too few arguments to return
+			wantEnError: `too few arguments to return
 	have (untyped int)
 	want (int, error)`,
-			expectCnError: `返回参数数量错误
+			wantCnError: `返回参数数量错误
 	现有 (untyped int)
 	需要 (int, error)`,
 		},
 		{
-			name: "Too many return arguments",
+			name: "TooManyReturnArguments",
 			code: `func foo() (int, error) { return 1, 2, "Hi" }`,
-			expectEnError: `too many arguments to return
+			wantEnError: `too many arguments to return
 	have (untyped int, untyped int, untyped string)
 	want (int, error)`,
-			expectCnError: `返回参数数量错误
+			wantCnError: `返回参数数量错误
 	现有 (untyped int, untyped int, untyped string)
 	需要 (int, error)`,
 		},
 		{
-			name: "Not enough return arguments empty",
+			name: "NotEnoughReturnArgumentsEmpty",
 			code: `func foo() byte { return }`,
-			expectEnError: `not enough arguments to return
+			wantEnError: `not enough arguments to return
 	have ()
 	want (byte)`,
-			expectCnError: `return 的参数不足
+			wantCnError: `return 的参数不足
 	有 ()
 	想要 (byte)`,
 		},
 		{
-			name:          "Init function with parameters",
-			code:          `func init(a int) {}`,
-			expectEnError: `func init must have no arguments and no return values`,
-			expectCnError: `func init 必须没有参数和返回值`,
+			name:        "InitFunctionWithParameters",
+			code:        `func init(a int) {}`,
+			wantEnError: `func init must have no arguments and no return values`,
+			wantCnError: `func init 必须没有参数和返回值`,
 		},
 
 		// 5. Control Flow Errors
 		{
-			name:          "Range type assignment error",
-			code:          `a := 1; var b []string; for _, a = range b {}`,
-			expectEnError: `cannot assign type string to a (type int) in range`,
-			expectCnError: `无法在 range 中将类型 string 赋值给 a (类型 int)`,
+			name:        "RangeTypeAssignmentError",
+			code:        `a := 1; var b []string; for _, a = range b {}`,
+			wantEnError: `cannot assign type string to a (type int) in range`,
+			wantCnError: `无法在 range 中将类型 string 赋值给 a (类型 int)`,
 		},
 		{
-			name:          "Fallthrough out of place",
-			code:          "func foo() {\n\tfallthrough\n}",
-			expectEnError: `fallthrough statement out of place`,
-			expectCnError: `fallthrough 语句位置错误`,
+			name:        "FallthroughOutOfPlace",
+			code:        "func foo() {\n\tfallthrough\n}",
+			wantEnError: `fallthrough statement out of place`,
+			wantCnError: `fallthrough 语句位置错误`,
 		},
 		{
-			name:          "Label not defined goto",
-			code:          `x := 1; goto foo`,
-			expectEnError: `label foo is not defined`,
-			expectCnError: `标签 foo 未定义`,
+			name:        "LabelNotDefinedGoto",
+			code:        `x := 1; goto foo`,
+			wantEnError: `label foo is not defined`,
+			wantCnError: `标签 foo 未定义`,
 		},
 		{
-			name:          "Label not defined break",
-			code:          `x := 1; break foo`,
-			expectEnError: `label foo is not defined`,
-			expectCnError: `标签 foo 未定义`,
+			name:        "LabelNotDefinedBreak",
+			code:        `x := 1; break foo`,
+			wantEnError: `label foo is not defined`,
+			wantCnError: `标签 foo 未定义`,
 		},
 		{
-			name: "Duplicate switch case",
+			name: "DuplicateSwitchCase",
 			code: `var n int; switch n { case 100: case 100: }`,
-			expectEnError: `duplicate case 100 in switch
+			wantEnError: `duplicate case 100 in switch
 	previous case at main.xgo:1:28`,
-			expectCnError: `switch 中重复的 case 100
+			wantCnError: `switch 中重复的 case 100
 	先前 case 位于 main.xgo:1:28`,
 		},
 		{
-			name:          "Multiple defaults in switch",
-			code:          `var n interface{}; switch n { default: default: }`,
-			expectEnError: `multiple defaults in switch (first at main.xgo:1:31)`,
-			expectCnError: `switch 中有多个 default (第一个位于 main.xgo:1:31)`,
+			name:        "MultipleDefaultsInSwitch",
+			code:        `var n interface{}; switch n { default: default: }`,
+			wantEnError: `multiple defaults in switch (first at main.xgo:1:31)`,
+			wantCnError: `switch 中有多个 default (第一个位于 main.xgo:1:31)`,
 		},
 		{
-			name: "Duplicate case in type switch",
+			name: "DuplicateCaseInTypeSwitch",
 			code: `var n interface{} = 100; switch n.(type) { case int: case int: }`,
-			expectEnError: `duplicate case int in type switch
+			wantEnError: `duplicate case int in type switch
 	previous case at main.xgo:1:49`,
-			expectCnError: `switch 中重复的 case int
+			wantCnError: `switch 中重复的 case int
 	先前 case 位于 main.xgo:1:49`,
 		},
 		{
-			name:          "Multiple defaults in type switch",
-			code:          `var n interface{} = 100; switch n.(type) { default: default: }`,
-			expectEnError: `multiple defaults in type switch (first at main.xgo:1:44)`,
-			expectCnError: `switch 中有多个 default (第一个位于 main.xgo:1:44)`,
+			name:        "MultipleDefaultsInTypeSwitch",
+			code:        `var n interface{} = 100; switch n.(type) { default: default: }`,
+			wantEnError: `multiple defaults in type switch (first at main.xgo:1:44)`,
+			wantCnError: `switch 中有多个 default (第一个位于 main.xgo:1:44)`,
 		},
 
 		// 6. Data Structure Errors
 		{
-			name:          "Array literal bounds basic",
-			code:          `var a [3]int = [3]int{1, 2, 3, 4}`,
-			expectEnError: `array index 3 out of bounds [0:3]`,
-			expectCnError: `数组索引 3 超出范围 [0:3]`,
+			name:        "ArrayLiteralBoundsBasic",
+			code:        `var a [3]int = [3]int{1, 2, 3, 4}`,
+			wantEnError: `array index 3 out of bounds [0:3]`,
+			wantCnError: `数组索引 3 超出范围 [0:3]`,
 		},
 		{
-			name:          "Array literal bounds with index",
-			code:          `a := "Hi"; b := [10]int{9: 1, 3}`,
-			expectEnError: `array index 10 out of bounds [0:10]`,
-			expectCnError: `数组索引 10 超出范围 [0:10]`,
+			name:        "ArrayLiteralBoundsWithIndex",
+			code:        `a := "Hi"; b := [10]int{9: 1, 3}`,
+			wantEnError: `array index 10 out of bounds [0:10]`,
+			wantCnError: `数组索引 10 超出范围 [0:10]`,
 		},
 		{
-			name:          "Array literal bounds overflow",
-			code:          `a := "Hi"; b := [1]int{1, 2}`,
-			expectEnError: `array index 1 out of bounds [0:1]`,
-			expectCnError: `数组索引 1 超出范围 [0:1]`,
+			name:        "ArrayLiteralBoundsOverflow",
+			code:        `a := "Hi"; b := [1]int{1, 2}`,
+			wantEnError: `array index 1 out of bounds [0:1]`,
+			wantCnError: `数组索引 1 超出范围 [0:1]`,
 		},
 		{
-			name:          "Array index with value out of bounds",
-			code:          `a := "Hi"; b := [10]int{12: 2}`,
-			expectEnError: `array index 12 (value 12) out of bounds [0:10]`,
-			expectCnError: `数组索引 12 (值 12) 超出范围 [0:10]`,
+			name:        "ArrayIndexWithValueOutOfBounds",
+			code:        `a := "Hi"; b := [10]int{12: 2}`,
+			wantEnError: `array index 12 (value 12) out of bounds [0:10]`,
+			wantCnError: `数组索引 12 (值 12) 超出范围 [0:10]`,
 		},
 		{
-			name:          "Array literal type error",
-			code:          `a := "Hi"; b := [10]int{a+"!": 1}`,
-			expectEnError: `cannot use a+"!" as index which must be non-negative integer constant`,
-			expectCnError: `无法将 a+"!" 用作索引，索引必须是非负整数常量`,
+			name:        "ArrayLiteralTypeError",
+			code:        `a := "Hi"; b := [10]int{a+"!": 1}`,
+			wantEnError: `cannot use a+"!" as index which must be non-negative integer constant`,
+			wantCnError: `无法将 a+"!" 用作索引，索引必须是非负整数常量`,
 		},
 		{
-			name:          "Array index non-constant",
-			code:          `a := "Hi"; b := [10]int{a: 1}`,
-			expectEnError: `cannot use a as index which must be non-negative integer constant`,
-			expectCnError: `无法将 a 用作索引，索引必须是非负整数常量`,
+			name:        "ArrayIndexNonConstant",
+			code:        `a := "Hi"; b := [10]int{a: 1}`,
+			wantEnError: `cannot use a as index which must be non-negative integer constant`,
+			wantCnError: `无法将 a 用作索引，索引必须是非负整数常量`,
 		},
 		{
-			name:          "Non-constant array bound",
-			code:          `var n int; var a [n]int`,
-			expectEnError: `non-constant array bound n`,
-			expectCnError: `非常量 array bound n`,
+			name:        "NonConstantArrayBound",
+			code:        `var n int; var a [n]int`,
+			wantEnError: `non-constant array bound n`,
+			wantCnError: `非常量 array bound n`,
 		},
 		{
-			name:          "Slice literal index error",
-			code:          `a := "Hi"; b := []int{a: 1}`,
-			expectEnError: `cannot use a as index which must be non-negative integer constant`,
-			expectCnError: `无法将 a 用作索引，索引必须是非负整数常量`,
+			name:        "SliceLiteralIndexError",
+			code:        `a := "Hi"; b := []int{a: 1}`,
+			wantEnError: `cannot use a as index which must be non-negative integer constant`,
+			wantCnError: `无法将 a 用作索引，索引必须是非负整数常量`,
 		},
 		{
-			name:          "Slice literal type error",
-			code:          `a := "Hi"; b := []int{a}`,
-			expectEnError: `cannot use a (type string) as type int in slice literal`,
-			expectCnError: `无法将 a (类型 string) 用作类型 int 在 slice literal 中`,
+			name:        "SliceLiteralTypeError",
+			code:        `a := "Hi"; b := []int{a}`,
+			wantEnError: `cannot use a (type string) as type int in slice literal`,
+			wantCnError: `无法将 a (类型 string) 用作类型 int 在 slice literal 中`,
 		},
 		{
-			name:          "Slice literal indexed type error",
-			code:          `a := "Hi"; b := []int{2: a}`,
-			expectEnError: `cannot use a (type string) as type int in slice literal`,
-			expectCnError: `无法将 a (类型 string) 用作类型 int 在 slice literal 中`,
+			name:        "SliceLiteralIndexedTypeError",
+			code:        `a := "Hi"; b := []int{2: a}`,
+			wantEnError: `cannot use a (type string) as type int in slice literal`,
+			wantCnError: `无法将 a (类型 string) 用作类型 int 在 slice literal 中`,
 		},
 		{
-			name:          "Cannot slice pointer",
-			code:          `var a *byte; x := 1; b := a[x:2]`,
-			expectEnError: `cannot slice a (type *byte)`,
-			expectCnError: `无法切片 a (类型 *byte)`,
+			name:        "CannotSlicePointer",
+			code:        `var a *byte; x := 1; b := a[x:2]`,
+			wantEnError: `cannot slice a (type *byte)`,
+			wantCnError: `无法切片 a (类型 *byte)`,
 		},
 		{
-			name:          "Cannot slice bool",
-			code:          `a := true; b := a[1:2]`,
-			expectEnError: `cannot slice a (type bool)`,
-			expectCnError: `无法切片 a (类型 bool)`,
+			name:        "CannotSliceBool",
+			code:        `a := true; b := a[1:2]`,
+			wantEnError: `cannot slice a (type bool)`,
+			wantCnError: `无法切片 a (类型 bool)`,
 		},
 		{
-			name:          "Map literal missing key",
-			code:          `map[string]int{2}`,
-			expectEnError: `missing key in map literal`,
-			expectCnError: `映射字面量中缺少键`,
+			name:        "MapLiteralMissingKey",
+			code:        `map[string]int{2}`,
+			wantEnError: `missing key in map literal`,
+			wantCnError: `映射字面量中缺少键`,
 		},
 		{
-			name:          "Map literal key type error",
-			code:          `a := map[string]int{1+2: 2}`,
-			expectEnError: `cannot use 1+2 (type untyped int) as type string in map key`,
-			expectCnError: `无法将 1+2 (类型 untyped int) 用作类型 string 在 map key 中`,
+			name:        "MapLiteralKeyTypeError",
+			code:        `a := map[string]int{1+2: 2}`,
+			wantEnError: `cannot use 1+2 (type untyped int) as type string in map key`,
+			wantCnError: `无法将 1+2 (类型 untyped int) 用作类型 string 在 map key 中`,
 		},
 		{
-			name:          "Map literal value type error",
-			code:          `b := map[string]int{"Hi": "Go" + "+"}`,
-			expectEnError: `cannot use "Go" + "+" (type untyped string) as type int in map value`,
-			expectCnError: `无法将 "Go" + "+" (类型 untyped string) 用作类型 int 在 map value 中`,
+			name:        "MapLiteralValueTypeError",
+			code:        `b := map[string]int{"Hi": "Go" + "+"}`,
+			wantEnError: `cannot use "Go" + "+" (type untyped string) as type int in map value`,
+			wantCnError: `无法将 "Go" + "+" (类型 untyped string) 用作类型 int 在 map value 中`,
 		},
 		{
-			name:          "Invalid composite literal type",
-			code:          `int{2}`,
-			expectEnError: `invalid composite literal type int`,
-			expectCnError: `无效的复合字面量类型 int`,
+			name:        "InvalidCompositeLiteralType",
+			code:        `int{2}`,
+			wantEnError: `invalid composite literal type int`,
+			wantCnError: `无效的复合字面量类型 int`,
 		},
 		{
-			name:          "Invalid map literal",
-			code:          `var v any = {1:2,1}`,
-			expectEnError: `invalid map literal`,
-			expectCnError: `无效的映射字面量`,
+			name:        "InvalidMapLiteral",
+			code:        `var v any = {1:2,1}`,
+			wantEnError: `invalid map literal`,
+			wantCnError: `无效的映射字面量`,
 		},
 
 		// 7. Struct Errors
 		{
-			name:          "Struct too many values",
-			code:          `x := 1; a := struct{x int; y string}{1, "Hi", 2}`,
-			expectEnError: `too many values in struct{x int; y string}{...}`,
-			expectCnError: `struct{...} 中值的数量错误`,
+			name:        "StructTooManyValues",
+			code:        `x := 1; a := struct{x int; y string}{1, "Hi", 2}`,
+			wantEnError: `too many values in struct{x int; y string}{...}`,
+			wantCnError: `struct{...} 中值的数量错误`,
 		},
 		{
-			name:          "Struct too few values",
-			code:          `x := 1; a := struct{x int; y string}{1}`,
-			expectEnError: `too few values in struct{x int; y string}{...}`,
-			expectCnError: `struct{...} 中值的数量错误`,
+			name:        "StructTooFewValues",
+			code:        `x := 1; a := struct{x int; y string}{1}`,
+			wantEnError: `too few values in struct{x int; y string}{...}`,
+			wantCnError: `struct{...} 中值的数量错误`,
 		},
 		{
-			name:          "Struct field type mismatch",
-			code:          `x := 1; a := struct{x int; y string}{1, x}`,
-			expectEnError: `cannot use x (type int) as type string in value of field y`,
-			expectCnError: `无法将 x (类型 int) 用作类型 string 在 value of field y 中`,
+			name:        "StructFieldTypeMismatch",
+			code:        `x := 1; a := struct{x int; y string}{1, x}`,
+			wantEnError: `cannot use x (type int) as type string in value of field y`,
+			wantCnError: `无法将 x (类型 int) 用作类型 string 在 value of field y 中`,
 		},
 		{
-			name:          "Struct undefined field",
-			code:          `a := struct{x int; y string}{z: 1}`,
-			expectEnError: `z undefined (type struct{x int; y string} has no field or method z)`,
-			expectCnError: `z 未定义 (类型 struct{x int; y string} 没有字段或方法 z)`,
+			name:        "StructUndefinedField",
+			code:        `a := struct{x int; y string}{z: 1}`,
+			wantEnError: `z undefined (type struct{x int; y string} has no field or method z)`,
+			wantCnError: `z 未定义 (类型 struct{x int; y string} 没有字段或方法 z)`,
 		},
 		{
-			name:          "Struct field access undefined",
-			code:          `a := struct{x int; y string}{}; a.z = 1`,
-			expectEnError: `a.z undefined (type struct{x int; y string} has no field or method z)`,
-			expectCnError: `a.z 未定义 (类型 struct{x int; y string} 没有字段或方法 z)`,
+			name:        "StructFieldAccessUndefined",
+			code:        `a := struct{x int; y string}{}; a.z = 1`,
+			wantEnError: `a.z undefined (type struct{x int; y string} has no field or method z)`,
+			wantCnError: `a.z 未定义 (类型 struct{x int; y string} 没有字段或方法 z)`,
 		},
 
 		// 8. Package Import Errors
 		{
-			name:          "Undefined package in type",
-			code:          `func foo(t *testing.T) {}`,
-			expectEnError: `undefined: testing`,
-			expectCnError: `未定义: testing`,
+			name:        "UndefinedPackageInType",
+			code:        `func foo(t *testing.T) {}`,
+			wantEnError: `undefined: testing`,
+			wantCnError: `未定义: testing`,
 		},
 		{
-			name:          "Package field not a type",
-			code:          `import "testing"; func foo(t testing.Verbose) {}`,
-			expectEnError: `testing.Verbose is not a type`,
-			expectCnError: `testing.Verbose 不是一个类型`,
+			name:        "PackageFieldNotAType",
+			code:        `import "testing"; func foo(t testing.Verbose) {}`,
+			wantEnError: `testing.Verbose is not a type`,
+			wantCnError: `testing.Verbose 不是一个类型`,
 		},
 		{
-			name:          "Cannot refer to unexported name",
-			code:          `import "os"; func foo() { os.undefined }`,
-			expectEnError: `cannot refer to unexported name os.undefined`,
-			expectCnError: `无法引用未导出的名称 os.undefined`,
+			name:        "CannotReferToUnexportedName",
+			code:        `import "os"; func foo() { os.undefined }`,
+			wantEnError: `cannot refer to unexported name os.undefined`,
+			wantCnError: `无法引用未导出的名称 os.undefined`,
 		},
 		{
-			name:          "Undefined exported name",
-			code:          `import "os"; func foo() { os.UndefinedObject }`,
-			expectEnError: `undefined: os.UndefinedObject`,
-			expectCnError: `未定义: os.UndefinedObject`,
+			name:        "UndefinedExportedName",
+			code:        `import "os"; func foo() { os.UndefinedObject }`,
+			wantEnError: `undefined: os.UndefinedObject`,
+			wantCnError: `未定义: os.UndefinedObject`,
 		},
 
 		// 9. Pointer Operation Errors
 		{
-			name:          "Invalid indirect of string",
-			code:          `a := "test"; b := *a`,
-			expectEnError: `invalid indirect of a (type string)`,
-			expectCnError: `无效的间接引用 a (类型 string)`,
+			name:        "InvalidIndirectOfString",
+			code:        `a := "test"; b := *a`,
+			wantEnError: `invalid indirect of a (type string)`,
+			wantCnError: `无效的间接引用 a (类型 string)`,
 		},
 
 		// 11. Lambda Expression Errors
 		// Note: These may require specific XGo syntax support
 		{
-			name:          "Lambda multiple assignment",
-			code:          `var foo, foo1 func() = nil, => {}`, // XGo Lambda syntax
-			expectEnError: `lambda unsupport multiple assignment`,
-			expectCnError: `lambda 不支持多重赋值`,
+			name:        "LambdaMultipleAssignment",
+			code:        `var foo, foo1 func() = nil, => {}`, // XGo Lambda syntax
+			wantEnError: `lambda unsupport multiple assignment`,
+			wantCnError: `lambda 不支持多重赋值`,
 		},
 
 		// 12. Invalid Operations
 		{
-			name:          "Invalid operation indexing bool",
-			code:          `a := true; b := a[1]`,
-			expectEnError: `invalid operation: a[1] (type bool does not support indexing)`,
-			expectCnError: `无效操作: a[1] (类型 bool 不支持 indexing)`,
+			name:        "InvalidOperationIndexingBool",
+			code:        `a := true; b := a[1]`,
+			wantEnError: `invalid operation: a[1] (type bool does not support indexing)`,
+			wantCnError: `无效操作: a[1] (类型 bool 不支持 indexing)`,
 		},
 	}
 
@@ -554,24 +554,24 @@ func main() {
 			// Compile the code and get the actual error message
 			actualError := compileAndGetError(tt.code)
 
-			// Skip test if we couldn't get the expected error
+			// Skip test if we couldn't get the wanted error
 			if actualError == "" {
-				t.Skipf("Could not reproduce expected error for code: %s", tt.code)
+				t.Skipf("Could not reproduce wanted error for code: %s", tt.code)
 				return
 			}
 
-			// Check if we got the expected error message
-			if tt.expectEnError != "" && actualError != tt.expectEnError {
-				assert.Equal(t, tt.expectEnError, actualError, "Got different error than expected")
+			// Check if we got the wanted error message
+			if tt.wantEnError != "" && actualError != tt.wantEnError {
+				assert.Equal(t, tt.wantEnError, actualError, "got different error than wanted")
 			}
 
 			translator := NewTranslator()
 			// Test Chinese translation
 			cnResult := translator.Translate(actualError, LanguageCN)
 
-			// Check if the translated message equals expected Chinese terms
-			if tt.expectCnError != "" && cnResult != tt.expectCnError {
-				assert.Equal(t, tt.expectCnError, cnResult, "Chinese translation doesn't match expected term")
+			// Check if the translated message equals wanted Chinese terms
+			if tt.wantCnError != "" && cnResult != tt.wantCnError {
+				assert.Equal(t, tt.wantCnError, cnResult, "Chinese translation doesn't match wanted term")
 			}
 		})
 	}
@@ -580,7 +580,7 @@ func main() {
 // compileAndGetError compiles the given xgo code and returns the first error message
 func compileAndGetError(code string) string {
 	// Import necessary packages for compilation
-	gofset := gotoken.NewFileSet()
+	gofset := token.NewFileSet()
 
 	// Create files map
 	files := map[string]*xgo.File{

--- a/internal/analysis/passes/appends/appends_test.go
+++ b/internal/analysis/passes/appends/appends_test.go
@@ -1,7 +1,7 @@
 package appends
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +14,7 @@ import (
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
 	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
 	"github.com/goplus/xgolsw/internal/analysis/protocol"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 )
 
 func TestAppends(t *testing.T) {
@@ -24,7 +24,7 @@ func TestAppends(t *testing.T) {
 		wantDiag bool
 	}{
 		{
-			name: "append without values",
+			name: "AppendWithoutValues",
 			src: `
 var s []int
 _ = append(s)
@@ -32,7 +32,7 @@ _ = append(s)
 			wantDiag: true,
 		},
 		{
-			name: "append with values",
+			name: "AppendWithValues",
 			src: `
 var s []int
 _ = append(s, 1)
@@ -48,19 +48,19 @@ _ = append(s, 1)
 			f, err := parser.ParseFile(fset, "test.xgo", tt.src, parser.ParseComments)
 			require.NoError(t, err)
 
-			info := &xgotypes.Info{
+			info := &types.Info{
 				Info: typesutil.Info{
-					Types: make(map[ast.Expr]types.TypeAndValue),
-					Defs:  make(map[*ast.Ident]types.Object),
-					Uses:  make(map[*ast.Ident]types.Object),
+					Types: make(map[ast.Expr]gotypes.TypeAndValue),
+					Defs:  make(map[*ast.Ident]gotypes.Object),
+					Uses:  make(map[*ast.Ident]gotypes.Object),
 				},
 			}
 
 			checker := typesutil.NewChecker(
-				&types.Config{},
+				&gotypes.Config{},
 				&typesutil.Config{
 					Fset:  fset,
-					Types: types.NewPackage("test", "test"),
+					Types: gotypes.NewPackage("test", "test"),
 				},
 				nil,
 				&info.Info,
@@ -86,7 +86,11 @@ _ = append(s, 1)
 			_, err = Analyzer.Run(pass)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.wantDiag, len(diagnostics) > 0)
+			if tt.wantDiag {
+				assert.NotEmpty(t, diagnostics)
+			} else {
+				assert.Empty(t, diagnostics)
+			}
 		})
 	}
 }

--- a/internal/analysis/passes/internal/analysisutil/util.go
+++ b/internal/analysis/passes/internal/analysisutil/util.go
@@ -4,9 +4,10 @@ package analysisutil
 
 import (
 	"fmt"
-	"go/parser"
-	"go/token"
+	goparser "go/parser"
 	"strings"
+
+	"github.com/goplus/xgo/token"
 )
 
 // MustExtractDoc is like [ExtractDoc] but it panics on error.
@@ -89,7 +90,7 @@ func ExtractDoc(content, name string) (string, error) {
 		return "", fmt.Errorf("empty XGo source file")
 	}
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "", content, parser.ParseComments|parser.PackageClauseOnly)
+	f, err := goparser.ParseFile(fset, "", content, goparser.ParseComments|goparser.PackageClauseOnly)
 	if err != nil {
 		return "", fmt.Errorf("not an XGo source file")
 	}

--- a/internal/analysis/passes/internal/typeutil/typeutil.go
+++ b/internal/analysis/passes/internal/typeutil/typeutil.go
@@ -1,19 +1,19 @@
 package typeutil
 
 import (
-	"go/types"
+	gotypes "go/types"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/internal/analysis/ast/astutil"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 )
 
 // Callee returns the named target of a function call, if any:
 // a function, method, builtin, or variable.
 //
 // Functions and methods may potentially have type parameters.
-func Callee(info *xgotypes.Info, call *ast.CallExpr) types.Object {
+func Callee(info *types.Info, call *ast.CallExpr) gotypes.Object {
 	fun := astutil.Unparen(call.Fun)
 
 	// Look through type instantiation if necessary.
@@ -27,7 +27,7 @@ func Callee(info *xgotypes.Info, call *ast.CallExpr) types.Object {
 		fun, _, _, _ = UnpackIndexExpr(fun)
 	}
 
-	var obj types.Object
+	var obj gotypes.Object
 	switch fun := fun.(type) {
 	case *ast.Ident:
 		obj = info.Uses[fun] // type, var, builtin, or declared func
@@ -38,11 +38,11 @@ func Callee(info *xgotypes.Info, call *ast.CallExpr) types.Object {
 			obj = info.Uses[fun.Sel] // qualified identifier?
 		}
 	}
-	if _, ok := obj.(*types.TypeName); ok {
+	if _, ok := obj.(*gotypes.TypeName); ok {
 		return nil // T(x) is a conversion, not a call
 	}
 	// A Func is required to match instantiations.
-	if _, ok := obj.(*types.Func); isInstance && !ok {
+	if _, ok := obj.(*gotypes.Func); isInstance && !ok {
 		return nil // Was not a Func.
 	}
 	return obj
@@ -53,8 +53,8 @@ func Callee(info *xgotypes.Info, call *ast.CallExpr) types.Object {
 //
 // Note: for calls of instantiated functions and methods, StaticCallee returns
 // the corresponding generic function or method on the generic type.
-func StaticCallee(info *xgotypes.Info, call *ast.CallExpr) *types.Func {
-	if f, ok := Callee(info, call).(*types.Func); ok && !interfaceMethod(f) {
+func StaticCallee(info *types.Info, call *ast.CallExpr) *gotypes.Func {
+	if f, ok := Callee(info, call).(*gotypes.Func); ok && !interfaceMethod(f) {
 		return f
 	}
 	return nil
@@ -79,7 +79,7 @@ func UnpackIndexExpr(n ast.Node) (x ast.Expr, lbrack token.Pos, indices []ast.Ex
 	return nil, token.NoPos, nil, token.NoPos
 }
 
-func interfaceMethod(f *types.Func) bool {
-	recv := f.Type().(*types.Signature).Recv()
-	return recv != nil && types.IsInterface(recv.Type())
+func interfaceMethod(f *gotypes.Func) bool {
+	recv := f.Type().(*gotypes.Signature).Recv()
+	return recv != nil && gotypes.IsInterface(recv.Type())
 }

--- a/internal/analysis/passes/propertyname/propertyname.go
+++ b/internal/analysis/passes/propertyname/propertyname.go
@@ -2,7 +2,7 @@ package propertyname
 
 import (
 	_ "embed"
-	"go/types"
+	gotypes "go/types"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
@@ -46,7 +46,7 @@ func run(pass *protocol.Pass) (any, error) {
 		}
 
 		xgoutil.WalkCallExprArgs(pass.TypesInfo, call,
-			func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
+			func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 				param := params.At(paramIndex)
 				if !pass.IsPropertyNameType(param.Type()) {
 					return true

--- a/internal/analysis/passes/propertyname/propertyname_test.go
+++ b/internal/analysis/passes/propertyname/propertyname_test.go
@@ -1,7 +1,7 @@
 package propertyname
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,11 +14,11 @@ import (
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
 	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
 	"github.com/goplus/xgolsw/internal/analysis/protocol"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 )
 
 type propertynameCallbacks struct {
-	isPropertyNameType      func(types.Type) bool
+	isPropertyNameType      func(gotypes.Type) bool
 	getPropertyNamesForCall func(*ast.CallExpr) []string
 }
 
@@ -30,7 +30,7 @@ func TestPropertyname(t *testing.T) {
 		wantDiag  bool
 	}{
 		{
-			name: "unknown property literal",
+			name: "UnknownPropertyLiteral",
 			src: `
 package test
 
@@ -43,8 +43,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ types.Type) bool {
-					named, ok := types.Unalias(typ).(*types.Named)
+				isPropertyNameType: func(typ gotypes.Type) bool {
+					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
 					return ok && named.Obj().Name() == "PropertyName"
 				},
 				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
@@ -54,7 +54,7 @@ func run() {
 			wantDiag: true,
 		},
 		{
-			name: "known property literal",
+			name: "KnownPropertyLiteral",
 			src: `
 package test
 
@@ -67,8 +67,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ types.Type) bool {
-					named, ok := types.Unalias(typ).(*types.Named)
+				isPropertyNameType: func(typ gotypes.Type) bool {
+					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
 					return ok && named.Obj().Name() == "PropertyName"
 				},
 				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
@@ -78,7 +78,7 @@ func run() {
 			wantDiag: false,
 		},
 		{
-			name: "const identifier argument",
+			name: "ConstIdentifierArgument",
 			src: `
 package test
 
@@ -93,8 +93,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ types.Type) bool {
-					named, ok := types.Unalias(typ).(*types.Named)
+				isPropertyNameType: func(typ gotypes.Type) bool {
+					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
 					return ok && named.Obj().Name() == "PropertyName"
 				},
 				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
@@ -104,7 +104,7 @@ func run() {
 			wantDiag: true,
 		},
 		{
-			name: "non constant identifier argument",
+			name: "NonConstantIdentifierArgument",
 			src: `
 package test
 
@@ -119,8 +119,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ types.Type) bool {
-					named, ok := types.Unalias(typ).(*types.Named)
+				isPropertyNameType: func(typ gotypes.Type) bool {
+					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
 					return ok && named.Obj().Name() == "PropertyName"
 				},
 				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
@@ -130,7 +130,7 @@ func run() {
 			wantDiag: false,
 		},
 		{
-			name: "nil IsPropertyNameType callback",
+			name: "NilIsPropertyNameTypeCallback",
 			src: `
 package test
 
@@ -151,7 +151,7 @@ func run() {
 			wantDiag: false,
 		},
 		{
-			name: "nil GetPropertyNamesForCall callback",
+			name: "NilGetPropertyNamesForCallCallback",
 			src: `
 package test
 
@@ -164,8 +164,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ types.Type) bool {
-					named, ok := types.Unalias(typ).(*types.Named)
+				isPropertyNameType: func(typ gotypes.Type) bool {
+					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
 					return ok && named.Obj().Name() == "PropertyName"
 				},
 				getPropertyNamesForCall: nil,
@@ -173,7 +173,7 @@ func run() {
 			wantDiag: false,
 		},
 		{
-			name: "nil return from GetPropertyNamesForCall skips validation",
+			name: "NilReturnFromGetPropertyNamesForCallSkipsValidation",
 			src: `
 package test
 
@@ -186,8 +186,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ types.Type) bool {
-					named, ok := types.Unalias(typ).(*types.Named)
+				isPropertyNameType: func(typ gotypes.Type) bool {
+					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
 					return ok && named.Obj().Name() == "PropertyName"
 				},
 				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
@@ -197,7 +197,7 @@ func run() {
 			wantDiag: false,
 		},
 		{
-			name: "empty return from GetPropertyNamesForCall reports all properties unknown",
+			name: "EmptyReturnFromGetPropertyNamesForCallReportsAllPropertiesUnknown",
 			src: `
 package test
 
@@ -210,8 +210,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ types.Type) bool {
-					named, ok := types.Unalias(typ).(*types.Named)
+				isPropertyNameType: func(typ gotypes.Type) bool {
+					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
 					return ok && named.Obj().Name() == "PropertyName"
 				},
 				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
@@ -225,7 +225,11 @@ func run() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			diagnostics := runPropertynameAnalyzer(t, tt.src, tt.callbacks)
-			assert.Equal(t, tt.wantDiag, len(diagnostics) > 0)
+			if tt.wantDiag {
+				assert.NotEmpty(t, diagnostics)
+			} else {
+				assert.Empty(t, diagnostics)
+			}
 		})
 	}
 }
@@ -237,19 +241,19 @@ func runPropertynameAnalyzer(t *testing.T, src string, callbacks propertynameCal
 	f, err := parser.ParseFile(fset, "test.xgo", src, parser.ParseComments)
 	require.NoError(t, err)
 
-	info := &xgotypes.Info{
+	info := &types.Info{
 		Info: typesutil.Info{
-			Types: make(map[ast.Expr]types.TypeAndValue),
-			Defs:  make(map[*ast.Ident]types.Object),
-			Uses:  make(map[*ast.Ident]types.Object),
+			Types: make(map[ast.Expr]gotypes.TypeAndValue),
+			Defs:  make(map[*ast.Ident]gotypes.Object),
+			Uses:  make(map[*ast.Ident]gotypes.Object),
 		},
 	}
 
 	checker := typesutil.NewChecker(
-		&types.Config{},
+		&gotypes.Config{},
 		&typesutil.Config{
 			Fset:  fset,
-			Types: types.NewPackage("test", "test"),
+			Types: gotypes.NewPackage("test", "test"),
 		},
 		nil,
 		&info.Info,

--- a/internal/analysis/protocol/analysis.go
+++ b/internal/analysis/protocol/analysis.go
@@ -3,12 +3,12 @@ package protocol
 import (
 	"flag"
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"reflect"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -90,14 +90,14 @@ type Pass struct {
 	Analyzer *Analyzer // the identity of the current analyzer
 
 	// syntax and type information
-	Fset         *token.FileSet // file position information; Run may add new files
-	Files        []*ast.File    // the abstract syntax tree of each file
-	OtherFiles   []string       // names of non-Go files of this package
-	IgnoredFiles []string       // names of ignored source files in this package
-	Pkg          *types.Package // type information about the package
-	TypesInfo    *xgotypes.Info // type information about the syntax trees
-	TypesSizes   types.Sizes    // function for computing sizes of types
-	TypeErrors   []types.Error  // type errors (only if Analyzer.RunDespiteErrors)
+	Fset         *token.FileSet   // file position information; Run may add new files
+	Files        []*ast.File      // the abstract syntax tree of each file
+	OtherFiles   []string         // names of non-Go files of this package
+	IgnoredFiles []string         // names of ignored source files in this package
+	Pkg          *gotypes.Package // type information about the package
+	TypesInfo    *types.Info      // type information about the syntax trees
+	TypesSizes   gotypes.Sizes    // function for computing sizes of types
+	TypeErrors   []gotypes.Error  // type errors (only if Analyzer.RunDespiteErrors)
 
 	// Report reports a Diagnostic, a finding about a specific location
 	// in the analyzed source code such as a potential mistake.
@@ -115,7 +115,7 @@ type Pass struct {
 	// property name type (i.e., a type whose string value must be a valid
 	// property name). This is provided by the driver and keeps analyzers
 	// decoupled from spx-specific knowledge.
-	IsPropertyNameType func(typ types.Type) bool
+	IsPropertyNameType func(typ gotypes.Type) bool
 
 	// GetPropertyNamesForCall, if non-nil, returns the set of valid property
 	// names for the receiver of the given call expression. The driver is
@@ -145,12 +145,12 @@ type Pass struct {
 	//
 	// ImportObjectFact panics if called after the pass is complete.
 	// ImportObjectFact is not concurrency-safe.
-	ImportObjectFact func(obj types.Object, fact Fact) bool
+	ImportObjectFact func(obj gotypes.Object, fact Fact) bool
 
 	// ImportPackageFact retrieves a fact associated with package pkg,
 	// which must be this package or one of its dependencies.
 	// See comments for ImportObjectFact.
-	ImportPackageFact func(pkg *types.Package, fact Fact) bool
+	ImportPackageFact func(pkg *gotypes.Package, fact Fact) bool
 
 	// ExportObjectFact associates a fact of type *T with the obj,
 	// replacing any previous fact of that type.
@@ -158,7 +158,7 @@ type Pass struct {
 	// ExportObjectFact panics if it is called after the pass is
 	// complete, or if obj does not belong to the package being analyzed.
 	// ExportObjectFact is not concurrency-safe.
-	ExportObjectFact func(obj types.Object, fact Fact)
+	ExportObjectFact func(obj gotypes.Object, fact Fact)
 
 	// ExportPackageFact associates a fact with the current package.
 	// See comments for ExportObjectFact.
@@ -177,13 +177,13 @@ type Pass struct {
 
 // PackageFact is a package together with an associated fact.
 type PackageFact struct {
-	Package *types.Package
+	Package *gotypes.Package
 	Fact    Fact
 }
 
 // ObjectFact is an object together with an associated fact.
 type ObjectFact struct {
-	Object types.Object
+	Object gotypes.Object
 	Fact   Fact
 }
 

--- a/internal/importer.go
+++ b/internal/importer.go
@@ -2,10 +2,10 @@ package internal
 
 import (
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"sync"
 
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/internal/pkgdata"
 	"golang.org/x/tools/go/gcexportdata"
 )
@@ -13,22 +13,22 @@ import (
 // importer implements [types.Importer].
 type importer struct {
 	mu     sync.Mutex
-	fset   *xgotoken.FileSet
-	loaded map[string]*types.Package
+	fset   *token.FileSet
+	loaded map[string]*gotypes.Package
 }
 
 // newImporter creates a new instance of [importer].
 func newImporter() *importer {
-	loaded := make(map[string]*types.Package)
-	loaded["unsafe"] = types.Unsafe
+	loaded := make(map[string]*gotypes.Package)
+	loaded["unsafe"] = gotypes.Unsafe
 	return &importer{
-		fset:   xgotoken.NewFileSet(),
+		fset:   token.NewFileSet(),
 		loaded: loaded,
 	}
 }
 
 // Import implements [types.Importer].
-func (imp *importer) Import(path string) (*types.Package, error) {
+func (imp *importer) Import(path string) (*gotypes.Package, error) {
 	imp.mu.Lock()
 	defer imp.mu.Unlock()
 

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -4,14 +4,14 @@ import (
 	"cmp"
 	"encoding/json"
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"slices"
 	"strconv"
 	"strings"
 	"unicode"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/internal/pkgdata"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
@@ -167,14 +167,14 @@ func (s *Server) xgoGetProperties(params XGoGetPropertiesParams) ([]XGoProperty,
 	}
 
 	// Get the type of the object
-	var namedType *types.Named
+	var namedType *gotypes.Named
 	switch obj := obj.(type) {
-	case *types.TypeName:
+	case *gotypes.TypeName:
 		// If it's a type name (e.g., "Game"), get its underlying type
 		// Unalias to handle type aliases (e.g., type MyGame = Game)
-		typ := types.Unalias(obj.Type())
+		typ := gotypes.Unalias(obj.Type())
 		typ = xgoutil.DerefType(typ)
-		if named, ok := typ.(*types.Named); ok {
+		if named, ok := typ.(*gotypes.Named); ok {
 			namedType = named
 		} else {
 			return nil, fmt.Errorf("target %q is not a named type", params.Target)
@@ -184,7 +184,7 @@ func (s *Server) xgoGetProperties(params XGoGetPropertiesParams) ([]XGoProperty,
 	}
 
 	// Get underlying struct type
-	if _, ok := namedType.Underlying().(*types.Struct); !ok {
+	if _, ok := namedType.Underlying().(*gotypes.Struct); !ok {
 		return nil, fmt.Errorf("target %q is not a struct type", params.Target)
 	}
 
@@ -192,7 +192,7 @@ func (s *Server) xgoGetProperties(params XGoGetPropertiesParams) ([]XGoProperty,
 
 	properties := []XGoProperty{}
 	seenNames := make(map[string]bool)
-	collectPropertiesFromNamedType(namedType, mainPkgDoc, make(map[*types.Named]bool), seenNames, &properties)
+	collectPropertiesFromNamedType(namedType, mainPkgDoc, make(map[*gotypes.Named]bool), seenNames, &properties)
 
 	slices.SortStableFunc(properties, func(a, b XGoProperty) int {
 		if p1, p2 := xgoPropertyKindPriority[a.Kind], xgoPropertyKindPriority[b.Kind]; p1 != p2 {
@@ -210,7 +210,7 @@ type propertyMember struct {
 	// Name is the property name (lowerCamelCase for methods, original for fields).
 	Name string
 	// Type is the property's value type.
-	Type types.Type
+	Type gotypes.Type
 	// Kind indicates whether the property comes from a field or a method.
 	Kind XGoPropertyKind
 	// SpxDef is the full spx definition for the member.
@@ -222,13 +222,13 @@ type propertyMember struct {
 // outer-scope-first order. Outer (less deeply nested) members shadow embedded
 // ones with the same name. visited prevents infinite recursion for cyclic
 // embeddings; seenNames tracks already-yielded property names.
-func walkPropertyMembers(namedType *types.Named, pkgDocFor func(*types.Package) *pkgdoc.PkgDoc, visited map[*types.Named]bool, seenNames map[string]bool, onMember func(propertyMember)) {
+func walkPropertyMembers(namedType *gotypes.Named, pkgDocFor func(*gotypes.Package) *pkgdoc.PkgDoc, visited map[*gotypes.Named]bool, seenNames map[string]bool, onMember func(propertyMember)) {
 	if visited[namedType] {
 		return
 	}
 	visited[namedType] = true
 
-	structType, ok := namedType.Underlying().(*types.Struct)
+	structType, ok := namedType.Underlying().(*gotypes.Struct)
 	if !ok {
 		return
 	}
@@ -237,11 +237,11 @@ func walkPropertyMembers(namedType *types.Named, pkgDocFor func(*types.Package) 
 
 	// Single pass over fields: yield direct property fields and collect
 	// embedded types for later recursion, so each field is visited only once.
-	var embeddedTypes []*types.Named
+	var embeddedTypes []*gotypes.Named
 	for field := range structType.Fields() {
 		if field.Embedded() {
-			embeddedType := types.Unalias(xgoutil.DerefType(field.Type()))
-			if embNamed, ok := embeddedType.(*types.Named); ok {
+			embeddedType := gotypes.Unalias(xgoutil.DerefType(field.Type()))
+			if embNamed, ok := embeddedType.(*gotypes.Named); ok {
 				embeddedTypes = append(embeddedTypes, embNamed)
 			}
 			continue
@@ -272,7 +272,7 @@ func walkPropertyMembers(namedType *types.Named, pkgDocFor func(*types.Package) 
 			continue
 		}
 		seenNames[name] = true
-		sig := method.Type().(*types.Signature)
+		sig := method.Type().(*gotypes.Signature)
 		onMember(propertyMember{
 			Name:   name,
 			Type:   sig.Results().At(0).Type(),
@@ -290,8 +290,8 @@ func walkPropertyMembers(namedType *types.Named, pkgDocFor func(*types.Package) 
 // makePkgDocFor returns a function that resolves the [pkgdoc.PkgDoc] for a
 // given package, using mainPkgDoc for the main package and pre-built package
 // data for all others.
-func makePkgDocFor(mainPkgDoc *pkgdoc.PkgDoc) func(*types.Package) *pkgdoc.PkgDoc {
-	return func(pkg *types.Package) *pkgdoc.PkgDoc {
+func makePkgDocFor(mainPkgDoc *pkgdoc.PkgDoc) func(*gotypes.Package) *pkgdoc.PkgDoc {
+	return func(pkg *gotypes.Package) *pkgdoc.PkgDoc {
 		if xgoutil.IsMainPkg(pkg) {
 			return mainPkgDoc
 		}
@@ -302,7 +302,7 @@ func makePkgDocFor(mainPkgDoc *pkgdoc.PkgDoc) func(*types.Package) *pkgdoc.PkgDo
 
 // collectPropertiesFromNamedType recursively collects properties from a named
 // type into properties, using walkPropertyMembers for the traversal.
-func collectPropertiesFromNamedType(namedType *types.Named, mainPkgDoc *pkgdoc.PkgDoc, visited map[*types.Named]bool, seenNames map[string]bool, properties *[]XGoProperty) {
+func collectPropertiesFromNamedType(namedType *gotypes.Named, mainPkgDoc *pkgdoc.PkgDoc, visited map[*gotypes.Named]bool, seenNames map[string]bool, properties *[]XGoProperty) {
 	walkPropertyMembers(namedType, makePkgDocFor(mainPkgDoc), visited, seenNames, func(m propertyMember) {
 		*properties = append(*properties, XGoProperty{
 			Name:       m.Name,
@@ -318,22 +318,22 @@ func collectPropertiesFromNamedType(namedType *types.Named, mainPkgDoc *pkgdoc.P
 // Returns true if:
 // - The field is not embedded
 // - The field type is a basic type (int, float64, string, etc.), spx.Value, or spx.List
-func isPropertyField(field *types.Var) bool {
+func isPropertyField(field *gotypes.Var) bool {
 	if field.Embedded() {
 		return false
 	}
 
-	fieldType := types.Unalias(xgoutil.DerefType(field.Type()))
+	fieldType := gotypes.Unalias(xgoutil.DerefType(field.Type()))
 
 	// Allow basic types (int, float64, string, bool, etc.)
-	if _, ok := fieldType.(*types.Basic); ok {
+	if _, ok := fieldType.(*gotypes.Basic); ok {
 		if pkg := field.Pkg(); pkg != nil && pkg.Name() == "main" {
 			return true
 		}
 	}
 
 	// Allow spx.Value and spx.List
-	if named, ok := fieldType.(*types.Named); ok {
+	if named, ok := fieldType.(*gotypes.Named); ok {
 		if pkg := named.Obj().Pkg(); pkg != nil && pkg.Path() == SpxPkgPath {
 			name := named.Obj().Name()
 			if name == "Value" || name == "List" {
@@ -353,7 +353,7 @@ func isPropertyField(field *types.Var) bool {
 //   - The method has exactly one return value
 //   - The return type is a basic type (int, float64, string, etc.), or a named
 //     type from github.com/goplus/spx/v2 named "Value" or "List"
-func isPropertyMethod(method *types.Func) bool {
+func isPropertyMethod(method *gotypes.Func) bool {
 	// Skip XGo_ methods (internal methods)
 	if strings.HasPrefix(method.Name(), "XGo_") {
 		return false
@@ -362,7 +362,7 @@ func isPropertyMethod(method *types.Func) bool {
 	if method.Name() != "" && unicode.IsLower(rune(method.Name()[0])) {
 		return false
 	}
-	sig, ok := method.Type().(*types.Signature)
+	sig, ok := method.Type().(*gotypes.Signature)
 	if !ok {
 		return false
 	}
@@ -372,11 +372,11 @@ func isPropertyMethod(method *types.Func) bool {
 	}
 
 	// The return type must be a basic type, spx.Value, or spx.List
-	retType := types.Unalias(xgoutil.DerefType(sig.Results().At(0).Type()))
-	if _, ok := retType.(*types.Basic); ok {
+	retType := gotypes.Unalias(xgoutil.DerefType(sig.Results().At(0).Type()))
+	if _, ok := retType.(*gotypes.Basic); ok {
 		return true
 	}
-	if named, ok := retType.(*types.Named); ok {
+	if named, ok := retType.(*gotypes.Named); ok {
 		if pkg := named.Obj().Pkg(); pkg != nil && pkg.Path() == SpxPkgPath {
 			name := named.Obj().Name()
 			if name == "Value" || name == "List" {
@@ -391,19 +391,19 @@ func isPropertyMethod(method *types.Func) bool {
 // This is useful for determining if a rename operation affects a property that may be
 // monitored by the IDE. Returns true if the object is a field or method that qualifies
 // as a property according to the same criteria used by xgoGetProperties.
-func isPropertyOfEnclosingType(obj types.Object) bool {
+func isPropertyOfEnclosingType(obj gotypes.Object) bool {
 	if obj == nil {
 		return false
 	}
 
 	// Check if the current object is a property (field or method)
 	switch obj := obj.(type) {
-	case *types.Var:
+	case *gotypes.Var:
 		if obj.IsField() {
 			// Check if this field is a property
 			return isPropertyField(obj)
 		}
-	case *types.Func:
+	case *gotypes.Func:
 		// Check if this method is a property
 		return isPropertyMethod(obj)
 	}
@@ -418,7 +418,7 @@ func isPropertyOfEnclosingType(obj types.Object) bool {
 //
 // Performance note: This function has O(N_types × N_fields_per_type) complexity.
 // For better performance in hot paths, consider caching results or using alternative approaches.
-func findEnclosingTypeForField(field *types.Var) *types.Named {
+func findEnclosingTypeForField(field *gotypes.Var) *gotypes.Named {
 	if field == nil || !field.IsField() {
 		return nil
 	}
@@ -439,17 +439,17 @@ func findEnclosingTypeForField(field *types.Var) *types.Named {
 			continue
 		}
 
-		typeName, ok := typeObj.(*types.TypeName)
+		typeName, ok := typeObj.(*gotypes.TypeName)
 		if !ok {
 			continue
 		}
 
-		namedType, ok := typeName.Type().(*types.Named)
+		namedType, ok := typeName.Type().(*gotypes.Named)
 		if !ok {
 			continue
 		}
 
-		structType, ok := namedType.Underlying().(*types.Struct)
+		structType, ok := namedType.Underlying().(*gotypes.Struct)
 		if !ok {
 			continue
 		}
@@ -470,14 +470,14 @@ func findEnclosingTypeForField(field *types.Var) *types.Named {
 // findEnclosingTypeForMethod finds the exact enclosing type for a given method.
 // This returns the receiver type of the method.
 // Returns the enclosing *types.Named if found, nil otherwise.
-func findEnclosingTypeForMethod(method *types.Func) *types.Named {
+func findEnclosingTypeForMethod(method *gotypes.Func) *gotypes.Named {
 	if method == nil {
 		return nil
 	}
 
 	// Note: According to go/types documentation, Func.Type() is always a *Signature.
 	// This check is defensive programming for potential internal errors.
-	sig, ok := method.Type().(*types.Signature)
+	sig, ok := method.Type().(*gotypes.Signature)
 	if !ok {
 		return nil
 	}
@@ -489,7 +489,7 @@ func findEnclosingTypeForMethod(method *types.Func) *types.Named {
 
 	// Dereference pointer receiver if needed
 	recvType := xgoutil.DerefType(recv.Type())
-	namedType, ok := recvType.(*types.Named)
+	namedType, ok := recvType.(*gotypes.Named)
 	if !ok {
 		return nil
 	}
@@ -500,17 +500,17 @@ func findEnclosingTypeForMethod(method *types.Func) *types.Named {
 // findEnclosingType finds the exact enclosing type for a given object.
 // Supports both fields and methods.
 // Returns the enclosing *types.Named if found, nil otherwise.
-func findEnclosingType(obj types.Object) *types.Named {
+func findEnclosingType(obj gotypes.Object) *gotypes.Named {
 	if obj == nil {
 		return nil
 	}
 
 	switch obj := obj.(type) {
-	case *types.Var:
+	case *gotypes.Var:
 		if obj.IsField() {
 			return findEnclosingTypeForField(obj)
 		}
-	case *types.Func:
+	case *gotypes.Func:
 		return findEnclosingTypeForMethod(obj)
 	}
 
@@ -518,7 +518,7 @@ func findEnclosingType(obj types.Object) *types.Named {
 }
 
 // findInputSlots finds all input slots in the AST file.
-func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot {
+func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -536,21 +536,21 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 		}
 	}
 
-	xgoast.Inspect(astFile, func(node xgoast.Node) bool {
+	ast.Inspect(astFile, func(node ast.Node) bool {
 		if node == nil {
 			return true
 		}
 
 		switch node := node.(type) {
-		case *xgoast.BranchStmt:
+		case *ast.BranchStmt:
 			if callExpr := xgoutil.CreateCallExprFromBranchStmt(typeInfo, node); callExpr != nil {
 				slots := findInputSlotsFromCallExpr(result, callExpr)
 				addInputSlots(slots...)
 			}
-		case *xgoast.CallExpr:
+		case *ast.CallExpr:
 			slots := findInputSlotsFromCallExpr(result, node)
 			addInputSlots(slots...)
-		case *xgoast.BinaryExpr:
+		case *ast.BinaryExpr:
 			leftSlot := checkValueInputSlot(result, node.X, nil)
 			if leftSlot != nil {
 				addInputSlots(*leftSlot)
@@ -560,12 +560,12 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 			if rightSlot != nil {
 				addInputSlots(*rightSlot)
 			}
-		case *xgoast.UnaryExpr:
+		case *ast.UnaryExpr:
 			slot := checkValueInputSlot(result, node.X, nil)
 			if slot != nil {
 				addInputSlots(*slot)
 			}
-		case *xgoast.AssignStmt:
+		case *ast.AssignStmt:
 			for _, lhs := range node.Lhs {
 				slot := checkAddressInputSlot(result, lhs)
 				if slot != nil {
@@ -574,7 +574,7 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 			}
 
 			for i, rhs := range node.Rhs {
-				var declaredType types.Type
+				var declaredType gotypes.Type
 				if len(node.Lhs) == len(node.Rhs) {
 					declaredType = typeInfo.TypeOf(node.Lhs[i])
 				}
@@ -584,9 +584,9 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 					addInputSlots(*slot)
 				}
 			}
-		case *xgoast.ForStmt:
+		case *ast.ForStmt:
 			if node.Init != nil {
-				if expr, ok := node.Init.(*xgoast.ExprStmt); ok {
+				if expr, ok := node.Init.(*ast.ExprStmt); ok {
 					slot := checkValueInputSlot(result, expr.X, nil)
 					if slot != nil {
 						addInputSlots(*slot)
@@ -595,23 +595,23 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 			}
 
 			if node.Cond != nil {
-				slot := checkValueInputSlot(result, node.Cond, types.Typ[types.Bool])
+				slot := checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool])
 				if slot != nil {
 					addInputSlots(*slot)
 				}
 			}
 
 			if node.Post != nil {
-				if expr, ok := node.Post.(*xgoast.ExprStmt); ok {
+				if expr, ok := node.Post.(*ast.ExprStmt); ok {
 					slot := checkValueInputSlot(result, expr.X, nil)
 					if slot != nil {
 						addInputSlots(*slot)
 					}
 				}
 			}
-		case *xgoast.ValueSpec:
+		case *ast.ValueSpec:
 			for i, value := range node.Values {
-				var declaredType types.Type
+				var declaredType gotypes.Type
 				if len(node.Names) == len(node.Values) {
 					nameIdent := node.Names[i]
 					if nameIdent != nil && nameIdent.Name != "_" {
@@ -627,33 +627,33 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 					addInputSlots(*slot)
 				}
 			}
-		case *xgoast.ReturnStmt:
+		case *ast.ReturnStmt:
 			for _, res := range node.Results {
 				slot := checkValueInputSlot(result, res, nil)
 				if slot != nil {
 					addInputSlots(*slot)
 				}
 			}
-		case *xgoast.IfStmt:
-			slot := checkValueInputSlot(result, node.Cond, types.Typ[types.Bool])
+		case *ast.IfStmt:
+			slot := checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool])
 			if slot != nil {
 				addInputSlots(*slot)
 			}
-		case *xgoast.SwitchStmt:
+		case *ast.SwitchStmt:
 			if node.Tag != nil {
 				slot := checkValueInputSlot(result, node.Tag, nil)
 				if slot != nil {
 					addInputSlots(*slot)
 				}
 			}
-		case *xgoast.CaseClause:
+		case *ast.CaseClause:
 			for _, expr := range node.List {
 				slot := checkValueInputSlot(result, expr, nil)
 				if slot != nil {
 					addInputSlots(*slot)
 				}
 			}
-		case *xgoast.RangeStmt:
+		case *ast.RangeStmt:
 			if node.Key != nil && !isBlank(node.Key) {
 				slot := checkAddressInputSlot(result, node.Key)
 				if slot != nil {
@@ -672,7 +672,7 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 			if slot != nil {
 				addInputSlots(*slot)
 			}
-		case *xgoast.IncDecStmt:
+		case *ast.IncDecStmt:
 			slot := checkAddressInputSlot(result, node.X)
 			if slot != nil {
 				addInputSlots(*slot)
@@ -685,21 +685,21 @@ func findInputSlots(result *compileResult, astFile *xgoast.File) []XGoInputSlot 
 }
 
 // findInputSlotsFromCallExpr finds input slots from a call expression.
-func findInputSlotsFromCallExpr(result *compileResult, callExpr *xgoast.CallExpr) []SpxInputSlot {
+func findInputSlotsFromCallExpr(result *compileResult, callExpr *ast.CallExpr) []SpxInputSlot {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 
 	var inputSlots []SpxInputSlot
-	xgoutil.WalkCallExprArgs(typeInfo, callExpr, func(fun *types.Func, params *types.Tuple, paramIndex int, arg xgoast.Expr, argIndex int) bool {
+	xgoutil.WalkCallExprArgs(typeInfo, callExpr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 		param := params.At(paramIndex)
 		if !param.Pos().IsValid() {
 			return true
 		}
 
 		declaredType := xgoutil.DerefType(param.Type())
-		if sliceType, ok := declaredType.(*types.Slice); ok {
+		if sliceType, ok := declaredType.(*gotypes.Slice); ok {
 			declaredType = xgoutil.DerefType(sliceType.Elem())
 		}
 
@@ -713,7 +713,7 @@ func findInputSlotsFromCallExpr(result *compileResult, callExpr *xgoast.CallExpr
 }
 
 // collectPredefinedNames collects all predefined names for the given expression.
-func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredType types.Type) []string {
+func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType gotypes.Type) []string {
 	typeInfo, _ := result.proj.TypeInfo()
 	astPkg, _ := result.proj.ASTPackage()
 	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, expr)
@@ -724,11 +724,11 @@ func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredTyp
 		names = slices.Grow(names, n)
 	}
 	seenNames := make(map[string]struct{})
-	addNameOf := func(obj types.Object) {
+	addNameOf := func(obj gotypes.Object) {
 		name := obj.Name()
 		switch obj.(type) {
-		case *types.Var, *types.Const:
-			if typ := obj.Type(); typ != nil && declaredType != nil && !types.AssignableTo(typ, declaredType) {
+		case *gotypes.Var, *gotypes.Const:
+			if typ := obj.Type(); typ != nil && declaredType != nil && !gotypes.AssignableTo(typ, declaredType) {
 				return
 			}
 
@@ -739,16 +739,16 @@ func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredTyp
 				strings.HasPrefix(name, "__gop_"):
 				return
 			}
-		case *types.Func:
+		case *gotypes.Func:
 			if declaredType != nil {
 				// For functions with no parameters and exactly one return value,
 				// check if the return type is assignable to the declared type.
-				funcSig := obj.Type().(*types.Signature)
+				funcSig := obj.Type().(*gotypes.Signature)
 				if funcSig.Params().Len() != 0 || funcSig.Results().Len() != 1 {
 					return
 				}
 				funcReturnType := funcSig.Results().At(0).Type()
-				if !types.AssignableTo(funcReturnType, declaredType) {
+				if !gotypes.AssignableTo(funcReturnType, declaredType) {
 					return
 				}
 			}
@@ -764,7 +764,7 @@ func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredTyp
 		names = append(names, name)
 	}
 
-	for scope := innermostScope; scope != nil && scope != types.Universe; scope = scope.Parent() {
+	for scope := innermostScope; scope != nil && scope != gotypes.Universe; scope = scope.Parent() {
 		growNames(len(scope.Names()))
 		for _, name := range scope.Names() {
 			obj := scope.Lookup(name)
@@ -775,28 +775,28 @@ func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredTyp
 
 			if scope != innermostScope || obj.Pos() < expr.Pos() {
 				switch obj.(type) {
-				case *types.Var, *types.Const:
+				case *gotypes.Var, *gotypes.Const:
 					addNameOf(obj)
 				}
 			}
 
 			if astFile.IsClass && xgoutil.IsSyntheticThisIdent(result.proj.Fset, typeInfo, astPkg, defIdent) {
 				objType := xgoutil.DerefType(obj.Type())
-				named, ok := objType.(*types.Named)
+				named, ok := objType.(*gotypes.Named)
 				if !ok || !xgoutil.IsNamedStructType(named) {
 					continue
 				}
 
-				xgoutil.WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+				xgoutil.WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 					switch member := member.(type) {
-					case *types.Var:
+					case *gotypes.Var:
 						if !member.Origin().Embedded() {
 							addNameOf(member)
 						}
-					case *types.Func:
+					case *gotypes.Func:
 						// Add methods with no parameters and exactly one return value.
 						// For example, the method `Game.BackdropName` can be used in `echo backdropname`.
-						funcSig := member.Type().(*types.Signature)
+						funcSig := member.Type().(*gotypes.Signature)
 						if funcSig.Params().Len() == 0 && funcSig.Results().Len() == 1 {
 							addNameOf(member)
 						}
@@ -807,10 +807,10 @@ func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredTyp
 		}
 	}
 
-	for _, scope := range []*types.Scope{
+	for _, scope := range []*gotypes.Scope{
 		GetSpxPkg().Scope(),
 		GetMathPkg().Scope(),
-		types.Universe,
+		gotypes.Universe,
 	} {
 		growNames(len(scope.Names()))
 		for _, name := range scope.Names() {
@@ -818,7 +818,7 @@ func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredTyp
 			if obj == nil {
 				continue
 			}
-			if _, ok := obj.(*types.Var); ok {
+			if _, ok := obj.(*gotypes.Var); ok {
 				addNameOf(obj)
 			}
 		}
@@ -828,23 +828,23 @@ func collectPredefinedNames(result *compileResult, expr xgoast.Expr, declaredTyp
 }
 
 // checkValueInputSlot checks if the expression is a value input slot.
-func checkValueInputSlot(result *compileResult, expr xgoast.Expr, declaredType types.Type) *SpxInputSlot {
+func checkValueInputSlot(result *compileResult, expr ast.Expr, declaredType gotypes.Type) *SpxInputSlot {
 	switch expr := expr.(type) {
-	case *xgoast.BasicLit:
+	case *ast.BasicLit:
 		return createValueInputSlotFromBasicLit(result, expr, declaredType)
-	case *xgoast.Ident:
+	case *ast.Ident:
 		return createValueInputSlotFromIdent(result, expr, declaredType)
-	case *xgoast.UnaryExpr:
+	case *ast.UnaryExpr:
 		return createValueInputSlotFromUnaryExpr(result, expr, declaredType)
-	case *xgoast.CallExpr:
+	case *ast.CallExpr:
 		return createValueInputSlotFromColorFuncCall(result, expr, declaredType)
 	}
 	return nil
 }
 
 // checkAddressInputSlot checks if the expression is an address input slot.
-func checkAddressInputSlot(result *compileResult, expr xgoast.Expr) *SpxInputSlot {
-	if ident, ok := expr.(*xgoast.Ident); ok {
+func checkAddressInputSlot(result *compileResult, expr ast.Expr) *SpxInputSlot {
+	if ident, ok := expr.(*ast.Ident); ok {
 		return &SpxInputSlot{
 			Kind:   SpxInputSlotKindAddress,
 			Accept: SpxInputSlotAccept{Type: SpxInputTypeUnknown},
@@ -861,24 +861,24 @@ func checkAddressInputSlot(result *compileResult, expr xgoast.Expr) *SpxInputSlo
 }
 
 // createValueInputSlotFromBasicLit creates a value input slot from a basic literal.
-func createValueInputSlotFromBasicLit(result *compileResult, lit *xgoast.BasicLit, declaredType types.Type) *SpxInputSlot {
+func createValueInputSlotFromBasicLit(result *compileResult, lit *ast.BasicLit, declaredType gotypes.Type) *SpxInputSlot {
 	input := SpxInput{Kind: SpxInputKindInPlace}
 	switch lit.Kind {
-	case xgotoken.STRING:
+	case token.STRING:
 		input.Type = SpxInputTypeString
 		v, err := strconv.Unquote(lit.Value)
 		if err != nil {
 			return nil
 		}
 		input.Value = v
-	case xgotoken.INT:
+	case token.INT:
 		input.Type = SpxInputTypeInteger
 		v, err := strconv.ParseInt(lit.Value, 0, 64)
 		if err != nil {
 			return nil
 		}
 		input.Value = v
-	case xgotoken.FLOAT:
+	case token.FLOAT:
 		input.Type = SpxInputTypeDecimal
 		v, err := strconv.ParseFloat(lit.Value, 64)
 		if err != nil {
@@ -917,7 +917,7 @@ func createValueInputSlotFromBasicLit(result *compileResult, lit *xgoast.BasicLi
 }
 
 // createValueInputSlotFromIdent creates a value input slot from an identifier.
-func createValueInputSlotFromIdent(result *compileResult, ident *xgoast.Ident, declaredType types.Type) *SpxInputSlot {
+func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, declaredType gotypes.Type) *SpxInputSlot {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -935,7 +935,7 @@ func createValueInputSlotFromIdent(result *compileResult, ident *xgoast.Ident, d
 	}
 	switch input.Type {
 	case SpxInputTypeBoolean:
-		if basicType, ok := typ.(*types.Basic); ok && basicType.Kind() == types.UntypedBool {
+		if basicType, ok := typ.(*gotypes.Basic); ok && basicType.Kind() == gotypes.UntypedBool {
 			input.Kind = SpxInputKindInPlace
 			input.Value = ident.Name == "true"
 			input.Name = ""
@@ -951,7 +951,7 @@ func createValueInputSlotFromIdent(result *compileResult, ident *xgoast.Ident, d
 		if obj != nil && !IsInSpxPkg(obj) {
 			break
 		}
-		cnst, ok := obj.(*types.Const)
+		cnst, ok := obj.(*gotypes.Const)
 		if !ok {
 			break
 		}
@@ -1006,19 +1006,19 @@ func createValueInputSlotFromIdent(result *compileResult, ident *xgoast.Ident, d
 }
 
 // createValueInputSlotFromUnaryExpr creates a value input slot from a unary expression.
-func createValueInputSlotFromUnaryExpr(result *compileResult, expr *xgoast.UnaryExpr, declaredType types.Type) *SpxInputSlot {
+func createValueInputSlotFromUnaryExpr(result *compileResult, expr *ast.UnaryExpr, declaredType gotypes.Type) *SpxInputSlot {
 	var inputSlot *SpxInputSlot
 	switch x := expr.X.(type) {
-	case *xgoast.BasicLit:
+	case *ast.BasicLit:
 		inputSlot = createValueInputSlotFromBasicLit(result, x, declaredType)
 		if inputSlot == nil {
 			return nil
 		}
 
 		switch expr.Op {
-		case xgotoken.ADD:
+		case token.ADD:
 			// Nothing to do for unary plus.
-		case xgotoken.SUB:
+		case token.SUB:
 			switch v := inputSlot.Input.Value.(type) {
 			case int64:
 				inputSlot.Input.Value = -v
@@ -1027,9 +1027,9 @@ func createValueInputSlotFromUnaryExpr(result *compileResult, expr *xgoast.Unary
 			default:
 				return nil
 			}
-		case xgotoken.XOR:
+		case token.XOR:
 			switch x.Kind {
-			case xgotoken.INT:
+			case token.INT:
 				switch v := inputSlot.Input.Value.(type) {
 				case int64:
 					inputSlot.Input.Value = ^v
@@ -1040,14 +1040,14 @@ func createValueInputSlotFromUnaryExpr(result *compileResult, expr *xgoast.Unary
 				return nil
 			}
 		}
-	case *xgoast.Ident:
+	case *ast.Ident:
 		inputSlot = createValueInputSlotFromIdent(result, x, declaredType)
 		if inputSlot == nil {
 			return nil
 		}
 
 		switch expr.Op {
-		case xgotoken.NOT:
+		case token.NOT:
 			switch v := inputSlot.Input.Value.(type) {
 			case bool:
 				inputSlot.Input.Value = !v
@@ -1064,7 +1064,7 @@ func createValueInputSlotFromUnaryExpr(result *compileResult, expr *xgoast.Unary
 
 // createValueInputSlotFromColorFuncCall creates a value input slot from an spx
 // color function call.
-func createValueInputSlotFromColorFuncCall(result *compileResult, callExpr *xgoast.CallExpr, declaredType types.Type) *SpxInputSlot {
+func createValueInputSlotFromColorFuncCall(result *compileResult, callExpr *ast.CallExpr, declaredType gotypes.Type) *SpxInputSlot {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -1090,20 +1090,20 @@ func createValueInputSlotFromColorFuncCall(result *compileResult, callExpr *xgoa
 		if i >= maxArgs {
 			break
 		}
-		lit, ok := argExpr.(*xgoast.BasicLit)
+		lit, ok := argExpr.(*ast.BasicLit)
 		if !ok {
 			return nil
 		}
 
 		var val float64
 		switch lit.Kind {
-		case xgotoken.FLOAT:
+		case token.FLOAT:
 			floatVal, err := strconv.ParseFloat(lit.Value, 64)
 			if err != nil {
 				return nil
 			}
 			val = floatVal
-		case xgotoken.INT:
+		case token.INT:
 			intVal, err := strconv.ParseInt(lit.Value, 0, 64)
 			if err != nil {
 				return nil
@@ -1135,7 +1135,7 @@ func createValueInputSlotFromColorFuncCall(result *compileResult, callExpr *xgoa
 }
 
 // isSpxColorFunc checks if the fun is an spx color function.
-func isSpxColorFunc(fun *types.Func) bool {
+func isSpxColorFunc(fun *gotypes.Func) bool {
 	switch fun {
 	case GetSpxHSBFunc(), GetSpxHSBAFunc():
 		return true
@@ -1144,18 +1144,18 @@ func isSpxColorFunc(fun *types.Func) bool {
 }
 
 // inferSpxInputTypeFromType attempts to infer the input type from the given type.
-func inferSpxInputTypeFromType(typ types.Type) SpxInputType {
-	if basicType, ok := typ.(*types.Basic); ok {
+func inferSpxInputTypeFromType(typ gotypes.Type) SpxInputType {
+	if basicType, ok := typ.(*gotypes.Basic); ok {
 		switch basicType.Kind() {
-		case types.String, types.UntypedString:
+		case gotypes.String, gotypes.UntypedString:
 			return SpxInputTypeString
-		case types.Int, types.Int8, types.Int16, types.Int32, types.Int64,
-			types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64,
-			types.UntypedInt:
+		case gotypes.Int, gotypes.Int8, gotypes.Int16, gotypes.Int32, gotypes.Int64,
+			gotypes.Uint, gotypes.Uint8, gotypes.Uint16, gotypes.Uint32, gotypes.Uint64,
+			gotypes.UntypedInt:
 			return SpxInputTypeInteger
-		case types.Float32, types.Float64, types.UntypedFloat:
+		case gotypes.Float32, gotypes.Float64, gotypes.UntypedFloat:
 			return SpxInputTypeDecimal
-		case types.Bool, types.UntypedBool:
+		case gotypes.Bool, gotypes.UntypedBool:
 			return SpxInputTypeBoolean
 		}
 		return SpxInputTypeUnknown
@@ -1185,7 +1185,7 @@ func inferSpxInputTypeFromType(typ types.Type) SpxInputType {
 	}
 
 	// Fall back to the alias RHS when no direct basic or spx type match is found.
-	if alias, ok := typ.(*types.Alias); ok {
+	if alias, ok := typ.(*gotypes.Alias); ok {
 		rhs := alias.Rhs()
 		if rhs != nil && rhs != typ {
 			return inferSpxInputTypeFromType(rhs)
@@ -1196,7 +1196,7 @@ func inferSpxInputTypeFromType(typ types.Type) SpxInputType {
 
 // inferSpxSpriteResourceEnclosingNode infers the enclosing [SpxSpriteResource]
 // for the given node. It returns nil if no [SpxSpriteResource] can be inferred.
-func inferSpxSpriteResourceEnclosingNode(result *compileResult, node xgoast.Node) *SpxSpriteResource {
+func inferSpxSpriteResourceEnclosingNode(result *compileResult, node ast.Node) *SpxSpriteResource {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -1206,19 +1206,19 @@ func inferSpxSpriteResourceEnclosingNode(result *compileResult, node xgoast.Node
 	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, node)
 
 	var spxSpriteResource *SpxSpriteResource
-	xgoutil.WalkPathEnclosingInterval(astFile, node.Pos(), node.End(), false, func(node xgoast.Node) bool {
+	xgoutil.WalkPathEnclosingInterval(astFile, node.Pos(), node.End(), false, func(node ast.Node) bool {
 		if node == nil {
 			return true
 		}
 
-		callExpr, ok := node.(*xgoast.CallExpr)
+		callExpr, ok := node.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
 
 		var spxSpriteName string
-		if sel, ok := callExpr.Fun.(*xgoast.SelectorExpr); ok {
-			ident, ok := sel.X.(*xgoast.Ident)
+		if sel, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
+			ident, ok := sel.X.(*ast.Ident)
 			if !ok {
 				return false
 			}
@@ -1226,7 +1226,7 @@ func inferSpxSpriteResourceEnclosingNode(result *compileResult, node xgoast.Node
 			if obj == nil {
 				return false
 			}
-			named, ok := xgoutil.DerefType(obj.Type()).(*types.Named)
+			named, ok := xgoutil.DerefType(obj.Type()).(*gotypes.Named)
 			if !ok {
 				return false
 			}
@@ -1246,8 +1246,8 @@ func inferSpxSpriteResourceEnclosingNode(result *compileResult, node xgoast.Node
 }
 
 // isBlank checks if an expression is a blank identifier (_).
-func isBlank(expr xgoast.Expr) bool {
-	ident, ok := expr.(*xgoast.Ident)
+func isBlank(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
 	return ok && ident.Name == "_"
 }
 

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -1,13 +1,13 @@
 package server
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"reflect"
 	"slices"
 	"testing"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -536,7 +536,7 @@ onStart => {
 		}
 	})
 
-	t.Run("spx.Sprite.StepTo", func(t *testing.T) {
+	t.Run("SpxSpriteStepTo", func(t *testing.T) {
 		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///MySprite.spx")
 		require.NoError(t, err)
 		require.False(t, result.hasErrorSeverityDiagnostic)
@@ -559,7 +559,7 @@ onStart => {
 		})
 	})
 
-	t.Run("spx.Sprite.Clone", func(t *testing.T) {
+	t.Run("SpxSpriteClone", func(t *testing.T) {
 		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///MySprite.spx")
 		require.NoError(t, err)
 		require.False(t, result.hasErrorSeverityDiagnostic)
@@ -615,7 +615,7 @@ onStart => {
 	for _, tt := range []struct {
 		name           string
 		exprPosition   Position
-		exprFilter     func(xgoast.Node) bool
+		exprFilter     func(ast.Node) bool
 		wantNil        bool
 		wantKind       SpxInputSlotKind
 		wantAcceptType SpxInputType
@@ -627,7 +627,7 @@ onStart => {
 		{
 			name:           "IntegerLiteral",
 			exprPosition:   Position{Line: 3, Character: 14},
-			exprFilter:     func(node xgoast.Node) bool { _, ok := node.(*xgoast.BasicLit); return ok },
+			exprFilter:     func(node ast.Node) bool { _, ok := node.(*ast.BasicLit); return ok },
 			wantKind:       SpxInputSlotKindValue,
 			wantAcceptType: SpxInputTypeInteger,
 			wantInputKind:  SpxInputKindInPlace,
@@ -637,7 +637,7 @@ onStart => {
 		{
 			name:           "FloatLiteral",
 			exprPosition:   Position{Line: 4, Character: 16},
-			exprFilter:     func(node xgoast.Node) bool { _, ok := node.(*xgoast.BasicLit); return ok },
+			exprFilter:     func(node ast.Node) bool { _, ok := node.(*ast.BasicLit); return ok },
 			wantKind:       SpxInputSlotKindValue,
 			wantAcceptType: SpxInputTypeDecimal,
 			wantInputKind:  SpxInputKindInPlace,
@@ -647,7 +647,7 @@ onStart => {
 		{
 			name:           "StringLiteral",
 			exprPosition:   Position{Line: 5, Character: 14},
-			exprFilter:     func(node xgoast.Node) bool { _, ok := node.(*xgoast.BasicLit); return ok },
+			exprFilter:     func(node ast.Node) bool { _, ok := node.(*ast.BasicLit); return ok },
 			wantKind:       SpxInputSlotKindValue,
 			wantAcceptType: SpxInputTypeString,
 			wantInputKind:  SpxInputKindInPlace,
@@ -657,7 +657,7 @@ onStart => {
 		{
 			name:           "DirectionIdentifier",
 			exprPosition:   Position{Line: 8, Character: 14},
-			exprFilter:     func(node xgoast.Node) bool { _, ok := node.(*xgoast.Ident); return ok },
+			exprFilter:     func(node ast.Node) bool { _, ok := node.(*ast.Ident); return ok },
 			wantKind:       SpxInputSlotKindValue,
 			wantAcceptType: SpxInputTypeDirection,
 			wantInputKind:  SpxInputKindInPlace,
@@ -667,7 +667,7 @@ onStart => {
 		{
 			name:           "BooleanIdentifier",
 			exprPosition:   Position{Line: 9, Character: 15},
-			exprFilter:     func(node xgoast.Node) bool { _, ok := node.(*xgoast.Ident); return ok },
+			exprFilter:     func(node ast.Node) bool { _, ok := node.(*ast.Ident); return ok },
 			wantKind:       SpxInputSlotKindValue,
 			wantAcceptType: SpxInputTypeBoolean,
 			wantInputKind:  SpxInputKindInPlace,
@@ -677,7 +677,7 @@ onStart => {
 		{
 			name:           "ColorFunctionCall",
 			exprPosition:   Position{Line: 12, Character: 16},
-			exprFilter:     func(node xgoast.Node) bool { _, ok := node.(*xgoast.CallExpr); return ok },
+			exprFilter:     func(node ast.Node) bool { _, ok := node.(*ast.CallExpr); return ok },
 			wantKind:       SpxInputSlotKindValue,
 			wantAcceptType: SpxInputTypeColor,
 			wantInputKind:  SpxInputKindInPlace,
@@ -690,7 +690,7 @@ onStart => {
 		{
 			name:         "NonValueNode",
 			exprPosition: Position{Line: 15, Character: 16},
-			exprFilter:   func(node xgoast.Node) bool { _, ok := node.(*xgoast.CompositeLit); return ok },
+			exprFilter:   func(node ast.Node) bool { _, ok := node.(*ast.CompositeLit); return ok },
 			wantNil:      true,
 		},
 	} {
@@ -698,9 +698,9 @@ onStart => {
 			pos := PosAt(result.proj, astFile, tt.exprPosition)
 			require.True(t, pos.IsValid())
 
-			var expr xgoast.Expr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-				if node, ok := node.(xgoast.Expr); ok && tt.exprFilter(node) {
+			var expr ast.Expr
+			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+				if node, ok := node.(ast.Expr); ok && tt.exprFilter(node) {
 					expr = node
 					return false
 				}
@@ -750,26 +750,26 @@ onStart => {
 	for _, tt := range []struct {
 		name         string
 		exprPosition Position
-		exprFilter   func(xgoast.Node) bool
+		exprFilter   func(ast.Node) bool
 		wantNil      bool
 		wantName     string
 	}{
 		{
 			name:         "ExistingIdentifier",
 			exprPosition: Position{Line: 6, Character: 2},
-			exprFilter:   func(node xgoast.Node) bool { _, ok := node.(*xgoast.Ident); return ok },
+			exprFilter:   func(node ast.Node) bool { _, ok := node.(*ast.Ident); return ok },
 			wantName:     "varA",
 		},
 		{
 			name:         "CallExpr",
 			exprPosition: Position{Line: 7, Character: 2},
-			exprFilter:   func(node xgoast.Node) bool { _, ok := node.(*xgoast.CallExpr); return ok },
+			exprFilter:   func(node ast.Node) bool { _, ok := node.(*ast.CallExpr); return ok },
 			wantNil:      true,
 		},
 		{
 			name:         "BasicLit",
 			exprPosition: Position{Line: 8, Character: 14},
-			exprFilter:   func(node xgoast.Node) bool { _, ok := node.(*xgoast.BasicLit); return ok },
+			exprFilter:   func(node ast.Node) bool { _, ok := node.(*ast.BasicLit); return ok },
 			wantNil:      true,
 		},
 	} {
@@ -777,9 +777,9 @@ onStart => {
 			pos := PosAt(result.proj, astFile, tt.exprPosition)
 			require.True(t, pos.IsValid())
 
-			var expr xgoast.Expr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-				if node, ok := node.(xgoast.Expr); ok && tt.exprFilter(node) {
+			var expr ast.Expr
+			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+				if node, ok := node.(ast.Expr); ok && tt.exprFilter(node) {
 					expr = node
 					return false
 				}
@@ -791,7 +791,7 @@ onStart => {
 			if tt.wantNil {
 				assert.Nil(t, got)
 			} else {
-				assert.NotNil(t, got)
+				require.NotNil(t, got)
 				assert.Equal(t, SpxInputSlotKindAddress, got.Kind)
 				assert.Equal(t, SpxInputTypeUnknown, got.Accept.Type)
 				assert.Equal(t, SpxInputKindPredefined, got.Input.Kind)
@@ -836,7 +836,7 @@ onStart => {
 	for _, tt := range []struct {
 		name           string
 		litPosition    Position
-		declaredType   types.Type
+		declaredType   gotypes.Type
 		wantAcceptType SpxInputType
 		wantInputType  SpxInputType
 		wantInputKind  SpxInputKind
@@ -896,9 +896,9 @@ onStart => {
 			pos := PosAt(result.proj, astFile, tt.litPosition)
 			require.True(t, pos.IsValid())
 
-			var lit *xgoast.BasicLit
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-				if node, ok := node.(*xgoast.BasicLit); ok {
+			var lit *ast.BasicLit
+			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+				if node, ok := node.(*ast.BasicLit); ok {
 					lit = node
 					return false
 				}
@@ -918,8 +918,8 @@ onStart => {
 	}
 
 	t.Run("InvalidIntLiteral", func(t *testing.T) {
-		invalidIntLit := &xgoast.BasicLit{
-			Kind:  xgotoken.INT,
+		invalidIntLit := &ast.BasicLit{
+			Kind:  token.INT,
 			Value: "not.a.int",
 		}
 		got := createValueInputSlotFromBasicLit(result, invalidIntLit, nil)
@@ -927,8 +927,8 @@ onStart => {
 	})
 
 	t.Run("InvalidFloatLiteral", func(t *testing.T) {
-		invalidFloatLit := &xgoast.BasicLit{
-			Kind:  xgotoken.FLOAT,
+		invalidFloatLit := &ast.BasicLit{
+			Kind:  token.FLOAT,
 			Value: "not.a.float",
 		}
 		got := createValueInputSlotFromBasicLit(result, invalidFloatLit, nil)
@@ -936,8 +936,8 @@ onStart => {
 	})
 
 	t.Run("UnsupportedLiteralKind", func(t *testing.T) {
-		unsupportedLit := &xgoast.BasicLit{
-			Kind:  xgotoken.CHAR,
+		unsupportedLit := &ast.BasicLit{
+			Kind:  token.CHAR,
 			Value: "'c'",
 		}
 		got := createValueInputSlotFromBasicLit(result, unsupportedLit, nil)
@@ -945,8 +945,8 @@ onStart => {
 	})
 
 	t.Run("InvalidStringLiteral", func(t *testing.T) {
-		invalidStringLit := &xgoast.BasicLit{
-			Kind:  xgotoken.STRING,
+		invalidStringLit := &ast.BasicLit{
+			Kind:  token.STRING,
 			Value: "\"unclosed string literal", // Missing ending quote.
 		}
 		got := createValueInputSlotFromBasicLit(result, invalidStringLit, nil)
@@ -1060,9 +1060,9 @@ onStart => {
 			pos := PosAt(result.proj, astFile, tt.identPosition)
 			require.True(t, pos.IsValid())
 
-			var ident *xgoast.Ident
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-				if node, ok := node.(*xgoast.Ident); ok {
+			var ident *ast.Ident
+			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+				if node, ok := node.(*ast.Ident); ok {
 					ident = node
 					return false
 				}
@@ -1104,9 +1104,9 @@ onStart => {
 		pos := PosAt(result.proj, astFile, Position{Line: 4, Character: 7})
 		require.True(t, pos.IsValid())
 
-		var ident *xgoast.Ident
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-			if node, ok := node.(*xgoast.Ident); ok && node.Name == "mySound" {
+		var ident *ast.Ident
+		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			if node, ok := node.(*ast.Ident); ok && node.Name == "mySound" {
 				ident = node
 				return false
 			}
@@ -1114,8 +1114,8 @@ onStart => {
 		})
 		require.NotNil(t, ident)
 
-		pkg := types.NewPackage("example.com/pkg", "pkg")
-		declaredType := types.NewAlias(types.NewTypeName(0, pkg, "MySoundName", nil), GetSpxSoundNameType())
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
+		declaredType := gotypes.NewAlias(gotypes.NewTypeName(0, pkg, "MySoundName", nil), GetSpxSoundNameType())
 
 		got := createValueInputSlotFromIdent(result, ident, declaredType)
 		require.NotNil(t, got)
@@ -1215,9 +1215,9 @@ onStart => {
 			pos := PosAt(result.proj, astFile, tt.exprPosition)
 			require.True(t, pos.IsValid())
 
-			var unaryExpr *xgoast.UnaryExpr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-				if expr, ok := node.(*xgoast.UnaryExpr); ok {
+			var unaryExpr *ast.UnaryExpr
+			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+				if expr, ok := node.(*ast.UnaryExpr); ok {
 					unaryExpr = expr
 					return false
 				}
@@ -1290,9 +1290,9 @@ onStart => {
 			pos := PosAt(result.proj, astFile, tt.callExprPosition)
 			require.True(t, pos.IsValid())
 
-			var callExpr *xgoast.CallExpr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-				if node, ok := node.(*xgoast.CallExpr); ok {
+			var callExpr *ast.CallExpr
+			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+				if node, ok := node.(*ast.CallExpr); ok {
 					callExpr = node
 					return false
 				}
@@ -1310,8 +1310,7 @@ onStart => {
 				assert.Equal(t, SpxInputKindInPlace, got.Input.Kind)
 				assert.Equal(t, SpxInputTypeColor, got.Input.Type)
 
-				colorValue, ok := got.Input.Value.(SpxColorInputValue)
-				require.True(t, ok)
+				colorValue := requireValueAs[SpxColorInputValue](t, got.Input.Value)
 				assert.Equal(t, tt.wantValue.Constructor, colorValue.Constructor)
 				assert.ElementsMatch(t, tt.wantValue.Args, colorValue.Args)
 
@@ -1321,14 +1320,14 @@ onStart => {
 	}
 
 	t.Run("NonIdentifierFunction", func(t *testing.T) {
-		callExpr := &xgoast.CallExpr{
-			Fun: &xgoast.SelectorExpr{
-				X:   &xgoast.Ident{Name: "math"},
-				Sel: &xgoast.Ident{Name: "Max"},
+		callExpr := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.Ident{Name: "math"},
+				Sel: &ast.Ident{Name: "Max"},
 			},
-			Args: []xgoast.Expr{
-				&xgoast.BasicLit{Kind: xgotoken.INT, Value: "1"},
-				&xgoast.BasicLit{Kind: xgotoken.INT, Value: "2"},
+			Args: []ast.Expr{
+				&ast.BasicLit{Kind: token.INT, Value: "1"},
+				&ast.BasicLit{Kind: token.INT, Value: "2"},
 			},
 		}
 		got := createValueInputSlotFromColorFuncCall(result, callExpr, nil)
@@ -1336,9 +1335,9 @@ onStart => {
 	})
 
 	t.Run("NilFunctionType", func(t *testing.T) {
-		callExpr := &xgoast.CallExpr{
-			Fun:  &xgoast.Ident{Name: "unknownFunction"},
-			Args: []xgoast.Expr{&xgoast.BasicLit{Kind: xgotoken.INT, Value: "1"}},
+		callExpr := &ast.CallExpr{
+			Fun:  &ast.Ident{Name: "unknownFunction"},
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: "1"}},
 		}
 		got := createValueInputSlotFromColorFuncCall(result, callExpr, nil)
 		assert.Nil(t, got)
@@ -1348,7 +1347,7 @@ onStart => {
 func TestIsSpxColorFunc(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		fun  *types.Func
+		fun  *gotypes.Func
 		want bool
 	}{
 		{"HSB", GetSpxHSBFunc(), true},
@@ -1365,33 +1364,33 @@ func TestInferSpxInputTypeFromType(t *testing.T) {
 	t.Run("BasicTypes", func(t *testing.T) {
 		for _, tt := range []struct {
 			name string
-			typ  types.Type
+			typ  gotypes.Type
 			want SpxInputType
 		}{
-			{"String", types.Typ[types.String], SpxInputTypeString},
-			{"UntypedString", types.Typ[types.UntypedString], SpxInputTypeString},
+			{"String", gotypes.Typ[gotypes.String], SpxInputTypeString},
+			{"UntypedString", gotypes.Typ[gotypes.UntypedString], SpxInputTypeString},
 
-			{"Int", types.Typ[types.Int], SpxInputTypeInteger},
-			{"Int8", types.Typ[types.Int8], SpxInputTypeInteger},
-			{"Int16", types.Typ[types.Int16], SpxInputTypeInteger},
-			{"Int32", types.Typ[types.Int32], SpxInputTypeInteger},
-			{"Int64", types.Typ[types.Int64], SpxInputTypeInteger},
-			{"Uint", types.Typ[types.Uint], SpxInputTypeInteger},
-			{"Uint8", types.Typ[types.Uint8], SpxInputTypeInteger},
-			{"Uint16", types.Typ[types.Uint16], SpxInputTypeInteger},
-			{"Uint32", types.Typ[types.Uint32], SpxInputTypeInteger},
-			{"Uint64", types.Typ[types.Uint64], SpxInputTypeInteger},
-			{"UntypedInt", types.Typ[types.UntypedInt], SpxInputTypeInteger},
+			{"Int", gotypes.Typ[gotypes.Int], SpxInputTypeInteger},
+			{"Int8", gotypes.Typ[gotypes.Int8], SpxInputTypeInteger},
+			{"Int16", gotypes.Typ[gotypes.Int16], SpxInputTypeInteger},
+			{"Int32", gotypes.Typ[gotypes.Int32], SpxInputTypeInteger},
+			{"Int64", gotypes.Typ[gotypes.Int64], SpxInputTypeInteger},
+			{"Uint", gotypes.Typ[gotypes.Uint], SpxInputTypeInteger},
+			{"Uint8", gotypes.Typ[gotypes.Uint8], SpxInputTypeInteger},
+			{"Uint16", gotypes.Typ[gotypes.Uint16], SpxInputTypeInteger},
+			{"Uint32", gotypes.Typ[gotypes.Uint32], SpxInputTypeInteger},
+			{"Uint64", gotypes.Typ[gotypes.Uint64], SpxInputTypeInteger},
+			{"UntypedInt", gotypes.Typ[gotypes.UntypedInt], SpxInputTypeInteger},
 
-			{"Float32", types.Typ[types.Float32], SpxInputTypeDecimal},
-			{"Float64", types.Typ[types.Float64], SpxInputTypeDecimal},
-			{"UntypedFloat", types.Typ[types.UntypedFloat], SpxInputTypeDecimal},
+			{"Float32", gotypes.Typ[gotypes.Float32], SpxInputTypeDecimal},
+			{"Float64", gotypes.Typ[gotypes.Float64], SpxInputTypeDecimal},
+			{"UntypedFloat", gotypes.Typ[gotypes.UntypedFloat], SpxInputTypeDecimal},
 
-			{"Bool", types.Typ[types.Bool], SpxInputTypeBoolean},
-			{"UntypedBool", types.Typ[types.UntypedBool], SpxInputTypeBoolean},
+			{"Bool", gotypes.Typ[gotypes.Bool], SpxInputTypeBoolean},
+			{"UntypedBool", gotypes.Typ[gotypes.UntypedBool], SpxInputTypeBoolean},
 
-			{"Complex64", types.Typ[types.Complex64], SpxInputTypeUnknown},
-			{"Complex128", types.Typ[types.Complex128], SpxInputTypeUnknown},
+			{"Complex64", gotypes.Typ[gotypes.Complex64], SpxInputTypeUnknown},
+			{"Complex128", gotypes.Typ[gotypes.Complex128], SpxInputTypeUnknown},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				got := inferSpxInputTypeFromType(tt.typ)
@@ -1401,16 +1400,16 @@ func TestInferSpxInputTypeFromType(t *testing.T) {
 	})
 
 	t.Run("NonBasicType", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/pkg", "pkg")
-		structType := types.NewStruct([]*types.Var{}, []string{})
-		namedType := types.NewNamed(types.NewTypeName(0, pkg, "MyStruct", nil), structType, nil)
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
+		structType := gotypes.NewStruct([]*gotypes.Var{}, []string{})
+		namedType := gotypes.NewNamed(gotypes.NewTypeName(0, pkg, "MyStruct", nil), structType, nil)
 
 		got := inferSpxInputTypeFromType(namedType)
 		assert.Equal(t, SpxInputTypeUnknown, got)
 	})
 
 	t.Run("PointerType", func(t *testing.T) {
-		pointerType := types.NewPointer(types.Typ[types.Int])
+		pointerType := gotypes.NewPointer(gotypes.Typ[gotypes.Int])
 
 		got := inferSpxInputTypeFromType(pointerType)
 		assert.Equal(t, SpxInputTypeUnknown, got)
@@ -1419,7 +1418,7 @@ func TestInferSpxInputTypeFromType(t *testing.T) {
 	t.Run("SpxAliasTypes", func(t *testing.T) {
 		for _, tt := range []struct {
 			name       string
-			typeGetter func() *types.Alias
+			typeGetter func() *gotypes.Alias
 			want       SpxInputType
 		}{
 			{"BackdropName", GetSpxBackdropNameType, SpxInputTypeResourceName},
@@ -1442,7 +1441,7 @@ func TestInferSpxInputTypeFromType(t *testing.T) {
 	t.Run("SpxNamedTypes", func(t *testing.T) {
 		for _, tt := range []struct {
 			name       string
-			typeGetter func() *types.Named
+			typeGetter func() *gotypes.Named
 			want       SpxInputType
 		}{
 			{"EffectKind", GetSpxEffectKindType, SpxInputTypeEffectKind},
@@ -1456,32 +1455,32 @@ func TestInferSpxInputTypeFromType(t *testing.T) {
 	})
 
 	t.Run("AliasFallback", func(t *testing.T) {
-		pkg := types.NewPackage("example.com/pkg", "pkg")
-		namedIntType := types.NewNamed(types.NewTypeName(0, pkg, "MyCount", nil), types.Typ[types.Int], nil)
+		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
+		namedIntType := gotypes.NewNamed(gotypes.NewTypeName(0, pkg, "MyCount", nil), gotypes.Typ[gotypes.Int], nil)
 
 		for _, tt := range []struct {
 			name string
-			typ  types.Type
+			typ  gotypes.Type
 			want SpxInputType
 		}{
 			{
 				name: "AliasToBasic",
-				typ:  types.NewAlias(types.NewTypeName(0, pkg, "MyInt", nil), types.Typ[types.Int]),
+				typ:  gotypes.NewAlias(gotypes.NewTypeName(0, pkg, "MyInt", nil), gotypes.Typ[gotypes.Int]),
 				want: SpxInputTypeInteger,
 			},
 			{
 				name: "AliasToSpxResourceName",
-				typ:  types.NewAlias(types.NewTypeName(0, pkg, "MySoundName", nil), GetSpxSoundNameType()),
+				typ:  gotypes.NewAlias(gotypes.NewTypeName(0, pkg, "MySoundName", nil), GetSpxSoundNameType()),
 				want: SpxInputTypeResourceName,
 			},
 			{
 				name: "AliasToSpxDirection",
-				typ:  types.NewAlias(types.NewTypeName(0, pkg, "MyDirection", nil), GetSpxDirectionType()),
+				typ:  gotypes.NewAlias(gotypes.NewTypeName(0, pkg, "MyDirection", nil), GetSpxDirectionType()),
 				want: SpxInputTypeDirection,
 			},
 			{
 				name: "AliasToNamedType",
-				typ:  types.NewAlias(types.NewTypeName(0, pkg, "MyCountAlias", nil), namedIntType),
+				typ:  gotypes.NewAlias(gotypes.NewTypeName(0, pkg, "MyCountAlias", nil), namedIntType),
 				want: SpxInputTypeUnknown,
 			},
 		} {
@@ -1520,9 +1519,9 @@ onStart => {
 		pos := PosAt(result.proj, astFile, Position{Line: 2, Character: 11})
 		require.True(t, pos.IsValid())
 
-		var callExpr *xgoast.CallExpr
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-			if node, ok := node.(*xgoast.CallExpr); ok {
+		var callExpr *ast.CallExpr
+		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			if node, ok := node.(*ast.CallExpr); ok {
 				callExpr = node
 				return false
 			}
@@ -1545,9 +1544,9 @@ onStart => {
 		pos := PosAt(result.proj, astFile, Position{Line: 2, Character: 2})
 		require.True(t, pos.IsValid())
 
-		var callExpr *xgoast.CallExpr
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-			if node, ok := node.(*xgoast.CallExpr); ok {
+		var callExpr *ast.CallExpr
+		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			if node, ok := node.(*ast.CallExpr); ok {
 				callExpr = node
 				return false
 			}
@@ -1570,9 +1569,9 @@ onStart => {
 		pos := PosAt(result.proj, astFile, Position{Line: 1, Character: 2})
 		require.True(t, pos.IsValid())
 
-		var callExpr *xgoast.CallExpr
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node xgoast.Node) bool {
-			if node, ok := node.(*xgoast.CallExpr); ok {
+		var callExpr *ast.CallExpr
+		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			if node, ok := node.(*ast.CallExpr); ok {
 				callExpr = node
 				return false
 			}
@@ -1588,12 +1587,12 @@ onStart => {
 func TestIsBlank(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		expr xgoast.Expr
+		expr ast.Expr
 		want bool
 	}{
-		{"BlankIdent", &xgoast.Ident{Name: "_"}, true},
-		{"NonBlankIdent", &xgoast.Ident{Name: "variable"}, false},
-		{"BasicLit", &xgoast.BasicLit{Value: "test"}, false},
+		{"BlankIdent", &ast.Ident{Name: "_"}, true},
+		{"NonBlankIdent", &ast.Ident{Name: "variable"}, false},
+		{"BasicLit", &ast.BasicLit{Value: "test"}, false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isBlank(tt.expr)
@@ -1698,7 +1697,7 @@ func TestSortSpxInputSlots(t *testing.T) {
 		l5Slots := slices.DeleteFunc(slices.Clone(slots), func(s SpxInputSlot) bool {
 			return s.Range.Start.Line != 5
 		})
-		require.Equal(t, 3, len(l5Slots))
+		require.Len(t, l5Slots, 3)
 		assert.Equal(t, uint32(5), l5Slots[0].Range.Start.Character)
 		assert.Equal(t, uint32(15), l5Slots[1].Range.Start.Character)
 		assert.Equal(t, uint32(20), l5Slots[2].Range.Start.Character)
@@ -1706,7 +1705,7 @@ func TestSortSpxInputSlots(t *testing.T) {
 		l7Slots := slices.DeleteFunc(slices.Clone(slots), func(s SpxInputSlot) bool {
 			return s.Range.Start.Line != 7
 		})
-		require.Equal(t, 2, len(l7Slots))
+		require.Len(t, l7Slots, 2)
 		assert.Equal(t, uint32(10), l7Slots[0].Range.Start.Character)
 		assert.Equal(t, uint32(30), l7Slots[1].Range.Start.Character)
 	})
@@ -1748,7 +1747,7 @@ func TestSortSpxInputSlots(t *testing.T) {
 		l5c10Slots := slices.DeleteFunc(slices.Clone(slots), func(s SpxInputSlot) bool {
 			return s.Range.Start.Line != 5 || s.Range.Start.Character != 10
 		})
-		require.Equal(t, 2, len(l5c10Slots))
+		require.Len(t, l5c10Slots, 2)
 		assert.Equal(t, SpxInputSlotKindAddress, l5c10Slots[0].Kind)
 		assert.Equal(t, SpxInputSlotKindValue, l5c10Slots[1].Kind)
 	})
@@ -2120,17 +2119,17 @@ func onStart() {
 		mySpriteObj := pkg.Scope().Lookup("MySprite")
 		require.NotNil(t, mySpriteObj)
 
-		mySpriteTypeName, ok := mySpriteObj.(*types.TypeName)
+		mySpriteTypeName, ok := mySpriteObj.(*gotypes.TypeName)
 		require.True(t, ok)
 
-		mySpriteType, ok := mySpriteTypeName.Type().(*types.Named)
+		mySpriteType, ok := mySpriteTypeName.Type().(*gotypes.Named)
 		require.True(t, ok)
 
-		structType, ok := mySpriteType.Underlying().(*types.Struct)
+		structType, ok := mySpriteType.Underlying().(*gotypes.Struct)
 		require.True(t, ok)
 
 		// Test field x (should be property)
-		var xField *types.Var
+		var xField *gotypes.Var
 		for f := range structType.Fields() {
 			if f.Name() == "x" {
 				xField = f
@@ -2141,7 +2140,7 @@ func onStart() {
 		assert.True(t, isPropertyOfEnclosingType(xField), "x field should be a property")
 
 		// Test field y (should also be property)
-		var yField *types.Var
+		var yField *gotypes.Var
 		for f := range structType.Fields() {
 			if f.Name() == "y" {
 				yField = f
@@ -2193,14 +2192,14 @@ func onStart() {
 		mySpriteObj := pkg.Scope().Lookup("MySprite")
 		require.NotNil(t, mySpriteObj)
 
-		mySpriteTypeName, ok := mySpriteObj.(*types.TypeName)
+		mySpriteTypeName, ok := mySpriteObj.(*gotypes.TypeName)
 		require.True(t, ok)
 
-		mySpriteType, ok := mySpriteTypeName.Type().(*types.Named)
+		mySpriteType, ok := mySpriteTypeName.Type().(*gotypes.Named)
 		require.True(t, ok)
 
 		// Test Speed method (should be property - no params, one return)
-		var speedMethod *types.Func
+		var speedMethod *gotypes.Func
 		for method := range mySpriteType.Methods() {
 			if method.Name() == "Speed" {
 				speedMethod = method
@@ -2211,7 +2210,7 @@ func onStart() {
 		assert.True(t, isPropertyOfEnclosingType(speedMethod), "Speed method should be a property")
 
 		// Test Move method (should NOT be property - has parameters)
-		var moveMethod *types.Func
+		var moveMethod *gotypes.Func
 		for method := range mySpriteType.Methods() {
 			if method.Name() == "Move" {
 				moveMethod = method
@@ -2222,7 +2221,7 @@ func onStart() {
 		assert.False(t, isPropertyOfEnclosingType(moveMethod), "Move method should not be a property (has parameters)")
 
 		// Test XGo_Internal method (should NOT be property - XGo_ prefix)
-		var internalMethod *types.Func
+		var internalMethod *gotypes.Func
 		for method := range mySpriteType.Methods() {
 			if method.Name() == "XGo_Internal" {
 				internalMethod = method
@@ -2277,30 +2276,30 @@ func onStart() {
 		mySpriteObj := pkg.Scope().Lookup("MySprite")
 		require.NotNil(t, mySpriteObj)
 
-		mySpriteTypeName, ok := mySpriteObj.(*types.TypeName)
+		mySpriteTypeName, ok := mySpriteObj.(*gotypes.TypeName)
 		require.True(t, ok)
 
-		mySpriteType, ok := mySpriteTypeName.Type().(*types.Named)
+		mySpriteType, ok := mySpriteTypeName.Type().(*gotypes.Named)
 		require.True(t, ok)
 
-		mySpriteStruct, ok := mySpriteType.Underlying().(*types.Struct)
+		mySpriteStruct, ok := mySpriteType.Underlying().(*gotypes.Struct)
 		require.True(t, ok)
 
 		// Find OtherSprite type
 		otherSpriteObj := pkg.Scope().Lookup("OtherSprite")
 		require.NotNil(t, otherSpriteObj)
 
-		otherSpriteTypeName, ok := otherSpriteObj.(*types.TypeName)
+		otherSpriteTypeName, ok := otherSpriteObj.(*gotypes.TypeName)
 		require.True(t, ok)
 
-		otherSpriteType, ok := otherSpriteTypeName.Type().(*types.Named)
+		otherSpriteType, ok := otherSpriteTypeName.Type().(*gotypes.Named)
 		require.True(t, ok)
 
-		otherSpriteStruct, ok := otherSpriteType.Underlying().(*types.Struct)
+		otherSpriteStruct, ok := otherSpriteType.Underlying().(*gotypes.Struct)
 		require.True(t, ok)
 
 		// Test MySprite.x field
-		var mySpriteXField *types.Var
+		var mySpriteXField *gotypes.Var
 		for f := range mySpriteStruct.Fields() {
 			if f.Name() == "x" {
 				mySpriteXField = f
@@ -2313,7 +2312,7 @@ func onStart() {
 		assert.Equal(t, "main.MySprite", enclosingType.String(), "MySprite.x should return MySprite as enclosing type")
 
 		// Test MySprite.y field
-		var mySpriteYField *types.Var
+		var mySpriteYField *gotypes.Var
 		for f := range mySpriteStruct.Fields() {
 			if f.Name() == "y" {
 				mySpriteYField = f
@@ -2326,7 +2325,7 @@ func onStart() {
 		assert.Equal(t, "main.MySprite", enclosingType.String(), "MySprite.y should return MySprite as enclosing type")
 
 		// Test OtherSprite.x field (same name, different type)
-		var otherSpriteXField *types.Var
+		var otherSpriteXField *gotypes.Var
 		for f := range otherSpriteStruct.Fields() {
 			if f.Name() == "x" {
 				otherSpriteXField = f
@@ -2342,7 +2341,7 @@ func onStart() {
 		assert.NotEqual(t, mySpriteXField, otherSpriteXField, "MySprite.x and OtherSprite.x should be different field objects")
 
 		// Test OtherSprite.z field
-		var otherSpriteZField *types.Var
+		var otherSpriteZField *gotypes.Var
 		for f := range otherSpriteStruct.Fields() {
 			if f.Name() == "z" {
 				otherSpriteZField = f
@@ -2401,24 +2400,24 @@ func onStart() {
 		mySpriteObj := pkg.Scope().Lookup("MySprite")
 		require.NotNil(t, mySpriteObj)
 
-		mySpriteTypeName, ok := mySpriteObj.(*types.TypeName)
+		mySpriteTypeName, ok := mySpriteObj.(*gotypes.TypeName)
 		require.True(t, ok)
 
-		mySpriteType, ok := mySpriteTypeName.Type().(*types.Named)
+		mySpriteType, ok := mySpriteTypeName.Type().(*gotypes.Named)
 		require.True(t, ok)
 
 		// Find OtherSprite type
 		otherSpriteObj := pkg.Scope().Lookup("OtherSprite")
 		require.NotNil(t, otherSpriteObj)
 
-		otherSpriteTypeName, ok := otherSpriteObj.(*types.TypeName)
+		otherSpriteTypeName, ok := otherSpriteObj.(*gotypes.TypeName)
 		require.True(t, ok)
 
-		otherSpriteType, ok := otherSpriteTypeName.Type().(*types.Named)
+		otherSpriteType, ok := otherSpriteTypeName.Type().(*gotypes.Named)
 		require.True(t, ok)
 
 		// Test MySprite.Speed method
-		var mySpriteSpeedMethod *types.Func
+		var mySpriteSpeedMethod *gotypes.Func
 		for m := range mySpriteType.Methods() {
 			if m.Name() == "Speed" {
 				mySpriteSpeedMethod = m
@@ -2431,7 +2430,7 @@ func onStart() {
 		assert.Equal(t, "main.MySprite", enclosingType.String(), "MySprite.Speed should return MySprite as enclosing type")
 
 		// Test MySprite.Move method
-		var mySpriteMoveMethod *types.Func
+		var mySpriteMoveMethod *gotypes.Func
 		for m := range mySpriteType.Methods() {
 			if m.Name() == "Move" {
 				mySpriteMoveMethod = m
@@ -2444,7 +2443,7 @@ func onStart() {
 		assert.Equal(t, "main.MySprite", enclosingType.String(), "MySprite.Move should return MySprite as enclosing type")
 
 		// Test OtherSprite.Speed method (same name, different type)
-		var otherSpriteSpeedMethod *types.Func
+		var otherSpriteSpeedMethod *gotypes.Func
 		for m := range otherSpriteType.Methods() {
 			if m.Name() == "Speed" {
 				otherSpriteSpeedMethod = m
@@ -2460,7 +2459,7 @@ func onStart() {
 		assert.NotEqual(t, mySpriteSpeedMethod, otherSpriteSpeedMethod, "MySprite.Speed and OtherSprite.Speed should be different method objects")
 
 		// Test OtherSprite.Jump method
-		var otherSpriteJumpMethod *types.Func
+		var otherSpriteJumpMethod *gotypes.Func
 		for m := range otherSpriteType.Methods() {
 			if m.Name() == "Jump" {
 				otherSpriteJumpMethod = m
@@ -2513,7 +2512,7 @@ func onStart() {
 		// Test with Const (not Var or Func)
 		constObj := pkg.Scope().Lookup("MyConst")
 		if constObj != nil {
-			_, ok := constObj.(*types.Const)
+			_, ok := constObj.(*gotypes.Const)
 			if ok {
 				// Test findEnclosingType with Const (not Var or Func)
 				enclosingType := findEnclosingType(constObj)
@@ -2524,10 +2523,10 @@ func onStart() {
 		// Test with a free function (helper function without receiver)
 		helperFuncObj := pkg.Scope().Lookup("helperFunction")
 		if helperFuncObj != nil {
-			funcObj, ok := helperFuncObj.(*types.Func)
+			funcObj, ok := helperFuncObj.(*gotypes.Func)
 			if ok {
 				// Check if it has a receiver
-				sig, ok := funcObj.Type().(*types.Signature)
+				sig, ok := funcObj.Type().(*gotypes.Signature)
 				if ok && sig.Recv() == nil {
 					// Test findEnclosingType with free function
 					enclosingType := findEnclosingType(funcObj)
@@ -2557,11 +2556,11 @@ func onStart() {
 		// Create a synthetic method with a non-named receiver type
 		// to trigger the "namedType, ok := recvType.(*types.Named); if !ok" path
 
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		// Create a signature with this receiver
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
 		// Create a Func with this signature
-		funcObj := types.NewFunc(0, pkg, "MethodOnBasicType", sig)
+		funcObj := gotypes.NewFunc(0, pkg, "MethodOnBasicType", sig)
 
 		enclosingType := findEnclosingTypeForMethod(funcObj)
 		assert.Nil(t, enclosingType, "Method with non-Named receiver should return nil")
@@ -2571,13 +2570,13 @@ func onStart() {
 		// Create a synthetic method with a pointer to basic type receiver
 		// Even after DerefType, it should still be a basic type, not Named
 
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		// Create a receiver with a pointer to basic type
-		recv := types.NewVar(0, pkg, "recv", types.NewPointer(types.Typ[types.String]))
+		recv := gotypes.NewVar(0, pkg, "recv", gotypes.NewPointer(gotypes.Typ[gotypes.String]))
 		// Create a signature with this receiver
-		sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+		sig := gotypes.NewSignatureType(recv, nil, nil, nil, nil, false)
 		// Create a Func with this signature
-		funcObj := types.NewFunc(0, pkg, "MethodOnPointerToBasic", sig)
+		funcObj := gotypes.NewFunc(0, pkg, "MethodOnPointerToBasic", sig)
 
 		enclosingType := findEnclosingTypeForMethod(funcObj)
 		assert.Nil(t, enclosingType, "Method with pointer to basic type receiver should return nil")
@@ -2587,15 +2586,15 @@ func onStart() {
 		// Create a synthetic method with an interface receiver
 		// Interfaces are not *types.Named (though they can be underlying type of Named)
 
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		// Create an interface type directly (not as underlying of a Named type)
-		iface := types.NewInterfaceType(nil, nil).Complete()
+		iface := gotypes.NewInterfaceType(nil, nil).Complete()
 		// Create a receiver with this interface type
-		recv := types.NewVar(0, pkg, "recv", iface)
+		recv := gotypes.NewVar(0, pkg, "recv", iface)
 		// Create a signature with this receiver
-		sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+		sig := gotypes.NewSignatureType(recv, nil, nil, nil, nil, false)
 		// Create a Func with this signature
-		funcObj := types.NewFunc(0, pkg, "MethodOnInterface", sig)
+		funcObj := gotypes.NewFunc(0, pkg, "MethodOnInterface", sig)
 
 		enclosingType := findEnclosingTypeForMethod(funcObj)
 		assert.Nil(t, enclosingType, "Method with interface receiver should return nil")
@@ -2605,15 +2604,15 @@ func onStart() {
 		// Create a synthetic method with a struct receiver (not a Named type)
 		// The struct itself is not Named, only *types.Named wrapping it would be
 
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		// Create a struct type directly (not wrapped in Named)
-		structType := types.NewStruct(nil, nil)
+		structType := gotypes.NewStruct(nil, nil)
 		// Create a receiver with this struct type
-		recv := types.NewVar(0, pkg, "recv", structType)
+		recv := gotypes.NewVar(0, pkg, "recv", structType)
 		// Create a signature with this receiver
-		sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+		sig := gotypes.NewSignatureType(recv, nil, nil, nil, nil, false)
 		// Create a Func with this signature
-		funcObj := types.NewFunc(0, pkg, "MethodOnStruct", sig)
+		funcObj := gotypes.NewFunc(0, pkg, "MethodOnStruct", sig)
 
 		enclosingType := findEnclosingTypeForMethod(funcObj)
 		assert.Nil(t, enclosingType, "Method with non-Named struct receiver should return nil")
@@ -2623,52 +2622,52 @@ func onStart() {
 		// This test covers the continue branches in findEnclosingTypeForField
 		// by creating a package scope with various types of objects using the types package
 
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		scope := pkg.Scope()
 
 		// Create various objects in the scope to trigger different continue branches:
 
 		// 1. Add a Const (not a TypeName) - triggers line 328 continue
-		constObj := types.NewConst(0, pkg, "MyConst", types.Typ[types.Int], nil)
+		constObj := gotypes.NewConst(0, pkg, "MyConst", gotypes.Typ[gotypes.Int], nil)
 		scope.Insert(constObj)
 
 		// 2. Add a Var (not a TypeName) - triggers line 328 continue
-		varObj := types.NewVar(0, pkg, "MyVar", types.Typ[types.String])
+		varObj := gotypes.NewVar(0, pkg, "MyVar", gotypes.Typ[gotypes.String])
 		scope.Insert(varObj)
 
 		// 3. Add a Func (not a TypeName) - triggers line 328 continue
-		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		funcObj := types.NewFunc(0, pkg, "MyFunc", sig)
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		funcObj := gotypes.NewFunc(0, pkg, "MyFunc", sig)
 		scope.Insert(funcObj)
 
 		// 4. Add a type alias (TypeName but Type is not Named) - triggers line 333 continue
 		// Note: Type aliases in go/types are represented as TypeName with underlying type
-		aliasObj := types.NewTypeName(0, pkg, "IntAlias", types.Typ[types.Int])
+		aliasObj := gotypes.NewTypeName(0, pkg, "IntAlias", gotypes.Typ[gotypes.Int])
 		scope.Insert(aliasObj)
 
 		// 5. Add a named int type (Named but underlying is not Struct) - triggers line 338 continue
-		namedIntType := types.NewNamed(
-			types.NewTypeName(0, pkg, "MyInt", nil),
-			types.Typ[types.Int],
+		namedIntType := gotypes.NewNamed(
+			gotypes.NewTypeName(0, pkg, "MyInt", nil),
+			gotypes.Typ[gotypes.Int],
 			nil,
 		)
 		scope.Insert(namedIntType.Obj())
 
 		// 6. Add a named interface type (Named but underlying is Interface) - triggers line 338 continue
-		namedInterfaceType := types.NewNamed(
-			types.NewTypeName(0, pkg, "MyInterface", nil),
-			types.NewInterfaceType(nil, nil).Complete(),
+		namedInterfaceType := gotypes.NewNamed(
+			gotypes.NewTypeName(0, pkg, "MyInterface", nil),
+			gotypes.NewInterfaceType(nil, nil).Complete(),
 			nil,
 		)
 		scope.Insert(namedInterfaceType.Obj())
 
 		// 7. Finally, add a proper struct type with a field
-		structType := types.NewStruct([]*types.Var{
-			types.NewField(0, pkg, "x", types.Typ[types.Int], false),
-			types.NewField(0, pkg, "y", types.Typ[types.Int], false),
+		structType := gotypes.NewStruct([]*gotypes.Var{
+			gotypes.NewField(0, pkg, "x", gotypes.Typ[gotypes.Int], false),
+			gotypes.NewField(0, pkg, "y", gotypes.Typ[gotypes.Int], false),
 		}, nil)
-		namedStructType := types.NewNamed(
-			types.NewTypeName(0, pkg, "MyStruct", nil),
+		namedStructType := gotypes.NewNamed(
+			gotypes.NewTypeName(0, pkg, "MyStruct", nil),
 			structType,
 			nil,
 		)
@@ -2695,33 +2694,33 @@ func onStart() {
 	t.Run("FieldNotFoundInAnyStruct", func(t *testing.T) {
 		// Test the final "return nil" (line 353) when field is not found in any struct
 
-		pkg := types.NewPackage("test", "test")
+		pkg := gotypes.NewPackage("test", "test")
 		scope := pkg.Scope()
 
 		// Create a struct with field x
-		structType1 := types.NewStruct([]*types.Var{
-			types.NewField(0, pkg, "x", types.Typ[types.Int], false),
+		structType1 := gotypes.NewStruct([]*gotypes.Var{
+			gotypes.NewField(0, pkg, "x", gotypes.Typ[gotypes.Int], false),
 		}, nil)
-		namedStructType1 := types.NewNamed(
-			types.NewTypeName(0, pkg, "Struct1", nil),
+		namedStructType1 := gotypes.NewNamed(
+			gotypes.NewTypeName(0, pkg, "Struct1", nil),
 			structType1,
 			nil,
 		)
 		scope.Insert(namedStructType1.Obj())
 
 		// Create another struct with field y (not x)
-		structType2 := types.NewStruct([]*types.Var{
-			types.NewField(0, pkg, "y", types.Typ[types.Int], false),
+		structType2 := gotypes.NewStruct([]*gotypes.Var{
+			gotypes.NewField(0, pkg, "y", gotypes.Typ[gotypes.Int], false),
 		}, nil)
-		namedStructType2 := types.NewNamed(
-			types.NewTypeName(0, pkg, "Struct2", nil),
+		namedStructType2 := gotypes.NewNamed(
+			gotypes.NewTypeName(0, pkg, "Struct2", nil),
 			structType2,
 			nil,
 		)
 		scope.Insert(namedStructType2.Obj())
 
 		// Create a field that doesn't belong to any struct in the package
-		orphanField := types.NewField(0, pkg, "orphan", types.Typ[types.String], false)
+		orphanField := gotypes.NewField(0, pkg, "orphan", gotypes.Typ[gotypes.String], false)
 
 		// Try to find enclosing type for orphan field
 		enclosingType := findEnclosingTypeForField(orphanField)
@@ -2732,7 +2731,7 @@ func onStart() {
 		// Test field.Pkg() == nil case (line 314-315)
 		// Create a field with nil package
 
-		fieldWithNilPkg := types.NewField(0, nil, "fieldWithNilPkg", types.Typ[types.Int], false)
+		fieldWithNilPkg := gotypes.NewField(0, nil, "fieldWithNilPkg", gotypes.Typ[gotypes.Int], false)
 		assert.True(t, fieldWithNilPkg.IsField(), "Should be a field")
 		assert.Nil(t, fieldWithNilPkg.Pkg(), "Package should be nil")
 

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"path"
 	"slices"
 	"strconv"
@@ -10,9 +10,9 @@ import (
 	"sync"
 
 	"github.com/goplus/gogen"
-	xgoast "github.com/goplus/xgo/ast"
-	xgoscanner "github.com/goplus/xgo/scanner"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/scanner"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgo/x/typesutil"
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
 	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
@@ -37,7 +37,7 @@ type compileResult struct {
 	mainSpxFile string
 
 	// spxSpriteTypes stores the spx sprite types.
-	spxSpriteTypes map[types.Type]struct{}
+	spxSpriteTypes map[gotypes.Type]struct{}
 
 	// spxResourceSet is the set of spx resources.
 	spxResourceSet SpxResourceSet
@@ -50,7 +50,7 @@ type compileResult struct {
 	seenSpxResourceRefs map[SpxResourceRef]struct{}
 
 	// spxSpriteResourceAutoBindings stores spx sprite resource auto-bindings.
-	spxSpriteResourceAutoBindings map[types.Object]struct{}
+	spxSpriteResourceAutoBindings map[gotypes.Object]struct{}
 
 	// diagnostics stores diagnostic messages for each document.
 	diagnostics map[DocumentURI][]Diagnostic
@@ -67,8 +67,8 @@ type compileResult struct {
 func newCompileResult(proj *xgo.Project) *compileResult {
 	return &compileResult{
 		proj:                          proj,
-		spxSpriteTypes:                make(map[types.Type]struct{}),
-		spxSpriteResourceAutoBindings: make(map[types.Object]struct{}),
+		spxSpriteTypes:                make(map[gotypes.Type]struct{}),
+		spxSpriteResourceAutoBindings: make(map[gotypes.Object]struct{}),
 		diagnostics:                   make(map[DocumentURI][]Diagnostic),
 	}
 }
@@ -76,7 +76,7 @@ func newCompileResult(proj *xgo.Project) *compileResult {
 // spxDefinitionsFor returns all spx definitions for the given object. It
 // returns multiple definitions only if the object is an XGo overloadable
 // function.
-func (r *compileResult) spxDefinitionsFor(obj types.Object, selectorTypeName string) []SpxDefinition {
+func (r *compileResult) spxDefinitionsFor(obj gotypes.Object, selectorTypeName string) []SpxDefinition {
 	if obj == nil {
 		return nil
 	}
@@ -94,15 +94,15 @@ func (r *compileResult) spxDefinitionsFor(obj types.Object, selectorTypeName str
 
 	typeInfo, _ := r.proj.TypeInfo()
 	switch obj := obj.(type) {
-	case *types.Var:
+	case *gotypes.Var:
 		astPkg, _ := r.proj.ASTPackage()
 		forceVar := xgoutil.IsDefinedInClassFieldsDecl(r.proj.Fset, typeInfo, astPkg, obj)
 		return []SpxDefinition{GetSpxDefinitionForVar(obj, selectorTypeName, forceVar, pkgDoc)}
-	case *types.Const:
+	case *gotypes.Const:
 		return []SpxDefinition{GetSpxDefinitionForConst(obj, pkgDoc)}
-	case *types.TypeName:
+	case *gotypes.TypeName:
 		return []SpxDefinition{GetSpxDefinitionForType(obj, pkgDoc)}
-	case *types.Func:
+	case *gotypes.Func:
 		if typeInfo != nil {
 			if defIdent := typeInfo.ObjToDef[obj]; defIdent != nil && defIdent.Implicit() {
 				return nil
@@ -119,7 +119,7 @@ func (r *compileResult) spxDefinitionsFor(obj types.Object, selectorTypeName str
 			return defs
 		}
 		return []SpxDefinition{GetSpxDefinitionForFunc(obj, selectorTypeName, pkgDoc)}
-	case *types.PkgName:
+	case *gotypes.PkgName:
 		return []SpxDefinition{GetSpxDefinitionForPkg(obj, pkgDoc)}
 	}
 	return nil
@@ -128,7 +128,7 @@ func (r *compileResult) spxDefinitionsFor(obj types.Object, selectorTypeName str
 // spxDefinitionsForIdent returns all spx definitions for the given identifier.
 // It returns multiple definitions only if the identifier is an XGo
 // overloadable function.
-func (r *compileResult) spxDefinitionsForIdent(ident *xgoast.Ident) []SpxDefinition {
+func (r *compileResult) spxDefinitionsForIdent(ident *ast.Ident) []SpxDefinition {
 	if ident.Name == "_" {
 		return nil
 	}
@@ -141,9 +141,9 @@ func (r *compileResult) spxDefinitionsForIdent(ident *xgoast.Ident) []SpxDefinit
 
 // spxDefinitionsForNamedStruct returns all spx definitions for the given named
 // struct type.
-func (r *compileResult) spxDefinitionsForNamedStruct(named *types.Named) []SpxDefinition {
+func (r *compileResult) spxDefinitionsForNamedStruct(named *gotypes.Named) []SpxDefinition {
 	var defs []SpxDefinition
-	xgoutil.WalkStruct(named, func(member types.Object, selector *types.Named) bool {
+	xgoutil.WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
 		defs = append(defs, r.spxDefinitionsFor(member, selector.Obj().Name())...)
 		return true
 	})
@@ -152,7 +152,7 @@ func (r *compileResult) spxDefinitionsForNamedStruct(named *types.Named) []SpxDe
 
 // spxDefinitionForField returns the spx definition for the given field and
 // optional selector type name.
-func (r *compileResult) spxDefinitionForField(field *types.Var, selectorTypeName string) SpxDefinition {
+func (r *compileResult) spxDefinitionForField(field *gotypes.Var, selectorTypeName string) SpxDefinition {
 	var (
 		forceVar bool
 		pkgDoc   *pkgdoc.PkgDoc
@@ -176,7 +176,7 @@ func (r *compileResult) spxDefinitionForField(field *types.Var, selectorTypeName
 
 // spxDefinitionForMethod returns the spx definition for the given method and
 // optional selector type name.
-func (r *compileResult) spxDefinitionForMethod(method *types.Func, selectorTypeName string) SpxDefinition {
+func (r *compileResult) spxDefinitionForMethod(method *gotypes.Func, selectorTypeName string) SpxDefinition {
 	var pkgDoc *pkgdoc.PkgDoc
 	if typeInfo, _ := r.proj.TypeInfo(); typeInfo != nil {
 		if defIdent := typeInfo.ObjToDef[method]; defIdent != nil {
@@ -198,7 +198,7 @@ func (r *compileResult) spxDefinitionForMethod(method *types.Func, selectorTypeN
 
 // isInSpxEventHandler checks if the given position is inside an spx event
 // handler callback.
-func (r *compileResult) isInSpxEventHandler(pos xgotoken.Pos) bool {
+func (r *compileResult) isInSpxEventHandler(pos token.Pos) bool {
 	astPkg, _ := r.proj.ASTPackage()
 	astFile := xgoutil.PosASTFile(r.proj.Fset, astPkg, pos)
 	if astFile == nil {
@@ -210,12 +210,12 @@ func (r *compileResult) isInSpxEventHandler(pos xgotoken.Pos) bool {
 	}
 
 	var isIn bool
-	xgoutil.WalkPathEnclosingInterval(astFile, pos-1, pos, false, func(node xgoast.Node) bool {
-		callExpr, ok := node.(*xgoast.CallExpr)
+	xgoutil.WalkPathEnclosingInterval(astFile, pos-1, pos, false, func(node ast.Node) bool {
+		callExpr, ok := node.(*ast.CallExpr)
 		if !ok || len(callExpr.Args) == 0 {
 			return true
 		}
-		funcIdent, ok := callExpr.Fun.(*xgoast.Ident)
+		funcIdent, ok := callExpr.Fun.(*ast.Ident)
 		if !ok {
 			return true
 		}
@@ -230,7 +230,7 @@ func (r *compileResult) isInSpxEventHandler(pos xgotoken.Pos) bool {
 }
 
 // spxResourceRefAtPosition returns the spx resource reference at the given position.
-func (r *compileResult) spxResourceRefAtPosition(position xgotoken.Position) *SpxResourceRef {
+func (r *compileResult) spxResourceRefAtPosition(position token.Position) *SpxResourceRef {
 	var (
 		bestRef      *SpxResourceRef
 		bestNodeSpan int
@@ -256,7 +256,7 @@ func (r *compileResult) spxResourceRefAtPosition(position xgotoken.Position) *Sp
 }
 
 // spxImportsAtASTFilePosition returns the import at the given position in the given AST file.
-func (r *compileResult) spxImportsAtASTFilePosition(astFile *xgoast.File, position xgotoken.Position) *SpxReferencePkg {
+func (r *compileResult) spxImportsAtASTFilePosition(astFile *ast.File, position token.Position) *SpxReferencePkg {
 	fset := r.proj.Fset
 	for _, imp := range astFile.Imports {
 		nodePos := fset.Position(imp.Pos())
@@ -286,14 +286,14 @@ func (r *compileResult) spxImportsAtASTFilePosition(astFile *xgoast.File, positi
 }
 
 // hasSpxSpriteType reports whether the given type is an spx sprite type.
-func (r *compileResult) hasSpxSpriteType(typ types.Type) bool {
+func (r *compileResult) hasSpxSpriteType(typ gotypes.Type) bool {
 	_, ok := r.spxSpriteTypes[typ]
 	return ok
 }
 
 // hasSpxSpriteResourceAutoBinding reports whether the given object is an spx
 // resource auto-binding.
-func (r *compileResult) hasSpxSpriteResourceAutoBinding(obj types.Object) bool {
+func (r *compileResult) hasSpxSpriteResourceAutoBinding(obj gotypes.Object) bool {
 	_, ok := r.spxSpriteResourceAutoBindings[obj]
 	return ok
 }
@@ -370,7 +370,7 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 		astFile, err := snapshot.ASTFile(spxFile)
 		if err != nil {
 			var (
-				errorList xgoscanner.ErrorList
+				errorList scanner.ErrorList
 				codeError *gogen.CodeError
 			)
 			if errors.As(err, &errorList) && astFile.Pos().IsValid() {
@@ -460,7 +460,7 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 		spriteName := strings.TrimSuffix(path.Base(file), ".spx")
 		obj := pkg.Scope().Lookup(spriteName)
 		if obj != nil {
-			named, ok := xgoutil.DerefType(obj.Type()).(*types.Named)
+			named, ok := xgoutil.DerefType(obj.Type()).(*gotypes.Named)
 			if ok {
 				result.spxSpriteTypes[named] = struct{}{}
 			}
@@ -477,7 +477,7 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 // compileAndGetASTFileForDocumentURI handles common compilation and file
 // retrieval logic for a given document URI. The returned astFile is probably
 // nil even if the compilation succeeded.
-func (s *Server) compileAndGetASTFileForDocumentURI(uri DocumentURI) (result *compileResult, spxFile string, astFile *xgoast.File, err error) {
+func (s *Server) compileAndGetASTFileForDocumentURI(uri DocumentURI) (result *compileResult, spxFile string, astFile *ast.File, err error) {
 	spxFile, err = s.fromDocumentURI(uri)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("failed to get file path from document URI %q: %w", uri, err)
@@ -543,11 +543,11 @@ func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
 		// GetPropertyNamesForCall results per CallExpr. Two maps are needed
 		// because a cached nil (unknown target → skip validation) must be
 		// distinguished from a missing entry.
-		propertyNamesCached := make(map[*xgoast.CallExpr]struct{})
-		propertyNamesCache := make(map[*xgoast.CallExpr][]string)
+		propertyNamesCached := make(map[*ast.CallExpr]struct{})
+		propertyNamesCache := make(map[*ast.CallExpr][]string)
 		pass := &protocol.Pass{
 			Fset:      fset,
-			Files:     []*xgoast.File{astFile},
+			Files:     []*ast.File{astFile},
 			Pkg:       typeInfo.Pkg,
 			TypesInfo: typeInfo,
 			Report: func(d protocol.Diagnostic) {
@@ -558,10 +558,10 @@ func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
 				})
 			},
 			ResultOf: map[*protocol.Analyzer]any{
-				inspect.Analyzer: inspector.New([]*xgoast.File{astFile}),
+				inspect.Analyzer: inspector.New([]*ast.File{astFile}),
 			},
 			IsPropertyNameType: IsSpxPropertyNameType,
-			GetPropertyNamesForCall: func(call *xgoast.CallExpr) []string {
+			GetPropertyNamesForCall: func(call *ast.CallExpr) []string {
 				if _, ok := propertyNamesCached[call]; ok {
 					return propertyNamesCache[call]
 				}
@@ -571,7 +571,7 @@ func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
 					return nil
 				}
 				var names []string
-				walkPropertyMembers(named, makePkgDocFor(pkgDoc), make(map[*types.Named]bool), make(map[string]bool), func(m propertyMember) {
+				walkPropertyMembers(named, makePkgDocFor(pkgDoc), make(map[*gotypes.Named]bool), make(map[string]bool), func(m propertyMember) {
 					names = append(names, m.Name)
 				})
 				propertyNamesCache[call] = names
@@ -612,11 +612,11 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 		}
 
 		switch obj.(type) {
-		case *types.Const, *types.Var:
+		case *gotypes.Const, *gotypes.Var:
 			if ident.Obj == nil {
 				break
 			}
-			valueSpec, ok := ident.Obj.Decl.(*xgoast.ValueSpec)
+			valueSpec, ok := ident.Obj.Decl.(*ast.ValueSpec)
 			if !ok {
 				break
 			}
@@ -637,8 +637,8 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 		}
 
 		switch expr := expr.(type) {
-		case *xgoast.BasicLit:
-			if expr.Kind == xgotoken.STRING {
+		case *ast.BasicLit:
+			if expr.Kind == token.STRING {
 				if returnType := s.resolveReturnTypeForExpr(result, expr); returnType != nil {
 					getSpriteContext := sync.OnceValue(func() *SpxSpriteResource {
 						spxFileBaseName := path.Base(xgoutil.NodeFilename(result.proj.Fset, expr))
@@ -653,7 +653,7 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 					s.inspectSpxResourceRefForTypeAtExpr(result, expr, xgoutil.DerefType(tv.Type), nil)
 				}
 			}
-		case *xgoast.Ident:
+		case *ast.Ident:
 			typ := xgoutil.DerefType(tv.Type)
 			switch typ {
 			case GetSpxBackdropNameType(),
@@ -662,7 +662,7 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 				GetSpxWidgetNameType():
 				s.inspectSpxResourceRefForTypeAtExpr(result, s.resolveIdentifierToAssignedExpr(result, expr), typ, nil)
 			}
-		case *xgoast.CallExpr:
+		case *ast.CallExpr:
 			fun := xgoutil.FuncFromCallExpr(typeInfo, expr)
 			if fun == nil || !HasSpxResourceNameTypeParams(fun) {
 				continue
@@ -671,11 +671,11 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 			getSpriteContext := sync.OnceValue(func() *SpxSpriteResource {
 				return s.resolveSpxSpriteContextFromCallExpr(result, expr)
 			})
-			xgoutil.WalkCallExprArgs(typeInfo, expr, func(fun *types.Func, params *types.Tuple, paramIndex int, arg xgoast.Expr, argIndex int) bool {
+			xgoutil.WalkCallExprArgs(typeInfo, expr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 				param := params.At(paramIndex)
 				paramType := xgoutil.DerefType(param.Type())
 
-				if sliceLit, ok := arg.(*xgoast.SliceLit); ok {
+				if sliceLit, ok := arg.(*ast.SliceLit); ok {
 					for _, elt := range sliceLit.Elts {
 						s.inspectSpxResourceRefForTypeAtExpr(result, elt, paramType, getSpriteContext)
 					}
@@ -700,16 +700,16 @@ func (s *Server) inspectForAutoBindingSpxResources(result *compileResult) {
 	if gameObj == nil {
 		return
 	}
-	gameType, ok := gameObj.Type().(*types.Named)
+	gameType, ok := gameObj.Type().(*gotypes.Named)
 	if !ok || !xgoutil.IsNamedStructType(gameType) {
 		return
 	}
-	xgoutil.WalkStruct(gameType, func(member types.Object, selector *types.Named) bool {
-		field, ok := member.(*types.Var)
+	xgoutil.WalkStruct(gameType, func(member gotypes.Object, selector *gotypes.Named) bool {
+		field, ok := member.(*gotypes.Var)
 		if !ok {
 			return true
 		}
-		fieldType, ok := xgoutil.DerefType(field.Type()).(*types.Named)
+		fieldType, ok := xgoutil.DerefType(field.Type()).(*gotypes.Named)
 		if !ok {
 			return true
 		}
@@ -731,21 +731,21 @@ func (s *Server) inspectForAutoBindingSpxResources(result *compileResult) {
 
 // resolveIdentifierToAssignedExpr resolves an identifier to its assigned
 // expression by looking for assignment statements in the AST.
-func (s *Server) resolveIdentifierToAssignedExpr(result *compileResult, ident *xgoast.Ident) xgoast.Expr {
+func (s *Server) resolveIdentifierToAssignedExpr(result *compileResult, ident *ast.Ident) ast.Expr {
 	astPkg, _ := result.proj.ASTPackage()
 	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, ident)
 	if astFile == nil {
 		return ident
 	}
 
-	var resolvedExpr xgoast.Expr = ident
-	xgoutil.WalkPathEnclosingInterval(astFile, ident.Pos(), ident.End(), false, func(node xgoast.Node) bool {
-		assignStmt, ok := node.(*xgoast.AssignStmt)
+	var resolvedExpr ast.Expr = ident
+	xgoutil.WalkPathEnclosingInterval(astFile, ident.Pos(), ident.End(), false, func(node ast.Node) bool {
+		assignStmt, ok := node.(*ast.AssignStmt)
 		if !ok {
 			return true
 		}
 
-		idx := slices.IndexFunc(assignStmt.Lhs, func(lhs xgoast.Expr) bool {
+		idx := slices.IndexFunc(assignStmt.Lhs, func(lhs ast.Expr) bool {
 			return lhs == ident
 		})
 		if idx < 0 || idx >= len(assignStmt.Rhs) {
@@ -759,7 +759,7 @@ func (s *Server) resolveIdentifierToAssignedExpr(result *compileResult, ident *x
 
 // resolveReturnTypeForExpr resolves the function return type for an expression
 // when it appears in a return statement.
-func (s *Server) resolveReturnTypeForExpr(result *compileResult, expr xgoast.Expr) types.Type {
+func (s *Server) resolveReturnTypeForExpr(result *compileResult, expr ast.Expr) gotypes.Type {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -795,7 +795,7 @@ func (s *Server) resolveReturnTypeForExpr(result *compileResult, expr xgoast.Exp
 }
 
 // resolveSpxSpriteContextFromCallExpr resolves the sprite context from a call expression.
-func (s *Server) resolveSpxSpriteContextFromCallExpr(result *compileResult, callExpr *xgoast.CallExpr) *SpxSpriteResource {
+func (s *Server) resolveSpxSpriteContextFromCallExpr(result *compileResult, callExpr *ast.CallExpr) *SpxSpriteResource {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -805,7 +805,7 @@ func (s *Server) resolveSpxSpriteContextFromCallExpr(result *compileResult, call
 	if !xgoutil.IsValidType(funcType) {
 		return nil
 	}
-	funcSig, ok := funcType.(*types.Signature)
+	funcSig, ok := funcType.(*gotypes.Signature)
 	if !ok {
 		return nil
 	}
@@ -820,11 +820,11 @@ func (s *Server) resolveSpxSpriteContextFromCallExpr(result *compileResult, call
 	}
 
 	switch fun := callExpr.Fun.(type) {
-	case *xgoast.Ident:
+	case *ast.Ident:
 		spxSpriteName := strings.TrimSuffix(path.Base(xgoutil.NodeFilename(result.proj.Fset, callExpr)), ".spx")
 		return result.spxResourceSet.Sprite(spxSpriteName)
-	case *xgoast.SelectorExpr:
-		ident, ok := fun.X.(*xgoast.Ident)
+	case *ast.SelectorExpr:
+		ident, ok := fun.X.(*ast.Ident)
 		if !ok {
 			return nil
 		}
@@ -845,7 +845,7 @@ func (s *Server) resolveSpxSpriteContextFromCallExpr(result *compileResult, call
 
 // inspectSpxResourceRefForTypeAtExpr inspects an spx resource reference for a
 // given type at an expression.
-func (s *Server) inspectSpxResourceRefForTypeAtExpr(result *compileResult, expr xgoast.Expr, typ types.Type, getSpriteContext func() *SpxSpriteResource) {
+func (s *Server) inspectSpxResourceRefForTypeAtExpr(result *compileResult, expr ast.Expr, typ gotypes.Type, getSpriteContext func() *SpxSpriteResource) {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return
@@ -857,7 +857,7 @@ func (s *Server) inspectSpxResourceRefForTypeAtExpr(result *compileResult, expr 
 		return
 	}
 	spxResourceRefKind := SpxResourceRefKindStringLiteral
-	if _, ok := expr.(*xgoast.Ident); ok {
+	if _, ok := expr.(*ast.Ident); ok {
 		spxResourceRefKind = SpxResourceRefKindConstantReference
 	}
 
@@ -962,7 +962,7 @@ func (s *Server) inspectSpxResourceRefForTypeAtExpr(result *compileResult, expr 
 }
 
 // addEmptySpxResourceNameDiagnostic adds a diagnostic for empty spx resource name.
-func (s *Server) addEmptySpxResourceNameDiagnostic(result *compileResult, expr xgoast.Expr, resourceType string) {
+func (s *Server) addEmptySpxResourceNameDiagnostic(result *compileResult, expr ast.Expr, resourceType string) {
 	result.addDiagnostics(s.nodeDocumentURI(result.proj, expr), Diagnostic{
 		Severity: SeverityError,
 		Range:    RangeForNode(result.proj, expr),
@@ -971,7 +971,7 @@ func (s *Server) addEmptySpxResourceNameDiagnostic(result *compileResult, expr x
 }
 
 // addSpxResourceNotFoundDiagnostic adds a diagnostic for spx resource not found.
-func (s *Server) addSpxResourceNotFoundDiagnostic(result *compileResult, expr xgoast.Expr, resourceType, resourceName, contextSpriteName string) {
+func (s *Server) addSpxResourceNotFoundDiagnostic(result *compileResult, expr ast.Expr, resourceType, resourceName, contextSpriteName string) {
 	message := fmt.Sprintf("%s resource %q not found", resourceType, resourceName)
 	if contextSpriteName != "" {
 		message = fmt.Sprintf("%s in sprite %q", message, contextSpriteName)

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -3,20 +3,20 @@ package server
 import (
 	"cmp"
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"path"
 	"slices"
 	"strconv"
 	"strings"
 	"unicode"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgoscanner "github.com/goplus/xgo/scanner"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/scanner"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/internal/pkgdata"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -91,26 +91,26 @@ type completionContext struct {
 	itemSet *completionItemSet
 
 	proj           *xgo.Project
-	typeInfo       *xgotypes.Info
+	typeInfo       *types.Info
 	result         *compileResult
 	spxFile        string
-	astFile        *xgoast.File
-	astFileScope   *types.Scope
-	tokenFile      *xgotoken.File
-	pos            xgotoken.Pos
-	innermostScope *types.Scope
+	astFile        *ast.File
+	astFileScope   *gotypes.Scope
+	tokenFile      *token.File
+	pos            token.Pos
+	innermostScope *gotypes.Scope
 
 	kind completionKind
 
-	enclosingNode      xgoast.Node
-	enclosingCallExpr  *xgoast.CallExpr
-	selectorExpr       *xgoast.SelectorExpr
-	expectedTypes      []types.Type
-	expectedStructType *types.Struct
-	compositeLitType   *types.Named
-	assignTargets      []*xgoast.Ident
-	declValueSpec      *xgoast.ValueSpec
-	switchTag          xgoast.Expr
+	enclosingNode      ast.Node
+	enclosingCallExpr  *ast.CallExpr
+	selectorExpr       *ast.SelectorExpr
+	expectedTypes      []gotypes.Type
+	expectedStructType *gotypes.Struct
+	compositeLitType   *gotypes.Named
+	assignTargets      []*ast.Ident
+	declValueSpec      *ast.ValueSpec
+	switchTag          ast.Expr
 	returnIndex        int
 
 	inStringLit             bool
@@ -128,14 +128,14 @@ func (ctx *completionContext) analyze() {
 	}
 	for i, node := range slices.Backward(path) {
 		switch node := node.(type) {
-		case *xgoast.ImportSpec:
+		case *ast.ImportSpec:
 			ctx.kind = completionKindImport
-		case *xgoast.SelectorExpr:
+		case *ast.SelectorExpr:
 			if node.Sel == nil || node.Sel.End() >= ctx.pos {
 				ctx.kind = completionKindDot
 				ctx.selectorExpr = node
 			}
-		case *xgoast.CallExpr:
+		case *ast.CallExpr:
 			if ctx.enclosingCallExpr == nil {
 				ctx.enclosingCallExpr = node
 			}
@@ -155,14 +155,14 @@ func (ctx *completionContext) analyze() {
 			if shouldSetCallContext {
 				for _, arg := range node.Args {
 					// Check for SliceLit (XGo-style slice literals)
-					if sl, ok := arg.(*xgoast.SliceLit); ok {
+					if sl, ok := arg.(*ast.SliceLit); ok {
 						if sl.Pos() <= ctx.pos && ctx.pos <= sl.End() {
 							shouldSetCallContext = false
 							break
 						}
 					}
 
-					comp, ok := arg.(*xgoast.CompositeLit)
+					comp, ok := arg.(*ast.CompositeLit)
 					if !ok {
 						continue
 					}
@@ -182,7 +182,7 @@ func (ctx *completionContext) analyze() {
 						// Also don't set call context if we're in a struct literal
 						// field value position.
 						for _, elt := range comp.Elts {
-							if kv, ok := elt.(*xgoast.KeyValueExpr); ok {
+							if kv, ok := elt.(*ast.KeyValueExpr); ok {
 								if kv.Colon < ctx.pos {
 									shouldSetCallContext = false
 									break
@@ -201,15 +201,15 @@ func (ctx *completionContext) analyze() {
 				ctx.enclosingNode = node
 				ctx.valueExpression = true
 			}
-		case *xgoast.FuncLit:
+		case *ast.FuncLit:
 			// Skip FuncLit, as we want general completion inside function literals
 			// to allow access to all variables and identifiers.
 			continue
-		case *xgoast.SliceLit:
+		case *ast.SliceLit:
 			// Skip SliceLit, as XGo-style slice literals should allow general completion
 			// to access all variables and identifiers.
 			continue
-		case *xgoast.CompositeLit:
+		case *ast.CompositeLit:
 			typ := ctx.typeInfo.TypeOf(node)
 			if !xgoutil.IsValidType(typ) {
 				// Try to get type from the CompositeLit.Type field.
@@ -233,13 +233,13 @@ func (ctx *completionContext) analyze() {
 
 			// Skip slice and array literals, as they should also use general completion
 			// to allow variable suggestions inside the literal.
-			if _, ok := typ.Underlying().(*types.Slice); ok {
+			if _, ok := typ.Underlying().(*gotypes.Slice); ok {
 				if ctx.valueExprAtPos(node) != nil {
 					ctx.valueExpression = true
 				}
 				continue
 			}
-			if _, ok := typ.Underlying().(*types.Array); ok {
+			if _, ok := typ.Underlying().(*gotypes.Array); ok {
 				if ctx.valueExprAtPos(node) != nil {
 					ctx.valueExpression = true
 				}
@@ -251,7 +251,7 @@ func (ctx *completionContext) analyze() {
 				continue
 			}
 			typ = named
-			st, ok := named.Underlying().(*types.Struct)
+			st, ok := named.Underlying().(*gotypes.Struct)
 			if !ok {
 				continue
 			}
@@ -260,7 +260,7 @@ func (ctx *completionContext) analyze() {
 			// If so, we want general completion for the value, not struct field completion.
 			inFieldValue := false
 			for _, elt := range node.Elts {
-				if kv, ok := elt.(*xgoast.KeyValueExpr); ok {
+				if kv, ok := elt.(*ast.KeyValueExpr); ok {
 					// Check if cursor is in the value part of the key-value pair.
 					if kv.Colon < ctx.pos && ctx.pos <= kv.Value.End() {
 						inFieldValue = true
@@ -280,8 +280,8 @@ func (ctx *completionContext) analyze() {
 			ctx.expectedStructType = st
 			ctx.compositeLitType = named
 			ctx.enclosingNode = node
-		case *xgoast.AssignStmt:
-			if node.Tok != xgotoken.ASSIGN && node.Tok != xgotoken.DEFINE {
+		case *ast.AssignStmt:
+			if node.Tok != token.ASSIGN && node.Tok != token.DEFINE {
 				continue
 			}
 			for j, rhs := range node.Rhs {
@@ -295,9 +295,9 @@ func (ctx *completionContext) analyze() {
 					ctx.kind = completionKindAssignOrDefine
 					ctx.valueExpression = true
 					if typ := ctx.typeInfo.TypeOf(node.Lhs[j]); xgoutil.IsValidType(typ) {
-						ctx.expectedTypes = []types.Type{typ}
+						ctx.expectedTypes = []gotypes.Type{typ}
 					}
-					if ident, ok := node.Lhs[j].(*xgoast.Ident); ok {
+					if ident, ok := node.Lhs[j].(*ast.Ident); ok {
 						defIdent := ctx.typeInfo.ObjToDef[ctx.typeInfo.ObjectOf(ident)]
 						if defIdent != nil {
 							ctx.assignTargets = append(ctx.assignTargets, defIdent)
@@ -306,7 +306,7 @@ func (ctx *completionContext) analyze() {
 
 					if len(node.Lhs) > 1 && len(node.Rhs) == 1 {
 						ctx.expectedFuncResultCount = len(node.Lhs)
-						resultVars := make([]*types.Var, 0, len(node.Lhs))
+						resultVars := make([]*gotypes.Var, 0, len(node.Lhs))
 						hasAllTypes := true
 						for _, lhsExpr := range node.Lhs {
 							typ := ctx.typeInfo.TypeOf(lhsExpr)
@@ -314,17 +314,17 @@ func (ctx *completionContext) analyze() {
 								hasAllTypes = false
 								break
 							}
-							resultVars = append(resultVars, types.NewVar(lhsExpr.Pos(), ctx.typeInfo.Pkg, "", typ))
+							resultVars = append(resultVars, gotypes.NewVar(lhsExpr.Pos(), ctx.typeInfo.Pkg, "", typ))
 						}
 						if hasAllTypes {
-							sig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(resultVars...), false)
+							sig := gotypes.NewSignatureType(nil, nil, nil, nil, gotypes.NewTuple(resultVars...), false)
 							ctx.expectedTypes = append(ctx.expectedTypes, sig)
 						}
 					}
 					break
 				}
 			}
-		case *xgoast.ReturnStmt:
+		case *ast.ReturnStmt:
 			sig := ctx.enclosingFunction(path[i+1:])
 			if sig == nil {
 				continue
@@ -338,20 +338,20 @@ func (ctx *completionContext) analyze() {
 			// return statement. If the cursor is in a value position, we should allow
 			// general completion instead of restricting to return type completion.
 			shouldSetReturnContext := true
-			var mapValueExpectedType types.Type
+			var mapValueExpectedType gotypes.Type
 			for j, result := range node.Results {
 				// Check for CompositeLit directly or within UnaryExpr (e.g., &Struct{}).
-				var comp *xgoast.CompositeLit
-				var sliceLit *xgoast.SliceLit
+				var comp *ast.CompositeLit
+				var sliceLit *ast.SliceLit
 				switch expr := result.(type) {
-				case *xgoast.CompositeLit:
+				case *ast.CompositeLit:
 					comp = expr
-				case *xgoast.SliceLit:
+				case *ast.SliceLit:
 					// Handle XGo-style slice literal [...].
 					sliceLit = expr
-				case *xgoast.UnaryExpr:
+				case *ast.UnaryExpr:
 					// Handle &Struct{...} case.
-					if c, ok := expr.X.(*xgoast.CompositeLit); ok {
+					if c, ok := expr.X.(*ast.CompositeLit); ok {
 						comp = c
 					}
 				}
@@ -369,7 +369,7 @@ func (ctx *completionContext) analyze() {
 					// Check if we're in a value position inside a composite literal.
 					// This applies to maps, slices, and arrays.
 					if valueExpr := ctx.valueExprAtPos(comp); valueExpr != nil {
-						var expected types.Type
+						var expected gotypes.Type
 						if j < results.Len() {
 							expected = results.At(j).Type()
 						}
@@ -397,21 +397,21 @@ func (ctx *completionContext) analyze() {
 
 			if mapValueExpectedType == nil {
 				if idx := ctx.findReturnValueIndex(node); idx >= 0 && idx < results.Len() {
-					if mapType, ok := xgoutil.DerefType(results.At(idx).Type()).Underlying().(*types.Map); ok {
+					if mapType, ok := xgoutil.DerefType(results.At(idx).Type()).Underlying().(*gotypes.Map); ok {
 						mapValueExpectedType = mapType.Elem()
 					}
 				}
 			}
 			if mapValueExpectedType == nil {
 				for result := range results.Variables() {
-					if mapType, ok := xgoutil.DerefType(result.Type()).Underlying().(*types.Map); ok {
+					if mapType, ok := xgoutil.DerefType(result.Type()).Underlying().(*gotypes.Map); ok {
 						mapValueExpectedType = mapType.Elem()
 						break
 					}
 				}
 			}
 			if mapValueExpectedType != nil {
-				ctx.expectedTypes = []types.Type{mapValueExpectedType}
+				ctx.expectedTypes = []gotypes.Type{mapValueExpectedType}
 				ctx.valueExpression = true
 			}
 
@@ -420,32 +420,32 @@ func (ctx *completionContext) analyze() {
 				ctx.valueExpression = true
 				ctx.returnIndex = ctx.findReturnValueIndex(node)
 				if ctx.returnIndex >= 0 && ctx.returnIndex < results.Len() {
-					ctx.expectedTypes = []types.Type{results.At(ctx.returnIndex).Type()}
+					ctx.expectedTypes = []gotypes.Type{results.At(ctx.returnIndex).Type()}
 				}
 			}
-		case *xgoast.GoStmt:
+		case *ast.GoStmt:
 			if ctx.enclosingCallExpr == nil {
 				ctx.enclosingCallExpr = node.Call
 			}
 			ctx.kind = completionKindCall
 			ctx.enclosingNode = node.Call
 			ctx.valueExpression = true
-		case *xgoast.DeferStmt:
+		case *ast.DeferStmt:
 			if ctx.enclosingCallExpr == nil {
 				ctx.enclosingCallExpr = node.Call
 			}
 			ctx.kind = completionKindCall
 			ctx.enclosingNode = node.Call
 			ctx.valueExpression = true
-		case *xgoast.SwitchStmt:
+		case *ast.SwitchStmt:
 			ctx.kind = completionKindSwitchCase
 			ctx.switchTag = node.Tag
-		case *xgoast.SelectStmt:
+		case *ast.SelectStmt:
 			ctx.kind = completionKindSelect
-		case *xgoast.DeclStmt:
-			if genDecl, ok := node.Decl.(*xgoast.GenDecl); ok && (genDecl.Tok == xgotoken.VAR || genDecl.Tok == xgotoken.CONST) {
+		case *ast.DeclStmt:
+			if genDecl, ok := node.Decl.(*ast.GenDecl); ok && (genDecl.Tok == token.VAR || genDecl.Tok == token.CONST) {
 				for _, spec := range genDecl.Specs {
-					valueSpec, ok := spec.(*xgoast.ValueSpec)
+					valueSpec, ok := spec.(*ast.ValueSpec)
 					if !ok || len(valueSpec.Names) == 0 {
 						continue
 					}
@@ -454,21 +454,21 @@ func (ctx *completionContext) analyze() {
 					}
 					ctx.kind = completionKindDecl
 					if typ := ctx.typeInfo.TypeOf(valueSpec.Type); xgoutil.IsValidType(typ) {
-						ctx.expectedTypes = []types.Type{typ}
+						ctx.expectedTypes = []gotypes.Type{typ}
 					}
 					ctx.assignTargets = valueSpec.Names
 					ctx.declValueSpec = valueSpec
 					break
 				}
 			}
-		case *xgoast.BasicLit:
-			if node.Kind == xgotoken.STRING {
+		case *ast.BasicLit:
+			if node.Kind == token.STRING {
 				if ctx.kind == completionKindUnknown {
 					ctx.kind = completionKindStringLit
 				}
 				ctx.inStringLit = true
 			}
-		case *xgoast.BlockStmt:
+		case *ast.BlockStmt:
 			ctx.kind = completionKindUnknown
 		}
 	}
@@ -491,8 +491,8 @@ func (ctx *completionContext) analyze() {
 
 // isInDisabledIdentifierContext reports whether the completion position is
 // inside an identifier context where completion should be suppressed.
-func (ctx *completionContext) isInDisabledIdentifierContext(path []xgoast.Node) bool {
-	ident := xgoutil.EnclosingNode[*xgoast.Ident](path)
+func (ctx *completionContext) isInDisabledIdentifierContext(path []ast.Node) bool {
+	ident := xgoutil.EnclosingNode[*ast.Ident](path)
 	if ident == nil {
 		return false
 	}
@@ -501,33 +501,33 @@ func (ctx *completionContext) isInDisabledIdentifierContext(path []xgoast.Node) 
 		return true
 	}
 
-	if funcDecl := xgoutil.EnclosingNode[*xgoast.FuncDecl](path); funcDecl != nil && funcDecl.Name == ident {
+	if funcDecl := xgoutil.EnclosingNode[*ast.FuncDecl](path); funcDecl != nil && funcDecl.Name == ident {
 		return true
 	}
 
-	if overloadDecl := xgoutil.EnclosingNode[*xgoast.OverloadFuncDecl](path); overloadDecl != nil && overloadDecl.Name == ident {
+	if overloadDecl := xgoutil.EnclosingNode[*ast.OverloadFuncDecl](path); overloadDecl != nil && overloadDecl.Name == ident {
 		return true
 	}
 
-	if importSpec := xgoutil.EnclosingNode[*xgoast.ImportSpec](path); importSpec != nil && importSpec.Name == ident {
+	if importSpec := xgoutil.EnclosingNode[*ast.ImportSpec](path); importSpec != nil && importSpec.Name == ident {
 		return true
 	}
 
-	if typeSpec := xgoutil.EnclosingNode[*xgoast.TypeSpec](path); typeSpec != nil && typeSpec.Name == ident {
+	if typeSpec := xgoutil.EnclosingNode[*ast.TypeSpec](path); typeSpec != nil && typeSpec.Name == ident {
 		return true
 	}
 
-	if valueSpec := xgoutil.EnclosingNode[*xgoast.ValueSpec](path); valueSpec != nil {
+	if valueSpec := xgoutil.EnclosingNode[*ast.ValueSpec](path); valueSpec != nil {
 		if slices.Contains(valueSpec.Names, ident) {
 			return true
 		}
 	}
 
-	if field := xgoutil.EnclosingNode[*xgoast.Field](path); field != nil && slices.Contains(field.Names, ident) {
+	if field := xgoutil.EnclosingNode[*ast.Field](path); field != nil && slices.Contains(field.Names, ident) {
 		return true
 	}
 
-	if labeledStmt := xgoutil.EnclosingNode[*xgoast.LabeledStmt](path); labeledStmt != nil && labeledStmt.Label == ident {
+	if labeledStmt := xgoutil.EnclosingNode[*ast.LabeledStmt](path); labeledStmt != nil && labeledStmt.Label == ident {
 		return true
 	}
 
@@ -548,33 +548,33 @@ func (ctx *completionContext) isInComment() bool {
 // isInImportStringLit reports whether the position of the current completion
 // context is inside an import string literal.
 func (ctx *completionContext) isInImportStringLit() bool {
-	var s xgoscanner.Scanner
+	var s scanner.Scanner
 	s.Init(ctx.tokenFile, ctx.astFile.Code, nil, 0)
 
 	var (
-		lastPos       xgotoken.Pos
-		lastTok       xgotoken.Token
+		lastPos       token.Pos
+		lastTok       token.Token
 		inImportGroup bool
 	)
 	for {
 		pos, tok, lit := s.Scan()
-		if tok == xgotoken.EOF {
+		if tok == token.EOF {
 			break
 		}
 
 		// Track if we're inside an import group.
-		if lastTok == xgotoken.IMPORT && tok == xgotoken.LPAREN {
+		if lastTok == token.IMPORT && tok == token.LPAREN {
 			inImportGroup = true
-		} else if tok == xgotoken.RPAREN {
+		} else if tok == token.RPAREN {
 			inImportGroup = false
 		}
 
 		// Check if we found `import` followed by `"` or we're in an import group.
-		if (lastTok == xgotoken.IMPORT || inImportGroup) &&
-			(tok == xgotoken.STRING || tok == xgotoken.ILLEGAL) {
+		if (lastTok == token.IMPORT || inImportGroup) &&
+			(tok == token.STRING || tok == token.ILLEGAL) {
 			// Check if position is after `import` keyword or within an import
 			// group, and inside a string literal (complete or incomplete).
-			if lastPos <= ctx.pos && ctx.pos <= pos+xgotoken.Pos(len(lit)) {
+			if lastPos <= ctx.pos && ctx.pos <= pos+token.Pos(len(lit)) {
 				return true
 			}
 		}
@@ -589,7 +589,7 @@ func (ctx *completionContext) isInImportStringLit() bool {
 // by a continuous sequence of non-whitespace characters (like an identifier or
 // a member access expression).
 func (ctx *completionContext) isLineStart() bool {
-	fileBase := xgotoken.Pos(ctx.tokenFile.Base())
+	fileBase := token.Pos(ctx.tokenFile.Base())
 	relPos := ctx.pos - fileBase
 	if relPos < 0 || int(relPos) > len(ctx.astFile.Code) {
 		return false
@@ -613,26 +613,26 @@ func (ctx *completionContext) isLineStart() bool {
 
 // isInIdentifier reports whether the position is within an identifier.
 func (ctx *completionContext) isInIdentifier() bool {
-	fileBase := xgotoken.Pos(ctx.tokenFile.Base())
+	fileBase := token.Pos(ctx.tokenFile.Base())
 	relPos := ctx.pos - fileBase
 	if relPos < 0 || int(relPos) > len(ctx.astFile.Code) {
 		return false
 	}
 
-	var s xgoscanner.Scanner
+	var s scanner.Scanner
 	s.Init(ctx.tokenFile, ctx.astFile.Code, nil, 0)
 
 	for {
 		pos, tok, lit := s.Scan()
-		if tok == xgotoken.EOF {
+		if tok == token.EOF {
 			break
 		}
 
 		// Check if position is inside this token. For identifiers, we should
 		// be either in the middle or at the end to trigger completion (not
 		// at the beginning).
-		if pos < ctx.pos && ctx.pos <= pos+xgotoken.Pos(len(lit)) {
-			return tok == xgotoken.IDENT
+		if pos < ctx.pos && ctx.pos <= pos+token.Pos(len(lit)) {
+			return tok == token.IDENT
 		}
 
 		// If we've scanned past our position, we're not in an identifier.
@@ -646,7 +646,7 @@ func (ctx *completionContext) isInIdentifier() bool {
 // isAfterNumberLiteral reports whether the position is immediately after a
 // number literal followed by a dot.
 func (ctx *completionContext) isAfterNumberLiteral() bool {
-	fileBase := xgotoken.Pos(ctx.tokenFile.Base())
+	fileBase := token.Pos(ctx.tokenFile.Base())
 	relPos := ctx.pos - fileBase
 	if relPos < 1 || int(relPos) > len(ctx.astFile.Code) {
 		return false
@@ -691,25 +691,25 @@ func (ctx *completionContext) isAfterNumberLiteral() bool {
 }
 
 // isMapType reports whether the given type is a map type.
-func isMapType(typ types.Type) bool {
+func isMapType(typ gotypes.Type) bool {
 	if !xgoutil.IsValidType(typ) {
 		return false
 	}
-	_, isMap := typ.Underlying().(*types.Map)
+	_, isMap := typ.Underlying().(*gotypes.Map)
 	return isMap
 }
 
-// isSliceOrArrayLiteral reports whether the given [xgoast.CompositeLit]
+// isSliceOrArrayLiteral reports whether the given [ast.CompositeLit]
 // represents a slice or array literal.
 //
 // In XGo, slice literals can be written without explicit type declaration when
 // passed as function arguments, e.g., `printSlice [1, 2, 3]`.
-func (ctx *completionContext) isSliceOrArrayLiteral(comp *xgoast.CompositeLit) bool {
+func (ctx *completionContext) isSliceOrArrayLiteral(comp *ast.CompositeLit) bool {
 	// Check if we have type information.
 	if typ := ctx.typeInfo.TypeOf(comp); xgoutil.IsValidType(typ) {
 		underlying := typ.Underlying()
-		_, isSlice := underlying.(*types.Slice)
-		_, isArray := underlying.(*types.Array)
+		_, isSlice := underlying.(*gotypes.Slice)
+		_, isArray := underlying.(*gotypes.Array)
 		return isSlice || isArray
 	}
 
@@ -717,8 +717,8 @@ func (ctx *completionContext) isSliceOrArrayLiteral(comp *xgoast.CompositeLit) b
 	if comp.Type != nil {
 		if typ := ctx.typeInfo.TypeOf(comp.Type); xgoutil.IsValidType(typ) {
 			underlying := typ.Underlying()
-			_, isSlice := underlying.(*types.Slice)
-			_, isArray := underlying.(*types.Array)
+			_, isSlice := underlying.(*gotypes.Slice)
+			_, isArray := underlying.(*gotypes.Array)
 			return isSlice || isArray
 		}
 	}
@@ -728,7 +728,7 @@ func (ctx *completionContext) isSliceOrArrayLiteral(comp *xgoast.CompositeLit) b
 	// If all elements are NOT key-value pairs, it might be a slice.
 	if len(comp.Elts) > 0 {
 		for _, elt := range comp.Elts {
-			if _, isKV := elt.(*xgoast.KeyValueExpr); isKV {
+			if _, isKV := elt.(*ast.KeyValueExpr); isKV {
 				// Has key-value pairs, so it's not a slice
 				return false
 			}
@@ -740,12 +740,12 @@ func (ctx *completionContext) isSliceOrArrayLiteral(comp *xgoast.CompositeLit) b
 	return false
 }
 
-// isMapLiteral reports whether the given [xgoast.CompositeLit] represents a map
+// isMapLiteral reports whether the given [ast.CompositeLit] represents a map
 // literal.
 //
 // In XGo, map literals can be written without explicit type declaration when
 // passed as function arguments, e.g., `println {"key": value}`.
-func (ctx *completionContext) isMapLiteral(comp *xgoast.CompositeLit) bool {
+func (ctx *completionContext) isMapLiteral(comp *ast.CompositeLit) bool {
 	// Check if we have type information.
 	if typ := ctx.typeInfo.TypeOf(comp); xgoutil.IsValidType(typ) {
 		return isMapType(typ)
@@ -768,7 +768,7 @@ func (ctx *completionContext) isMapLiteral(comp *xgoast.CompositeLit) bool {
 	// Note: An empty composite literal {} is ambiguous and could be either
 	// a map or struct, so we don't consider it a map without type info.
 	for _, elt := range comp.Elts {
-		if _, isKV := elt.(*xgoast.KeyValueExpr); isKV {
+		if _, isKV := elt.(*ast.KeyValueExpr); isKV {
 			return true
 		}
 	}
@@ -776,20 +776,20 @@ func (ctx *completionContext) isMapLiteral(comp *xgoast.CompositeLit) bool {
 }
 
 // mapLiteralElementType returns the element type for the given map literal.
-func (ctx *completionContext) mapLiteralElementType(comp *xgoast.CompositeLit) types.Type {
+func (ctx *completionContext) mapLiteralElementType(comp *ast.CompositeLit) gotypes.Type {
 	if comp == nil {
 		return nil
 	}
 
 	if typ := ctx.typeInfo.TypeOf(comp); xgoutil.IsValidType(typ) {
-		if mapType, ok := xgoutil.DerefType(typ).Underlying().(*types.Map); ok {
+		if mapType, ok := xgoutil.DerefType(typ).Underlying().(*gotypes.Map); ok {
 			return mapType.Elem()
 		}
 	}
 
 	if comp.Type != nil {
 		if typ := ctx.typeInfo.TypeOf(comp.Type); xgoutil.IsValidType(typ) {
-			if mapType, ok := xgoutil.DerefType(typ).Underlying().(*types.Map); ok {
+			if mapType, ok := xgoutil.DerefType(typ).Underlying().(*gotypes.Map); ok {
 				return mapType.Elem()
 			}
 		}
@@ -800,10 +800,10 @@ func (ctx *completionContext) mapLiteralElementType(comp *xgoast.CompositeLit) t
 
 // valueExprAtPos returns the expression for the value located at the current
 // position within the given composite literal, handling nested literals.
-func (ctx *completionContext) valueExprAtPos(comp *xgoast.CompositeLit) xgoast.Expr {
+func (ctx *completionContext) valueExprAtPos(comp *ast.CompositeLit) ast.Expr {
 	for _, elt := range comp.Elts {
 		// Handle KeyValueExpr for maps and structs.
-		if kv, ok := elt.(*xgoast.KeyValueExpr); ok {
+		if kv, ok := elt.(*ast.KeyValueExpr); ok {
 			if kv.Value == nil {
 				continue
 			}
@@ -811,7 +811,7 @@ func (ctx *completionContext) valueExprAtPos(comp *xgoast.CompositeLit) xgoast.E
 				continue
 			}
 
-			if innerComp, ok := kv.Value.(*xgoast.CompositeLit); ok {
+			if innerComp, ok := kv.Value.(*ast.CompositeLit); ok {
 				if inner := ctx.valueExprAtPos(innerComp); inner != nil {
 					return inner
 				}
@@ -821,7 +821,7 @@ func (ctx *completionContext) valueExprAtPos(comp *xgoast.CompositeLit) xgoast.E
 
 		// Handle direct expressions for slices and arrays.
 		if ctx.pos >= elt.Pos() && ctx.pos <= elt.End()+1 {
-			if innerComp, ok := elt.(*xgoast.CompositeLit); ok {
+			if innerComp, ok := elt.(*ast.CompositeLit); ok {
 				if inner := ctx.valueExprAtPos(innerComp); inner != nil {
 					return inner
 				}
@@ -834,12 +834,12 @@ func (ctx *completionContext) valueExprAtPos(comp *xgoast.CompositeLit) xgoast.E
 
 // expectedMapElementTypeAtPos returns the map element type for the current
 // position if it is within a map literal, handling nested map literals.
-func (ctx *completionContext) expectedMapElementTypeAtPos(comp *xgoast.CompositeLit, expected types.Type) types.Type {
+func (ctx *completionContext) expectedMapElementTypeAtPos(comp *ast.CompositeLit, expected gotypes.Type) gotypes.Type {
 	if comp == nil || ctx.pos < comp.Pos() || ctx.pos > comp.End() {
 		return nil
 	}
 
-	var mapType types.Type
+	var mapType gotypes.Type
 	if expected != nil {
 		mapType = expected
 	} else if typ := ctx.typeInfo.TypeOf(comp); xgoutil.IsValidType(typ) {
@@ -847,7 +847,7 @@ func (ctx *completionContext) expectedMapElementTypeAtPos(comp *xgoast.Composite
 	}
 
 	for _, elt := range comp.Elts {
-		kv, ok := elt.(*xgoast.KeyValueExpr)
+		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok || kv.Value == nil {
 			continue
 		}
@@ -856,16 +856,16 @@ func (ctx *completionContext) expectedMapElementTypeAtPos(comp *xgoast.Composite
 		}
 
 		if typ := ctx.typeInfo.TypeOf(kv.Value); xgoutil.IsValidType(typ) {
-			if mapTyp, ok := xgoutil.DerefType(typ).Underlying().(*types.Map); ok {
+			if mapTyp, ok := xgoutil.DerefType(typ).Underlying().(*gotypes.Map); ok {
 				return mapTyp.Elem()
 			}
 			return typ
 		}
 
-		if innerComp, ok := kv.Value.(*xgoast.CompositeLit); ok {
-			var innerExpected types.Type
+		if innerComp, ok := kv.Value.(*ast.CompositeLit); ok {
+			var innerExpected gotypes.Type
 			if mapType != nil {
-				if mapTyp, ok := xgoutil.DerefType(mapType).Underlying().(*types.Map); ok {
+				if mapTyp, ok := xgoutil.DerefType(mapType).Underlying().(*gotypes.Map); ok {
 					innerExpected = mapTyp.Elem()
 				}
 			}
@@ -880,7 +880,7 @@ func (ctx *completionContext) expectedMapElementTypeAtPos(comp *xgoast.Composite
 		}
 
 		if mapType != nil {
-			if mapTyp, ok := xgoutil.DerefType(mapType).Underlying().(*types.Map); ok {
+			if mapTyp, ok := xgoutil.DerefType(mapType).Underlying().(*gotypes.Map); ok {
 				return mapTyp.Elem()
 			}
 		}
@@ -891,7 +891,7 @@ func (ctx *completionContext) expectedMapElementTypeAtPos(comp *xgoast.Composite
 	}
 
 	if mapType != nil {
-		if mapTyp, ok := xgoutil.DerefType(mapType).Underlying().(*types.Map); ok {
+		if mapTyp, ok := xgoutil.DerefType(mapType).Underlying().(*gotypes.Map); ok {
 			return mapTyp.Elem()
 		}
 	}
@@ -902,23 +902,23 @@ func (ctx *completionContext) expectedMapElementTypeAtPos(comp *xgoast.Composite
 }
 
 // enclosingFunction gets the function signature containing the current position.
-func (ctx *completionContext) enclosingFunction(path []xgoast.Node) *types.Signature {
+func (ctx *completionContext) enclosingFunction(path []ast.Node) *gotypes.Signature {
 	for _, node := range path {
 		switch n := node.(type) {
-		case *xgoast.FuncDecl:
+		case *ast.FuncDecl:
 			obj := ctx.typeInfo.ObjectOf(n.Name)
 			if obj == nil {
 				continue
 			}
-			fun, ok := obj.(*types.Func)
+			fun, ok := obj.(*gotypes.Func)
 			if !ok {
 				continue
 			}
-			return fun.Type().(*types.Signature)
-		case *xgoast.FuncLit:
+			return fun.Type().(*gotypes.Signature)
+		case *ast.FuncLit:
 			// For function literals, get the type from the type info directly.
 			if typ := ctx.typeInfo.TypeOf(n); xgoutil.IsValidType(typ) {
-				if sig, ok := typ.(*types.Signature); ok {
+				if sig, ok := typ.(*gotypes.Signature); ok {
 					return sig
 				}
 			}
@@ -928,7 +928,7 @@ func (ctx *completionContext) enclosingFunction(path []xgoast.Node) *types.Signa
 }
 
 // findReturnValueIndex finds the index of the return value at the current position.
-func (ctx *completionContext) findReturnValueIndex(ret *xgoast.ReturnStmt) int {
+func (ctx *completionContext) findReturnValueIndex(ret *ast.ReturnStmt) int {
 	if len(ret.Results) == 0 {
 		return 0
 	}
@@ -1038,7 +1038,7 @@ func (ctx *completionContext) collectGeneral() error {
 			isSpxFileMatch := ctx.spxFile == name+".spx" || (ctx.spxFile == ctx.result.mainSpxFile && name == "Game")
 			isMainScopeObj := isInMainScope && isSpxFileMatch
 			if isThis || isMainScopeObj {
-				named, ok := xgoutil.DerefType(obj.Type()).(*types.Named)
+				named, ok := xgoutil.DerefType(obj.Type()).(*gotypes.Named)
 				if ok && xgoutil.IsNamedStructType(named) {
 					for _, def := range ctx.result.spxDefinitionsForNamedStruct(named) {
 						if ctx.inSpxEventHandler && def.ID.Name != nil {
@@ -1136,16 +1136,16 @@ func (ctx *completionContext) collectDot() error {
 		return nil
 	}
 
-	if ident, ok := ctx.selectorExpr.X.(*xgoast.Ident); ok {
+	if ident, ok := ctx.selectorExpr.X.(*ast.Ident); ok {
 		if obj := ctx.typeInfo.ObjectOf(ident); obj != nil {
-			if pkgName, ok := obj.(*types.PkgName); ok {
+			if pkgName, ok := obj.(*gotypes.PkgName); ok {
 				return ctx.collectPackageMembers(pkgName.Imported())
 			}
 		}
 	}
 
 	typ := ctx.typeInfo.TypeOf(ctx.selectorExpr.X)
-	if ident, ok := ctx.selectorExpr.X.(*xgoast.Ident); ok {
+	if ident, ok := ctx.selectorExpr.X.(*ast.Ident); ok {
 		if propertyLikeType := ctx.resolvePropertyLikeExprType(ident, typ); xgoutil.IsValidType(propertyLikeType) {
 			typ = propertyLikeType
 		}
@@ -1162,7 +1162,7 @@ func (ctx *completionContext) collectDot() error {
 		typ = named
 	}
 
-	if iface, ok := typ.Underlying().(*types.Interface); ok {
+	if iface, ok := typ.Underlying().(*gotypes.Interface); ok {
 		ctx.collectInterfaceMethodCompletions(iface, named, nil)
 	} else if named != nil && xgoutil.IsNamedStructType(named) {
 		ctx.itemSet.addSpxDefs(ctx.result.spxDefinitionsForNamedStruct(named)...)
@@ -1173,14 +1173,14 @@ func (ctx *completionContext) collectDot() error {
 // resolvePropertyLikeExprType returns the result type of a property-like
 // function reference. If type-checker information is unavailable, it falls back
 // to [completionContext.resolvePropertyLikeFuncResultType].
-func (ctx *completionContext) resolvePropertyLikeExprType(ident *xgoast.Ident, typ types.Type) types.Type {
+func (ctx *completionContext) resolvePropertyLikeExprType(ident *ast.Ident, typ gotypes.Type) gotypes.Type {
 	if ident == nil || ident.Name == "" {
 		return nil
 	}
 
-	if sig, ok := typ.(*types.Signature); ok && sig.Params().Len() == 0 && sig.Results().Len() == 1 {
+	if sig, ok := typ.(*gotypes.Signature); ok && sig.Params().Len() == 0 && sig.Results().Len() == 1 {
 		if obj := ctx.typeInfo.ObjectOf(ident); obj != nil {
-			if fun, ok := obj.(*types.Func); ok {
+			if fun, ok := obj.(*gotypes.Func); ok {
 				if fun.Name() != ident.Name && xgoutil.ToLowerCamelCase(fun.Name()) == ident.Name {
 					return sig.Results().At(0).Type()
 				}
@@ -1197,17 +1197,17 @@ func (ctx *completionContext) resolvePropertyLikeExprType(ident *xgoast.Ident, t
 
 // resolvePropertyLikeFuncResultType resolves the result type of a property-like
 // function from the enclosing scopes.
-func (ctx *completionContext) resolvePropertyLikeFuncResultType(ident *xgoast.Ident) types.Type {
+func (ctx *completionContext) resolvePropertyLikeFuncResultType(ident *ast.Ident) gotypes.Type {
 	if ident == nil || ident.Name == "" {
 		return nil
 	}
 
-	for scope := ctx.innermostScope; scope != nil && scope != types.Universe; scope = scope.Parent() {
+	for scope := ctx.innermostScope; scope != nil && scope != gotypes.Universe; scope = scope.Parent() {
 		isInnermost := scope == ctx.innermostScope
 		isPkgScope := ctx.typeInfo.Pkg != nil && scope == ctx.typeInfo.Pkg.Scope()
 		for _, name := range scope.Names() {
 			obj := scope.Lookup(name)
-			fun, ok := obj.(*types.Func)
+			fun, ok := obj.(*gotypes.Func)
 			if !ok || fun.Name() == ident.Name || xgoutil.ToLowerCamelCase(fun.Name()) != ident.Name {
 				continue
 			}
@@ -1215,7 +1215,7 @@ func (ctx *completionContext) resolvePropertyLikeFuncResultType(ident *xgoast.Id
 				continue
 			}
 
-			sig, ok := fun.Type().(*types.Signature)
+			sig, ok := fun.Type().(*gotypes.Signature)
 			if !ok || sig.Params().Len() != 0 || sig.Results().Len() != 1 {
 				continue
 			}
@@ -1229,12 +1229,12 @@ func (ctx *completionContext) resolvePropertyLikeFuncResultType(ident *xgoast.Id
 // interface type and all of its embedded interfaces. The selectorNamed tracks
 // the named interface whose methods should determine the completion definition
 // name. The visited prevents infinite recursion for cyclic embeddings.
-func (ctx *completionContext) collectInterfaceMethodCompletions(iface *types.Interface, selectorNamed *types.Named, visited map[*types.Interface]struct{}) {
+func (ctx *completionContext) collectInterfaceMethodCompletions(iface *gotypes.Interface, selectorNamed *gotypes.Named, visited map[*gotypes.Interface]struct{}) {
 	if iface == nil {
 		return
 	}
 	if visited == nil {
-		visited = make(map[*types.Interface]struct{})
+		visited = make(map[*gotypes.Interface]struct{})
 	}
 	if _, ok := visited[iface]; ok {
 		return
@@ -1259,26 +1259,26 @@ func (ctx *completionContext) collectInterfaceMethodCompletions(iface *types.Int
 	}
 
 	for embedded := range iface.EmbeddedTypes() {
-		embedded = types.Unalias(embedded)
+		embedded = gotypes.Unalias(embedded)
 
 		var (
-			named          *types.Named
-			ifaceToRecurse *types.Interface
+			named          *gotypes.Named
+			ifaceToRecurse *gotypes.Interface
 		)
 
 		switch t := embedded.(type) {
-		case *types.Named:
+		case *gotypes.Named:
 			named = t
-			ifaceToRecurse, _ = t.Underlying().(*types.Interface)
-		case *types.Interface:
+			ifaceToRecurse, _ = t.Underlying().(*gotypes.Interface)
+		case *gotypes.Interface:
 			ctx.collectInterfaceMethodCompletions(t, selectorNamed, visited)
 			continue
-		case *types.Pointer:
-			elem := types.Unalias(t.Elem())
-			if n, ok := elem.(*types.Named); ok {
+		case *gotypes.Pointer:
+			elem := gotypes.Unalias(t.Elem())
+			if n, ok := elem.(*gotypes.Named); ok {
 				named = n
-				ifaceToRecurse, _ = n.Underlying().(*types.Interface)
-			} else if iface, ok := elem.(*types.Interface); ok {
+				ifaceToRecurse, _ = n.Underlying().(*gotypes.Interface)
+			} else if iface, ok := elem.(*gotypes.Interface); ok {
 				ctx.collectInterfaceMethodCompletions(iface, selectorNamed, visited)
 				continue
 			}
@@ -1295,7 +1295,7 @@ func (ctx *completionContext) collectInterfaceMethodCompletions(iface *types.Int
 }
 
 // collectPackageMembers collects members of a package.
-func (ctx *completionContext) collectPackageMembers(pkg *types.Package) error {
+func (ctx *completionContext) collectPackageMembers(pkg *gotypes.Package) error {
 	if pkg == nil {
 		return nil
 	}
@@ -1318,7 +1318,7 @@ func (ctx *completionContext) collectPackageMembers(pkg *types.Package) error {
 
 // collectCall collects function call completions.
 func (ctx *completionContext) collectCall() error {
-	callExpr, ok := ctx.enclosingNode.(*xgoast.CallExpr)
+	callExpr, ok := ctx.enclosingNode.(*ast.CallExpr)
 	if !ok {
 		return nil
 	}
@@ -1326,7 +1326,7 @@ func (ctx *completionContext) collectCall() error {
 	if !xgoutil.IsValidType(typ) {
 		return ctx.collectGeneral()
 	}
-	sig, ok := typ.(*types.Signature)
+	sig, ok := typ.(*gotypes.Signature)
 	if !ok {
 		return ctx.collectGeneral()
 	}
@@ -1338,13 +1338,13 @@ func (ctx *completionContext) collectCall() error {
 	if fun := xgoutil.FuncFromCallExpr(ctx.typeInfo, callExpr); fun != nil {
 		funcOverloads := xgoutil.ExpandXGoOverloadableFunc(fun)
 		if len(funcOverloads) > 0 {
-			expectedTypes := make([]types.Type, 0, len(funcOverloads))
+			expectedTypes := make([]gotypes.Type, 0, len(funcOverloads))
 			for _, funcOverload := range funcOverloads {
-				sig := funcOverload.Type().(*types.Signature)
+				sig := funcOverload.Type().(*gotypes.Signature)
 				if argIndex < sig.Params().Len() {
 					expectedTypes = append(expectedTypes, sig.Params().At(argIndex).Type())
 				} else if sig.Variadic() && argIndex >= sig.Params().Len()-1 {
-					expectedTypes = append(expectedTypes, sig.Params().At(sig.Params().Len()-1).Type().(*types.Slice).Elem())
+					expectedTypes = append(expectedTypes, sig.Params().At(sig.Params().Len()-1).Type().(*gotypes.Slice).Elem())
 				}
 			}
 			ctx.expectedTypes = deduplicateTypes(expectedTypes)
@@ -1353,22 +1353,22 @@ func (ctx *completionContext) collectCall() error {
 	}
 
 	if argIndex < sig.Params().Len() {
-		ctx.expectedTypes = []types.Type{sig.Params().At(argIndex).Type()}
+		ctx.expectedTypes = []gotypes.Type{sig.Params().At(argIndex).Type()}
 	} else if sig.Variadic() && argIndex >= sig.Params().Len()-1 {
-		ctx.expectedTypes = []types.Type{sig.Params().At(sig.Params().Len() - 1).Type().(*types.Slice).Elem()}
+		ctx.expectedTypes = []gotypes.Type{sig.Params().At(sig.Params().Len() - 1).Type().(*gotypes.Slice).Elem()}
 	}
 	return ctx.collectGeneral()
 }
 
-func deduplicateTypes(expectedTypes []types.Type) []types.Type {
+func deduplicateTypes(expectedTypes []gotypes.Type) []gotypes.Type {
 	if len(expectedTypes) <= 1 {
 		return expectedTypes
 	}
 
-	deduplicated := make([]types.Type, 0, len(expectedTypes))
+	deduplicated := make([]gotypes.Type, 0, len(expectedTypes))
 	for _, expectedType := range expectedTypes {
-		if slices.ContainsFunc(deduplicated, func(existing types.Type) bool {
-			return types.Identical(existing, expectedType)
+		if slices.ContainsFunc(deduplicated, func(existing gotypes.Type) bool {
+			return gotypes.Identical(existing, expectedType)
 		}) {
 			continue
 		}
@@ -1378,7 +1378,7 @@ func deduplicateTypes(expectedTypes []types.Type) []types.Type {
 }
 
 // getCurrentArgIndex gets the current argument index in a function call.
-func (ctx *completionContext) getCurrentArgIndex(callExpr *xgoast.CallExpr) int {
+func (ctx *completionContext) getCurrentArgIndex(callExpr *ast.CallExpr) int {
 	if len(callExpr.Args) == 0 {
 		return 0
 	}
@@ -1409,7 +1409,7 @@ func (ctx *completionContext) collectReturn() error {
 }
 
 // collectTypeSpecific collects type-specific completions.
-func (ctx *completionContext) collectTypeSpecific(typ types.Type) error {
+func (ctx *completionContext) collectTypeSpecific(typ gotypes.Type) error {
 	if !xgoutil.IsValidType(typ) {
 		return nil
 	}
@@ -1507,8 +1507,8 @@ func (ctx *completionContext) getSpxSpriteResource() *SpxSpriteResource {
 	return ctx.getCurrentFileSpxSpriteResource()
 }
 
-func (ctx *completionContext) getEnclosingCallExpr() *xgoast.CallExpr {
-	if callExpr, ok := ctx.enclosingNode.(*xgoast.CallExpr); ok {
+func (ctx *completionContext) getEnclosingCallExpr() *ast.CallExpr {
+	if callExpr, ok := ctx.enclosingNode.(*ast.CallExpr); ok {
 		return callExpr
 	}
 	return ctx.enclosingCallExpr
@@ -1526,11 +1526,11 @@ func (ctx *completionContext) getCurrentFileSpxSpriteResource() *SpxSpriteResour
 // back to the current file's type.
 func (ctx *completionContext) getPropertyTarget() string {
 	if ctx.kind == completionKindCall {
-		if callExpr, ok := ctx.enclosingNode.(*xgoast.CallExpr); ok {
+		if callExpr, ok := ctx.enclosingNode.(*ast.CallExpr); ok {
 			named := PropertyTargetNamedTypeForCall(ctx.typeInfo, callExpr, ctx.spxFile, ctx.result.mainSpxFile)
 			if named != nil {
 				// For explicit-receiver calls, only consider main-package types.
-				if _, hasSel := callExpr.Fun.(*xgoast.SelectorExpr); hasSel && !xgoutil.IsInMainPkg(named.Obj()) {
+				if _, hasSel := callExpr.Fun.(*ast.SelectorExpr); hasSel && !xgoutil.IsInMainPkg(named.Obj()) {
 					return ""
 				}
 				return named.Obj().Name()
@@ -1555,24 +1555,24 @@ func (ctx *completionContext) collectPropertyNames(target string) {
 	if obj == nil {
 		return
 	}
-	typeName, ok := obj.(*types.TypeName)
+	typeName, ok := obj.(*gotypes.TypeName)
 	if !ok {
 		return
 	}
-	typ := types.Unalias(typeName.Type())
+	typ := gotypes.Unalias(typeName.Type())
 	typ = xgoutil.DerefType(typ)
-	namedType, ok := typ.(*types.Named)
+	namedType, ok := typ.(*gotypes.Named)
 	if !ok {
 		return
 	}
 
 	mainPkgDoc, _ := ctx.proj.PkgDoc()
-	ctx.collectPropertyNamesFromNamedType(namedType, mainPkgDoc, make(map[*types.Named]bool), make(map[string]bool))
+	ctx.collectPropertyNamesFromNamedType(namedType, mainPkgDoc, make(map[*gotypes.Named]bool), make(map[string]bool))
 }
 
 // collectPropertyNamesFromNamedType collects property name completion items
 // from the given named type (including embedded types) using walkPropertyMembers.
-func (ctx *completionContext) collectPropertyNamesFromNamedType(namedType *types.Named, mainPkgDoc *pkgdoc.PkgDoc, visited map[*types.Named]bool, seenNames map[string]bool) {
+func (ctx *completionContext) collectPropertyNamesFromNamedType(namedType *gotypes.Named, mainPkgDoc *pkgdoc.PkgDoc, visited map[*gotypes.Named]bool, seenNames map[string]bool) {
 	walkPropertyMembers(namedType, makePkgDocFor(mainPkgDoc), visited, seenNames, func(m propertyMember) {
 		insertText := m.Name
 		if !ctx.inStringLit {
@@ -1606,10 +1606,10 @@ func (ctx *completionContext) collectStructLit() error {
 	seenFields := make(map[string]struct{})
 
 	// Collect already used fields.
-	if composite, ok := ctx.enclosingNode.(*xgoast.CompositeLit); ok {
+	if composite, ok := ctx.enclosingNode.(*ast.CompositeLit); ok {
 		for _, elem := range composite.Elts {
-			if kv, ok := elem.(*xgoast.KeyValueExpr); ok {
-				if ident, ok := kv.Key.(*xgoast.Ident); ok {
+			if kv, ok := elem.(*ast.KeyValueExpr); ok {
+				if ident, ok := kv.Key.(*ast.Ident); ok {
 					seenFields[ident.Name] = struct{}{}
 				}
 			}
@@ -1638,7 +1638,7 @@ func (ctx *completionContext) collectStructLit() error {
 func (ctx *completionContext) collectSwitchCase() error {
 	if ctx.switchTag == nil {
 		for _, name := range []string{"int", "string", "bool", "error"} {
-			if obj := types.Universe.Lookup(name); obj != nil {
+			if obj := gotypes.Universe.Lookup(name); obj != nil {
 				ctx.itemSet.addSpxDefs(GetSpxDefinitionForBuiltinObj(obj))
 			}
 		}
@@ -1669,12 +1669,12 @@ func (ctx *completionContext) collectSwitchCase() error {
 	scope := pkg.Scope()
 	for _, name := range scope.Names() {
 		obj := scope.Lookup(name)
-		c, ok := obj.(*types.Const)
+		c, ok := obj.(*gotypes.Const)
 		if !ok {
 			continue
 		}
 
-		if types.Identical(c.Type(), typ) {
+		if gotypes.Identical(c.Type(), typ) {
 			ctx.itemSet.addSpxDefs(GetSpxDefinitionForConst(c, pkgDoc))
 		}
 	}
@@ -1731,10 +1731,10 @@ type completionItemSet struct {
 	items                         []CompletionItem
 	seenSpxDefs                   map[string]struct{}
 	supportedKinds                map[CompletionItemKind]struct{}
-	isCompatibleWithExpectedTypes func(typ types.Type) bool
+	isCompatibleWithExpectedTypes func(typ gotypes.Type) bool
 	disallowVoidFuncs             bool
 	expectedFuncResultCount       int
-	expectedTypes                 []types.Type
+	expectedTypes                 []gotypes.Type
 }
 
 // newCompletionItemSet creates a new [completionItemSet].
@@ -1771,13 +1771,13 @@ func (s *completionItemSet) setExpectedFuncResultCount(count int) {
 }
 
 // setExpectedTypes sets the expected types for the completion items.
-func (s *completionItemSet) setExpectedTypes(expectedTypes []types.Type) {
+func (s *completionItemSet) setExpectedTypes(expectedTypes []gotypes.Type) {
 	if len(expectedTypes) == 0 {
 		return
 	}
 
 	s.expectedTypes = expectedTypes
-	s.isCompatibleWithExpectedTypes = func(typ types.Type) bool {
+	s.isCompatibleWithExpectedTypes = func(typ gotypes.Type) bool {
 		for _, expectedType := range expectedTypes {
 			if xgoutil.IsValidType(expectedType) {
 				// First check direct compatibility.
@@ -1810,7 +1810,7 @@ func (s *completionItemSet) add(items ...CompletionItem) {
 func (s *completionItemSet) addSpxDefs(spxDefs ...SpxDefinition) {
 	for _, spxDef := range spxDefs {
 		if s.expectedFuncResultCount > 0 {
-			if sig, ok := spxDef.TypeHint.(*types.Signature); ok {
+			if sig, ok := spxDef.TypeHint.(*gotypes.Signature); ok {
 				resultCount := sig.Results().Len()
 				// Exclude multi-return functions with mismatched count.
 				// Single-return functions are allowed to fall through for further type checks.
@@ -1820,13 +1820,13 @@ func (s *completionItemSet) addSpxDefs(spxDefs ...SpxDefinition) {
 			}
 		}
 		if s.disallowVoidFuncs && spxDef.CompletionItemKind == FunctionCompletion {
-			if sig, ok := spxDef.TypeHint.(*types.Signature); ok && sig.Results().Len() == 0 {
+			if sig, ok := spxDef.TypeHint.(*gotypes.Signature); ok && sig.Results().Len() == 0 {
 				continue
 			}
 		}
 		if s.isCompatibleWithExpectedTypes != nil {
 			typeToCompare := spxDef.TypeHint
-			if sig, ok := typeToCompare.(*types.Signature); ok {
+			if sig, ok := typeToCompare.(*gotypes.Signature); ok {
 				switch sig.Results().Len() {
 				case 0:
 					// Void functions are not compatible with any expected type.

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -1,14 +1,14 @@
 package server
 
 import (
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 	"slices"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgo/x/typesutil"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2792,29 +2792,29 @@ onStart => {
 
 func TestCompletionContextResolvePropertyLikeExprType(t *testing.T) {
 	t.Run("NilIdentifierReturnsNil", func(t *testing.T) {
-		ctx := newPropertyLikeTestCompletionContext(types.NewPackage("main", "main"), nil, nil)
+		ctx := newPropertyLikeTestCompletionContext(gotypes.NewPackage("main", "main"), nil, nil)
 
 		assert.Nil(t, ctx.resolvePropertyLikeExprType(nil, nil))
 		assert.Nil(t, ctx.resolvePropertyLikeExprType(&ast.Ident{}, nil))
 	})
 
 	t.Run("SignatureMatch", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "Now", types.Typ[types.String])
-		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), map[*ast.Ident]types.Object{
+		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "Now", gotypes.Typ[gotypes.String])
+		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
 		got := ctx.resolvePropertyLikeExprType(ident, fun.Type())
-		assert.Same(t, types.Typ[types.String], got)
+		assert.Same(t, gotypes.Typ[gotypes.String], got)
 	})
 
 	t.Run("ValidNonPropertyLikeSignatureReturnsNil", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "now", types.Typ[types.String])
-		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), map[*ast.Ident]types.Object{
+		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "now", gotypes.Typ[gotypes.String])
+		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), map[*ast.Ident]gotypes.Object{
 			ident: fun,
 		})
 
@@ -2823,9 +2823,9 @@ func TestCompletionContextResolvePropertyLikeExprType(t *testing.T) {
 	})
 
 	t.Run("ValidTypeWithoutResolvedObjectReturnsNil", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "Now", types.Typ[types.String])
+		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "Now", gotypes.Typ[gotypes.String])
 		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), nil)
 
 		got := ctx.resolvePropertyLikeExprType(ident, fun.Type())
@@ -2833,41 +2833,41 @@ func TestCompletionContextResolvePropertyLikeExprType(t *testing.T) {
 	})
 
 	t.Run("InvalidTypeFallsBackToScopeWalk", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		fun := newPropertyLikeTestFunc(token.Pos(20), pkg, "Now", types.Typ[types.String])
+		fun := newPropertyLikeTestFunc(token.Pos(20), pkg, "Now", gotypes.Typ[gotypes.String])
 		pkg.Scope().Insert(fun)
 		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), nil)
 
 		got := ctx.resolvePropertyLikeExprType(ident, nil)
-		assert.Same(t, types.Typ[types.String], got)
+		assert.Same(t, gotypes.Typ[gotypes.String], got)
 	})
 }
 
 func TestCompletionContextResolvePropertyLikeFuncResultType(t *testing.T) {
 	t.Run("NilIdentifierReturnsNil", func(t *testing.T) {
-		ctx := newPropertyLikeTestCompletionContext(types.NewPackage("main", "main"), nil, nil)
+		ctx := newPropertyLikeTestCompletionContext(gotypes.NewPackage("main", "main"), nil, nil)
 
 		assert.Nil(t, ctx.resolvePropertyLikeFuncResultType(nil))
 		assert.Nil(t, ctx.resolvePropertyLikeFuncResultType(&ast.Ident{}))
 	})
 
 	t.Run("PackageScopeIgnoresDeclarationOrder", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		fun := newPropertyLikeTestFunc(token.Pos(20), pkg, "Now", types.Typ[types.String])
+		fun := newPropertyLikeTestFunc(token.Pos(20), pkg, "Now", gotypes.Typ[gotypes.String])
 		pkg.Scope().Insert(fun)
 		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), nil)
 
 		got := ctx.resolvePropertyLikeFuncResultType(ident)
-		assert.Same(t, types.Typ[types.String], got)
+		assert.Same(t, gotypes.Typ[gotypes.String], got)
 	})
 
 	t.Run("LocalScopeSkipsLaterFunction", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
-		localScope := types.NewScope(pkg.Scope(), token.NoPos, token.NoPos, "local")
+		pkg := gotypes.NewPackage("main", "main")
+		localScope := gotypes.NewScope(pkg.Scope(), token.NoPos, token.NoPos, "local")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		fun := newPropertyLikeTestFunc(token.Pos(20), pkg, "Now", types.Typ[types.String])
+		fun := newPropertyLikeTestFunc(token.Pos(20), pkg, "Now", gotypes.Typ[gotypes.String])
 		localScope.Insert(fun)
 		ctx := newPropertyLikeTestCompletionContext(pkg, localScope, nil)
 
@@ -2876,17 +2876,17 @@ func TestCompletionContextResolvePropertyLikeFuncResultType(t *testing.T) {
 	})
 
 	t.Run("SkipsFunctionWithParams", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		sig := types.NewSignatureType(
+		sig := gotypes.NewSignatureType(
 			nil,
 			nil,
 			nil,
-			types.NewTuple(types.NewVar(token.NoPos, nil, "v", types.Typ[types.String])),
-			types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.String])),
+			gotypes.NewTuple(gotypes.NewVar(token.NoPos, nil, "v", gotypes.Typ[gotypes.String])),
+			gotypes.NewTuple(gotypes.NewVar(token.NoPos, nil, "", gotypes.Typ[gotypes.String])),
 			false,
 		)
-		fun := types.NewFunc(token.Pos(1), pkg, "Now", sig)
+		fun := gotypes.NewFunc(token.Pos(1), pkg, "Now", sig)
 		pkg.Scope().Insert(fun)
 		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), nil)
 
@@ -2895,9 +2895,9 @@ func TestCompletionContextResolvePropertyLikeFuncResultType(t *testing.T) {
 	})
 
 	t.Run("SkipsLowerCamelFunctionName", func(t *testing.T) {
-		pkg := types.NewPackage("main", "main")
+		pkg := gotypes.NewPackage("main", "main")
 		ident := &ast.Ident{Name: "now", NamePos: 10}
-		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "now", types.Typ[types.String])
+		fun := newPropertyLikeTestFunc(token.Pos(1), pkg, "now", gotypes.Typ[gotypes.String])
 		pkg.Scope().Insert(fun)
 		ctx := newPropertyLikeTestCompletionContext(pkg, pkg.Scope(), nil)
 
@@ -2906,19 +2906,19 @@ func TestCompletionContextResolvePropertyLikeFuncResultType(t *testing.T) {
 	})
 }
 
-func newPropertyLikeTestCompletionContext(pkg *types.Package, innermostScope *types.Scope, uses map[*ast.Ident]types.Object) *completionContext {
+func newPropertyLikeTestCompletionContext(pkg *gotypes.Package, innermostScope *gotypes.Scope, uses map[*ast.Ident]gotypes.Object) *completionContext {
 	if uses == nil {
-		uses = make(map[*ast.Ident]types.Object)
+		uses = make(map[*ast.Ident]gotypes.Object)
 	}
 	return &completionContext{
-		typeInfo: &xgotypes.Info{
+		typeInfo: &types.Info{
 			Info: typesutil.Info{
-				Types:      make(map[ast.Expr]types.TypeAndValue),
-				Defs:       make(map[*ast.Ident]types.Object),
+				Types:      make(map[ast.Expr]gotypes.TypeAndValue),
+				Defs:       make(map[*ast.Ident]gotypes.Object),
 				Uses:       uses,
-				Selections: make(map[*ast.SelectorExpr]*types.Selection),
-				Implicits:  make(map[ast.Node]types.Object),
-				Scopes:     make(map[ast.Node]*types.Scope),
+				Selections: make(map[*ast.SelectorExpr]*gotypes.Selection),
+				Implicits:  make(map[ast.Node]gotypes.Object),
+				Scopes:     make(map[ast.Node]*gotypes.Scope),
 			},
 			Pkg: pkg,
 		},
@@ -2926,16 +2926,16 @@ func newPropertyLikeTestCompletionContext(pkg *types.Package, innermostScope *ty
 	}
 }
 
-func newPropertyLikeTestFunc(pos token.Pos, pkg *types.Package, name string, result types.Type) *types.Func {
-	sig := types.NewSignatureType(
+func newPropertyLikeTestFunc(pos token.Pos, pkg *gotypes.Package, name string, result gotypes.Type) *gotypes.Func {
+	sig := gotypes.NewSignatureType(
 		nil,
 		nil,
 		nil,
 		nil,
-		types.NewTuple(types.NewVar(token.NoPos, nil, "", result)),
+		gotypes.NewTuple(gotypes.NewVar(token.NoPos, nil, "", result)),
 		false,
 	)
-	return types.NewFunc(pos, pkg, name, sig)
+	return gotypes.NewFunc(pos, pkg, name, sig)
 }
 
 func containsCompletionItemLabel(items []CompletionItem, label string) bool {

--- a/internal/server/definition.go
+++ b/internal/server/definition.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"fmt"
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -88,9 +88,9 @@ func (s *Server) textDocumentTypeDefinition(params *TypeDefinitionParams) (any, 
 	objType := xgoutil.DerefType(obj.Type())
 	var objPos token.Pos
 	switch objType := objType.(type) {
-	case *types.Named:
+	case *gotypes.Named:
 		objPos = objType.Obj().Pos()
-	case *types.Alias:
+	case *gotypes.Alias:
 		objPos = objType.Obj().Pos()
 	default:
 		return nil, nil

--- a/internal/server/definition_test.go
+++ b/internal/server/definition_test.go
@@ -139,14 +139,14 @@ fmt.println "Hello, spx!"
 		})
 		require.NoError(t, err)
 		require.NotNil(t, def)
-		require.IsType(t, Location{}, def)
+		location := requireValueAs[Location](t, def)
 		assert.Equal(t, Location{
 			URI: "file:///main.spx",
 			Range: Range{
 				Start: Position{Line: 1, Character: 7},
 				End:   Position{Line: 1, Character: 7},
 			},
-		}, def.(Location))
+		}, location)
 	})
 
 	t.Run("ImportedPackageWithAlias", func(t *testing.T) {
@@ -166,14 +166,14 @@ fmt2.println "Hello, spx!"
 		})
 		require.NoError(t, err)
 		require.NotNil(t, def)
-		require.IsType(t, Location{}, def)
+		location := requireValueAs[Location](t, def)
 		assert.Equal(t, Location{
 			URI: "file:///main.spx",
 			Range: Range{
 				Start: Position{Line: 1, Character: 7},
 				End:   Position{Line: 1, Character: 11},
 			},
-		}, def.(Location))
+		}, location)
 	})
 
 	t.Run("InvalidTextDocument", func(t *testing.T) {

--- a/internal/server/diagnostic_test.go
+++ b/internal/server/diagnostic_test.go
@@ -45,6 +45,22 @@ onCloned => {
 	}
 }
 
+func requireRelatedFullDocumentDiagnosticReport(t *testing.T, report *DocumentDiagnosticReport) RelatedFullDocumentDiagnosticReport {
+	t.Helper()
+
+	fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
+	require.True(t, ok, "want RelatedFullDocumentDiagnosticReport, got %T", report.Value)
+	return fullReport
+}
+
+func requireWorkspaceFullDocumentDiagnosticReport(t *testing.T, item WorkspaceDocumentDiagnosticReport) WorkspaceFullDocumentDiagnosticReport {
+	t.Helper()
+
+	fullReport, ok := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+	require.True(t, ok, "want WorkspaceFullDocumentDiagnosticReport, got %T", item.Value)
+	return fullReport
+}
+
 func TestServerTextDocumentDiagnostic(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
 		s := New(newProjectWithoutModTime(newTestFileMap()), nil, fileMapGetter(newTestFileMap()), &MockScheduler{})
@@ -56,8 +72,7 @@ func TestServerTextDocumentDiagnostic(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, report)
 
-		fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
-		assert.True(t, ok, "expected RelatedFullDocumentDiagnosticReport")
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
 		assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 		assert.Empty(t, fullReport.Items)
 	})
@@ -78,8 +93,7 @@ var (
 		require.NoError(t, err)
 		require.NotNil(t, report)
 
-		fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
-		assert.True(t, ok, "expected RelatedFullDocumentDiagnosticReport")
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
 		assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 		require.Len(t, fullReport.Items, 2)
 		assert.Contains(t, fullReport.Items, Diagnostic{
@@ -122,8 +136,7 @@ onStart => {
 		require.NoError(t, err)
 		require.NotNil(t, report)
 
-		fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
-		assert.True(t, ok, "expected RelatedFullDocumentDiagnosticReport")
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
 		require.Len(t, fullReport.Items, 1)
 		assert.Contains(t, fullReport.Items, Diagnostic{
 			Severity: SeverityError,
@@ -152,8 +165,7 @@ func getValue() int {
 		require.NoError(t, err)
 		require.NotNil(t, report)
 
-		fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
-		assert.True(t, ok, "expected RelatedFullDocumentDiagnosticReport")
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
 		require.Len(t, fullReport.Items, 1)
 		assert.Contains(t, fullReport.Items, Diagnostic{
 			Severity: SeverityError,
@@ -177,8 +189,7 @@ func getValue() int {
 		require.NoError(t, err)
 		require.NotNil(t, report)
 
-		fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
-		assert.True(t, ok, "expected RelatedFullDocumentDiagnosticReport")
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
 		assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 		assert.Empty(t, fullReport.Items)
 	})
@@ -195,8 +206,7 @@ func getValue() int {
 		require.NoError(t, err)
 		require.NotNil(t, report)
 
-		fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
-		assert.True(t, ok, "expected RelatedFullDocumentDiagnosticReport")
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
 		assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 		require.Len(t, fullReport.Items, 1)
 		assert.Contains(t, fullReport.Items, Diagnostic{
@@ -219,8 +229,7 @@ func getValue() int {
 		require.NoError(t, err)
 		require.NotNil(t, report)
 
-		fullReport, ok := report.Value.(RelatedFullDocumentDiagnosticReport)
-		assert.True(t, ok, "expected RelatedFullDocumentDiagnosticReport")
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
 		assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 		assert.Empty(t, fullReport.Items)
 	})
@@ -236,7 +245,7 @@ func TestServerWorkspaceDiagnostic(t *testing.T) {
 		assert.Len(t, report.Items, 3)
 		foundFiles := make(map[string]struct{})
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			relPath, err := s.fromDocumentURI(fullReport.URI)
 			require.NoError(t, err)
 			foundFiles[relPath] = struct{}{}
@@ -266,7 +275,7 @@ var (
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			if fullReport.URI == "file:///main.spx" {
 				require.Len(t, fullReport.Items, 2)
 				assert.Contains(t, fullReport.Items, Diagnostic{
@@ -328,7 +337,7 @@ onStart => {
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			switch fullReport.URI {
 			case "file:///main.spx":
@@ -406,7 +415,7 @@ onStart => {
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			switch fullReport.URI {
 			case "file:///main.spx":
@@ -473,7 +482,7 @@ onStart => {
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			switch fullReport.URI {
 			case "file:///main.spx":
@@ -522,7 +531,7 @@ onStart => {
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			switch fullReport.URI {
 			case "file:///MySprite.spx":
@@ -569,7 +578,7 @@ onStart => {
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			switch fullReport.URI {
 			case "file:///MySprite.spx":
@@ -620,7 +629,7 @@ onStart => {
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			switch fullReport.URI {
 			case "file:///MySprite.spx":
@@ -676,7 +685,7 @@ onStart => {
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			assert.Empty(t, fullReport.Items)
 		}
@@ -699,7 +708,7 @@ onKey [KeyRight, KeyUp, KeyDown], => {}
 		require.NotNil(t, report)
 		assert.Len(t, report.Items, 1)
 		for _, item := range report.Items {
-			fullReport := item.Value.(WorkspaceFullDocumentDiagnosticReport)
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			assert.Empty(t, fullReport.Items)
 		}

--- a/internal/server/document.go
+++ b/internal/server/document.go
@@ -4,7 +4,7 @@ import (
 	"cmp"
 	"slices"
 
-	xgoast "github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -45,7 +45,7 @@ func (s *Server) textDocumentDocumentLink(params *DocumentLinkParams) ([]Documen
 
 	// Add links for spx definitions.
 	links = slices.Grow(links, len(typeInfo.Defs)+len(typeInfo.Uses))
-	addLinksForIdent := func(ident *xgoast.Ident) {
+	addLinksForIdent := func(ident *ast.Ident) {
 		if ident.Implicit() || xgoutil.NodeFilename(result.proj.Fset, ident) != spxFile {
 			return
 		}

--- a/internal/server/document_test.go
+++ b/internal/server/document_test.go
@@ -565,7 +565,7 @@ func TestSortDocumentLinks(t *testing.T) {
 		sortDocumentLinks(links)
 
 		// Links with nil targets should come first.
-		require.Equal(t, 4, len(links))
+		require.Len(t, links, 4)
 		assert.Nil(t, links[0].Target)
 		assert.Nil(t, links[1].Target)
 		assert.NotNil(t, links[2].Target)
@@ -589,7 +589,7 @@ func TestSortDocumentLinks(t *testing.T) {
 		sortDocumentLinks(links)
 
 		// Links with targets should be sorted by target URI string.
-		require.Equal(t, 3, len(links))
+		require.Len(t, links, 3)
 		assert.Equal(t, targetA, links[0].Target)
 		assert.Equal(t, targetB, links[1].Target)
 		assert.Equal(t, targetC, links[2].Target)
@@ -606,7 +606,7 @@ func TestSortDocumentLinks(t *testing.T) {
 		sortDocumentLinks(links)
 
 		// Same target URI should be sorted by line number.
-		require.Equal(t, 3, len(links))
+		require.Len(t, links, 3)
 		assert.Equal(t, uint32(10), links[0].Range.Start.Line)
 		assert.Equal(t, uint32(20), links[1].Range.Start.Line)
 		assert.Equal(t, uint32(30), links[2].Range.Start.Line)
@@ -623,7 +623,7 @@ func TestSortDocumentLinks(t *testing.T) {
 		sortDocumentLinks(links)
 
 		// Same target URI and line should be sorted by character position.
-		require.Equal(t, 3, len(links))
+		require.Len(t, links, 3)
 		assert.Equal(t, uint32(5), links[0].Range.Start.Character)
 		assert.Equal(t, uint32(15), links[1].Range.Start.Character)
 		assert.Equal(t, uint32(25), links[2].Range.Start.Character)
@@ -644,7 +644,7 @@ func TestSortDocumentLinks(t *testing.T) {
 		sortDocumentLinks(links)
 
 		// Nil targets should come first, sorted by line number.
-		require.Equal(t, 6, len(links))
+		require.Len(t, links, 6)
 		assert.Nil(t, links[0].Target)
 		assert.Nil(t, links[1].Target)
 		assert.Equal(t, uint32(1), links[0].Range.Start.Line)

--- a/internal/server/format.go
+++ b/internal/server/format.go
@@ -3,17 +3,17 @@ package server
 import (
 	"bytes"
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"io/fs"
 	"path"
 	"slices"
 	"time"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgofmt "github.com/goplus/xgo/format"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/format"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -106,7 +106,7 @@ func (s *Server) formatSpxXGo(snapshot *xgo.Project, spxFile string) ([]byte, er
 		return nil, fs.ErrNotExist
 	}
 	original := file.Content
-	formatted, err := xgofmt.Source(original, true, spxFile)
+	formatted, err := format.Source(original, true, spxFile)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (s *Server) formatSpxLambda(snapshot *xgo.Project, spxFile string) ([]byte,
 
 	// Format the modified AST.
 	var formattedBuf bytes.Buffer
-	if err := xgofmt.Node(&formattedBuf, snapshot.Fset, astFile); err != nil {
+	if err := format.Node(&formattedBuf, snapshot.Fset, astFile); err != nil {
 		return nil, err
 	}
 
@@ -142,18 +142,18 @@ func (s *Server) formatSpxLambda(snapshot *xgo.Project, spxFile string) ([]byte,
 
 // formatSpxDecls formats an spx source file by reordering declarations.
 func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, error) {
-	var astFile *xgoast.File
+	var astFile *ast.File
 	astFile, _ = snapshot.ASTFile(spxFile)
 	if astFile == nil {
 		return nil, nil
 	}
 
 	// Find the position of the first declaration that contains any syntax error.
-	var errorPos xgotoken.Pos
+	var errorPos token.Pos
 	for _, decl := range astFile.Decls {
-		xgoast.Inspect(decl, func(node xgoast.Node) bool {
+		ast.Inspect(decl, func(node ast.Node) bool {
 			switch node.(type) {
-			case *xgoast.BadExpr, *xgoast.BadStmt, *xgoast.BadDecl:
+			case *ast.BadExpr, *ast.BadStmt, *ast.BadDecl:
 				if !errorPos.IsValid() || decl.Pos() < errorPos {
 					errorPos = decl.Pos()
 					return false
@@ -164,7 +164,7 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 	}
 
 	// Get the start position of the shadow entry if it exists and not empty.
-	var shadowEntryPos xgotoken.Pos
+	var shadowEntryPos token.Pos
 	if astFile.ShadowEntry != nil &&
 		astFile.ShadowEntry.Pos().IsValid() &&
 		astFile.ShadowEntry.Pos() != errorPos &&
@@ -177,14 +177,14 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 
 	// Collect all declarations.
 	var (
-		importDecls       []xgoast.Decl
-		typeDecls         []xgoast.Decl
-		methodDecls       []xgoast.Decl
-		constDecls        []xgoast.Decl
-		varBlocks         []*xgoast.GenDecl
-		funcDecls         []xgoast.Decl
-		otherDecls        []xgoast.Decl
-		processedComments = make(map[*xgoast.CommentGroup]struct{})
+		importDecls       []ast.Decl
+		typeDecls         []ast.Decl
+		methodDecls       []ast.Decl
+		constDecls        []ast.Decl
+		varBlocks         []*ast.GenDecl
+		funcDecls         []ast.Decl
+		otherDecls        []ast.Decl
+		processedComments = make(map[*ast.CommentGroup]struct{})
 	)
 	fset := snapshot.Fset
 	for _, decl := range astFile.Decls {
@@ -194,20 +194,20 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 		}
 
 		switch decl := decl.(type) {
-		case *xgoast.GenDecl:
+		case *ast.GenDecl:
 			switch decl.Tok {
-			case xgotoken.IMPORT:
+			case token.IMPORT:
 				importDecls = append(importDecls, decl)
-			case xgotoken.TYPE:
+			case token.TYPE:
 				typeDecls = append(typeDecls, decl)
-			case xgotoken.CONST:
+			case token.CONST:
 				constDecls = append(constDecls, decl)
-			case xgotoken.VAR:
+			case token.VAR:
 				varBlocks = append(varBlocks, decl)
 			default:
 				otherDecls = append(otherDecls, decl)
 			}
-		case *xgoast.FuncDecl:
+		case *ast.FuncDecl:
 			if decl.Shadow {
 				continue
 			}
@@ -216,7 +216,7 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 			} else {
 				funcDecls = append(funcDecls, decl)
 			}
-		case *xgoast.OverloadFuncDecl:
+		case *ast.OverloadFuncDecl:
 			if decl.Recv != nil && !decl.IsClass {
 				methodDecls = append(methodDecls, decl)
 			} else {
@@ -246,14 +246,14 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 
 	// Split var blocks into two groups: with initialization and without initialization.
 	var (
-		varBlocksWithInit    []*xgoast.GenDecl // Blocks with initialization
-		varBlocksWithoutInit []*xgoast.GenDecl // Blocks without initialization
+		varBlocksWithInit    []*ast.GenDecl // Blocks with initialization
+		varBlocksWithoutInit []*ast.GenDecl // Blocks without initialization
 	)
 
 	for _, decl := range varBlocks {
 		// Check if the variable declaration has initialization expressions.
-		hasInit := slices.ContainsFunc(decl.Specs, func(spec xgoast.Spec) bool {
-			vs, ok := spec.(*xgoast.ValueSpec)
+		hasInit := slices.ContainsFunc(decl.Specs, func(spec ast.Spec) bool {
+			vs, ok := spec.(*ast.ValueSpec)
 			return ok && len(vs.Values) > 0
 		})
 
@@ -265,7 +265,7 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 	}
 
 	// Reorder declarations: imports -> types -> consts -> vars (without init) -> vars (with init) -> funcs -> others.
-	sortedDecls := make([]xgoast.Decl, 0, len(astFile.Decls))
+	sortedDecls := make([]ast.Decl, 0, len(astFile.Decls))
 	sortedDecls = append(sortedDecls, importDecls...)
 	sortedDecls = append(sortedDecls, typeDecls...)
 	sortedDecls = append(sortedDecls, methodDecls...)
@@ -299,7 +299,7 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 	}
 
 	// Find comments that appears on the same line after the given position.
-	findInlineComments := func(pos xgotoken.Pos) *xgoast.CommentGroup {
+	findInlineComments := func(pos token.Pos) *ast.CommentGroup {
 		line := fset.Position(pos).Line
 		for _, cg := range astFile.Comments {
 			if fset.Position(cg.Pos()).Line != line {
@@ -313,8 +313,8 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 	}
 
 	// Handle declarations and floating comments in order of their position.
-	processDecl := func(decl xgoast.Decl) error {
-		if genDecl, ok := decl.(*xgoast.GenDecl); ok && genDecl.Tok == xgotoken.VAR {
+	processDecl := func(decl ast.Decl) error {
+		if genDecl, ok := decl.(*ast.GenDecl); ok && genDecl.Tok == token.VAR {
 			currentVarBlocks := varBlocksWithoutInit
 			if len(currentVarBlocks) == 0 || currentVarBlocks[0] != genDecl {
 				currentVarBlocks = varBlocksWithInit
@@ -349,7 +349,7 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 					formattedBuf.WriteByte('\n')
 				}
 
-				var bodyStartPos xgotoken.Pos
+				var bodyStartPos token.Pos
 				if varBlock.Lparen.IsValid() {
 					if cg := findInlineComments(varBlock.Lparen); cg != nil {
 						cgStart := fset.Position(cg.Pos()).Offset
@@ -365,9 +365,9 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 						bodyStartPos = varBlock.Lparen + 1
 					}
 				} else {
-					bodyStartPos = varBlock.Pos() + xgotoken.Pos(len(varBlock.Tok.String())) + 1
+					bodyStartPos = varBlock.Pos() + token.Pos(len(varBlock.Tok.String())) + 1
 				}
-				var bodyEndPos xgotoken.Pos
+				var bodyEndPos token.Pos
 				if varBlock.Rparen.IsValid() {
 					bodyEndPos = varBlock.Rparen - 1
 				} else {
@@ -490,17 +490,17 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 	if len(formatted) == 0 || string(formatted) == "\n" {
 		return []byte{}, nil
 	}
-	return xgofmt.Source(formatted, true, spxFile)
+	return format.Source(formatted, true, spxFile)
 }
 
 // getDeclDoc returns the doc comment of a declaration if any.
-func getDeclDoc(decl xgoast.Decl) *xgoast.CommentGroup {
+func getDeclDoc(decl ast.Decl) *ast.CommentGroup {
 	switch decl := decl.(type) {
-	case *xgoast.GenDecl:
+	case *ast.GenDecl:
 		return decl.Doc
-	case *xgoast.FuncDecl:
+	case *ast.FuncDecl:
 		return decl.Doc
-	case *xgoast.OverloadFuncDecl:
+	case *ast.OverloadFuncDecl:
 		return decl.Doc
 	default:
 		return nil
@@ -519,17 +519,17 @@ func getDeclDoc(decl xgoast.Decl) *xgoast.CommentGroup {
 //  2. Only the last parameter of the lambda is checked.
 //
 // We may complete it in the future, if needed.
-func eliminateUnusedLambdaParams(proj *xgo.Project, astFile *xgoast.File) {
+func eliminateUnusedLambdaParams(proj *xgo.Project, astFile *ast.File) {
 	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return
 	}
-	xgoast.Inspect(astFile, func(n xgoast.Node) bool {
-		callExpr, ok := n.(*xgoast.CallExpr)
+	ast.Inspect(astFile, func(n ast.Node) bool {
+		callExpr, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		funIdent, ok := callExpr.Fun.(*xgoast.Ident)
+		funIdent, ok := callExpr.Fun.(*ast.Ident)
 		if !ok {
 			return true
 		}
@@ -539,14 +539,14 @@ func eliminateUnusedLambdaParams(proj *xgo.Project, astFile *xgoast.File) {
 		}
 		paramsType := funType.Signature().Params()
 		for argIdx, argExpr := range callExpr.Args {
-			lambdaExpr, ok := argExpr.(*xgoast.LambdaExpr2)
+			lambdaExpr, ok := argExpr.(*ast.LambdaExpr2)
 			if !ok {
 				continue
 			}
 			if argIdx >= paramsType.Len() {
 				break
 			}
-			lambdaSig, ok := paramsType.At(argIdx).Type().(*types.Signature)
+			lambdaSig, ok := paramsType.At(argIdx).Type().(*gotypes.Signature)
 			if !ok {
 				continue
 			}
@@ -562,11 +562,11 @@ func eliminateUnusedLambdaParams(proj *xgo.Project, astFile *xgoast.File) {
 
 			newParams := slices.Collect(lambdaSig.Params().Variables())
 			newParams = newParams[:len(newParams)-1] // Remove the last parameter.
-			newLambdaSig := types.NewSignatureType(
+			newLambdaSig := gotypes.NewSignatureType(
 				lambdaSig.Recv(),
 				slices.Collect(lambdaSig.RecvTypeParams().TypeParams()),
 				slices.Collect(lambdaSig.TypeParams().TypeParams()),
-				types.NewTuple(newParams...),
+				gotypes.NewTuple(newParams...),
 				lambdaSig.Results(),
 				lambdaSig.Variadic(),
 			)
@@ -579,11 +579,11 @@ func eliminateUnusedLambdaParams(proj *xgo.Project, astFile *xgoast.File) {
 				if overloadParamsType.Len() != paramsType.Len() {
 					continue
 				}
-				overloadLambdaSig, ok := overloadParamsType.At(argIdx).Type().(*types.Signature)
+				overloadLambdaSig, ok := overloadParamsType.At(argIdx).Type().(*gotypes.Signature)
 				if !ok {
 					continue
 				}
-				if types.AssignableTo(newLambdaSig, overloadLambdaSig) {
+				if gotypes.AssignableTo(newLambdaSig, overloadLambdaSig) {
 					hasMatchedOverload = true
 					break
 				}
@@ -601,7 +601,7 @@ func eliminateUnusedLambdaParams(proj *xgo.Project, astFile *xgoast.File) {
 }
 
 // getFuncAndOverloadsType returns the function type and all its overloads.
-func getFuncAndOverloadsType(proj *xgo.Project, funIdent *xgoast.Ident) (fun *types.Func, overloads []*types.Func) {
+func getFuncAndOverloadsType(proj *xgo.Project, funIdent *ast.Ident) (fun *gotypes.Func, overloads []*gotypes.Func) {
 	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return
@@ -610,7 +610,7 @@ func getFuncAndOverloadsType(proj *xgo.Project, funIdent *xgoast.Ident) (fun *ty
 	if funTypeObj == nil {
 		return
 	}
-	funType, ok := funTypeObj.(*types.Func)
+	funType, ok := funTypeObj.(*gotypes.Func)
 	if !ok {
 		return
 	}
@@ -630,13 +630,13 @@ func getFuncAndOverloadsType(proj *xgo.Project, funIdent *xgoast.Ident) (fun *ty
 	if recvType == nil {
 		return
 	}
-	recvNamed, ok := recvType.(*types.Named)
+	recvNamed, ok := recvType.(*gotypes.Named)
 	if !ok || !xgoutil.IsNamedStructType(recvNamed) {
 		return
 	}
-	var underlineFunType *types.Func
-	xgoutil.WalkStruct(recvNamed, func(member types.Object, selector *types.Named) bool {
-		method, ok := member.(*types.Func)
+	var underlineFunType *gotypes.Func
+	xgoutil.WalkStruct(recvNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
+		method, ok := member.(*gotypes.Func)
 		if !ok {
 			return true
 		}
@@ -652,7 +652,7 @@ func getFuncAndOverloadsType(proj *xgo.Project, funIdent *xgoast.Ident) (fun *ty
 	return funType, xgoutil.ExpandXGoOverloadableFunc(underlineFunType)
 }
 
-func isIdentUsed(typeInfo *xgotypes.Info, ident *xgoast.Ident) bool {
+func isIdentUsed(typeInfo *types.Info, ident *ast.Ident) bool {
 	obj := typeInfo.ObjectOf(ident)
 	if obj == nil {
 		return false

--- a/internal/server/format_test.go
+++ b/internal/server/format_test.go
@@ -762,6 +762,6 @@ onStart => {
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
-		require.Len(t, edits, 0)
+		require.Empty(t, edits)
 	})
 }

--- a/internal/server/highlight.go
+++ b/internal/server/highlight.go
@@ -3,8 +3,8 @@ package server
 import (
 	"slices"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -30,11 +30,11 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 	}
 
 	var highlights []DocumentHighlight
-	xgoast.Inspect(astFile, func(node xgoast.Node) bool {
+	ast.Inspect(astFile, func(node ast.Node) bool {
 		if node == nil {
 			return true
 		}
-		ident, ok := node.(*xgoast.Ident)
+		ident, ok := node.(*ast.Ident)
 		if !ok {
 			return true
 		}
@@ -51,14 +51,14 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 
 		for _, parent := range slices.Backward(path[:len(path)-1]) {
 			switch p := parent.(type) {
-			case *xgoast.ValueSpec:
+			case *ast.ValueSpec:
 				for _, name := range p.Names {
 					if name == ident {
 						kind = Write
 						break
 					}
 				}
-			case *xgoast.Field:
+			case *ast.Field:
 				if p.Names != nil {
 					for _, name := range p.Names {
 						if name == ident {
@@ -67,21 +67,21 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 						}
 					}
 				}
-			case *xgoast.FuncDecl:
+			case *ast.FuncDecl:
 				if p.Name == ident {
 					kind = Write
 				}
-			case *xgoast.TypeSpec:
+			case *ast.TypeSpec:
 				if p.Name == ident {
 					kind = Write
 				}
-			case *xgoast.LabeledStmt:
+			case *ast.LabeledStmt:
 				if p.Label == ident {
 					kind = Write
 				}
-			case *xgoast.AssignStmt:
+			case *ast.AssignStmt:
 				switch p.Tok {
-				case xgotoken.ASSIGN:
+				case token.ASSIGN:
 					for _, lhs := range p.Lhs {
 						if lhs == ident {
 							kind = Write
@@ -96,7 +96,7 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 							}
 						}
 					}
-				case xgotoken.DEFINE:
+				case token.DEFINE:
 					for _, lhs := range p.Lhs {
 						if lhs == ident {
 							kind = Write
@@ -106,19 +106,19 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 				default:
 					kind = Write
 				}
-			case *xgoast.IncDecStmt:
+			case *ast.IncDecStmt:
 				if p.X == ident {
 					kind = Write
 				}
-			case *xgoast.RangeStmt:
+			case *ast.RangeStmt:
 				if p.X == ident {
 					kind = Read
 				} else if p.Key == ident || p.Value == ident {
 					kind = Write
 				}
-			case *xgoast.TypeSwitchStmt:
+			case *ast.TypeSwitchStmt:
 				if p.Assign != nil {
-					if assign, ok := p.Assign.(*xgoast.AssignStmt); ok {
+					if assign, ok := p.Assign.(*ast.AssignStmt); ok {
 						for _, lhs := range assign.Lhs {
 							if lhs == ident {
 								kind = Write
@@ -127,19 +127,19 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 						}
 					}
 				}
-			case *xgoast.BinaryExpr,
-				*xgoast.UnaryExpr,
-				*xgoast.CallExpr,
-				*xgoast.CompositeLit,
-				*xgoast.IndexExpr,
-				*xgoast.ReturnStmt,
-				*xgoast.SendStmt:
+			case *ast.BinaryExpr,
+				*ast.UnaryExpr,
+				*ast.CallExpr,
+				*ast.CompositeLit,
+				*ast.IndexExpr,
+				*ast.ReturnStmt,
+				*ast.SendStmt:
 				kind = Read
-			case *xgoast.KeyValueExpr:
+			case *ast.KeyValueExpr:
 				if p.Key == ident || p.Value == ident {
 					kind = Read
 				}
-			case *xgoast.SelectorExpr:
+			case *ast.SelectorExpr:
 				if p.X == ident {
 					kind = Read
 				}

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"go/doc"
+	godoc "go/doc"
 	"strings"
 
 	"github.com/goplus/xgolsw/xgo/xgoutil"
@@ -45,7 +45,7 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 			return &Hover{
 				Contents: MarkupContent{
 					Kind:  Markdown,
-					Value: doc.Synopsis(rpkg.Pkg.Doc),
+					Value: godoc.Synopsis(rpkg.Pkg.Doc),
 				},
 				Range: RangeForNode(result.proj, rpkg.Node),
 			}, nil

--- a/internal/server/implementation.go
+++ b/internal/server/implementation.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"go/types"
+	gotypes "go/types"
 
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
@@ -27,9 +27,9 @@ func (s *Server) textDocumentImplementation(params *ImplementationParams) (any, 
 		return nil, nil
 	}
 
-	if method, ok := obj.(*types.Func); ok && method.Type().(*types.Signature).Recv() != nil {
-		if recv := method.Type().(*types.Signature).Recv().Type(); types.IsInterface(recv) {
-			locations := s.findImplementingMethodDefinitions(result, recv.(*types.Interface), method.Name())
+	if method, ok := obj.(*gotypes.Func); ok && method.Type().(*gotypes.Signature).Recv() != nil {
+		if recv := method.Type().(*gotypes.Signature).Recv().Type(); gotypes.IsInterface(recv) {
+			locations := s.findImplementingMethodDefinitions(result, recv.(*gotypes.Interface), method.Name())
 			return DedupeLocations(locations), nil
 		}
 	}
@@ -39,7 +39,7 @@ func (s *Server) textDocumentImplementation(params *ImplementationParams) (any, 
 
 // findImplementingMethodDefinitions finds the definition locations of all
 // methods that implement the given interface method.
-func (s *Server) findImplementingMethodDefinitions(result *compileResult, iface *types.Interface, methodName string) []Location {
+func (s *Server) findImplementingMethodDefinitions(result *compileResult, iface *gotypes.Interface, methodName string) []Location {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -50,11 +50,11 @@ func (s *Server) findImplementingMethodDefinitions(result *compileResult, iface 
 		if obj == nil {
 			continue
 		}
-		named, ok := obj.Type().(*types.Named)
+		named, ok := obj.Type().(*gotypes.Named)
 		if !ok {
 			continue
 		}
-		if !types.Implements(named, iface) {
+		if !gotypes.Implements(named, iface) {
 			continue
 		}
 

--- a/internal/server/implementation_test.go
+++ b/internal/server/implementation_test.go
@@ -73,8 +73,7 @@ func (t MyType) myMethod() {}
 		})
 		require.NoError(t, err)
 		require.NotNil(t, implementation)
-		location, ok := implementation.(Location)
-		require.True(t, ok)
+		location := requireValueAs[Location](t, implementation)
 		assert.Equal(t, Location{
 			URI: "file:///main.spx",
 			Range: Range{

--- a/internal/server/inlay_hint.go
+++ b/internal/server/inlay_hint.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"cmp"
-	"go/types"
+	gotypes "go/types"
 	"slices"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -31,14 +31,14 @@ func (s *Server) textDocumentInlayHint(params *InlayHintParams) ([]InlayHint, er
 // collectInlayHints collects inlay hints from the given AST file. If
 // rangeStart and rangeEnd positions are provided (non-zero), only hints within
 // the range are included.
-func collectInlayHints(result *compileResult, astFile *xgoast.File, rangeStart, rangeEnd xgotoken.Pos) []InlayHint {
+func collectInlayHints(result *compileResult, astFile *ast.File, rangeStart, rangeEnd token.Pos) []InlayHint {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 
 	var inlayHints []InlayHint
-	xgoast.Inspect(astFile, func(node xgoast.Node) bool {
+	ast.Inspect(astFile, func(node ast.Node) bool {
 		if node == nil || !node.Pos().IsValid() || !node.End().IsValid() {
 			return true
 		}
@@ -51,12 +51,12 @@ func collectInlayHints(result *compileResult, astFile *xgoast.File, rangeStart, 
 		}
 
 		switch node := node.(type) {
-		case *xgoast.BranchStmt:
+		case *ast.BranchStmt:
 			if callExpr := xgoutil.CreateCallExprFromBranchStmt(typeInfo, node); callExpr != nil {
 				hints := collectInlayHintsFromCallExpr(result, callExpr)
 				inlayHints = append(inlayHints, hints...)
 			}
-		case *xgoast.CallExpr:
+		case *ast.CallExpr:
 			hints := collectInlayHintsFromCallExpr(result, node)
 			inlayHints = append(inlayHints, hints...)
 		}
@@ -67,7 +67,7 @@ func collectInlayHints(result *compileResult, astFile *xgoast.File, rangeStart, 
 }
 
 // collectInlayHintsFromCallExpr collects inlay hints from a call expression.
-func collectInlayHintsFromCallExpr(result *compileResult, callExpr *xgoast.CallExpr) []InlayHint {
+func collectInlayHintsFromCallExpr(result *compileResult, callExpr *ast.CallExpr) []InlayHint {
 	astPkg, _ := result.proj.ASTPackage()
 	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, callExpr)
 	if astFile == nil {
@@ -79,14 +79,14 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *xgoast.CallE
 	}
 
 	var inlayHints []InlayHint
-	xgoutil.WalkCallExprArgs(typeInfo, callExpr, func(fun *types.Func, params *types.Tuple, paramIndex int, arg xgoast.Expr, argIndex int) bool {
+	xgoutil.WalkCallExprArgs(typeInfo, callExpr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
 		if paramIndex < argIndex {
 			// Stop processing variadic arguments beyond the declared parameters.
 			return false
 		}
 
 		switch arg.(type) {
-		case *xgoast.LambdaExpr, *xgoast.LambdaExpr2:
+		case *ast.LambdaExpr, *ast.LambdaExpr2:
 			// Skip lambda expressions.
 			return true
 		}

--- a/internal/server/inlay_hint_test.go
+++ b/internal/server/inlay_hint_test.go
@@ -137,7 +137,7 @@ onStart => {
 		inlayHints, err := s.textDocumentInlayHint(params)
 		require.NoError(t, err)
 		require.NotNil(t, inlayHints)
-		assert.Equal(t, 2, len(inlayHints))
+		assert.Len(t, inlayHints, 2)
 
 		for _, hint := range inlayHints {
 			assert.True(t, hint.Position.Line >= 7 && hint.Position.Line <= 11)
@@ -451,7 +451,7 @@ func TestSortInlayHints(t *testing.T) {
 		l5Hints := slices.DeleteFunc(slices.Clone(hints), func(h InlayHint) bool {
 			return h.Position.Line != 5
 		})
-		require.Equal(t, 3, len(l5Hints))
+		require.Len(t, l5Hints, 3)
 		assert.Equal(t, uint32(5), l5Hints[0].Position.Character)
 		assert.Equal(t, uint32(15), l5Hints[1].Position.Character)
 		assert.Equal(t, uint32(20), l5Hints[2].Position.Character)
@@ -459,7 +459,7 @@ func TestSortInlayHints(t *testing.T) {
 		l7Hints := slices.DeleteFunc(slices.Clone(hints), func(h InlayHint) bool {
 			return h.Position.Line != 7
 		})
-		require.Equal(t, 2, len(l7Hints))
+		require.Len(t, l7Hints, 2)
 		assert.Equal(t, uint32(10), l7Hints[0].Position.Character)
 		assert.Equal(t, "B2", l7Hints[0].Label)
 		assert.Equal(t, uint32(30), l7Hints[1].Position.Character)
@@ -482,7 +482,7 @@ func TestSortInlayHints(t *testing.T) {
 		l5c10Hints := slices.DeleteFunc(slices.Clone(hints), func(hint InlayHint) bool {
 			return hint.Position.Line != 5 || hint.Position.Character != 10
 		})
-		require.Equal(t, 3, len(l5c10Hints))
+		require.Len(t, l5c10Hints, 3)
 		assert.Equal(t, "A", l5c10Hints[0].Label)
 		assert.Equal(t, "M", l5c10Hints[1].Label)
 		assert.Equal(t, "Z", l5c10Hints[2].Label)

--- a/internal/server/reference.go
+++ b/internal/server/reference.go
@@ -1,9 +1,9 @@
 package server
 
 import (
-	"go/types"
+	gotypes "go/types"
 
-	xgoast "github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
@@ -33,7 +33,7 @@ func (s *Server) textDocumentReferences(params *ReferenceParams) ([]Location, er
 
 	locations = append(locations, s.findReferenceLocations(result, obj)...)
 
-	if fn, ok := obj.(*types.Func); ok && fn.Type().(*types.Signature).Recv() != nil {
+	if fn, ok := obj.(*gotypes.Func); ok && fn.Type().(*gotypes.Signature).Recv() != nil {
 		locations = append(locations, s.handleMethodReferences(result, fn)...)
 		locations = append(locations, s.handleEmbeddedFieldReferences(result, obj)...)
 	}
@@ -54,7 +54,7 @@ func (s *Server) textDocumentReferences(params *ReferenceParams) ([]Location, er
 }
 
 // findReferenceLocations returns all locations where the given object is referenced.
-func (s *Server) findReferenceLocations(result *compileResult, obj types.Object) []Location {
+func (s *Server) findReferenceLocations(result *compileResult, obj gotypes.Object) []Location {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
@@ -75,11 +75,11 @@ func (s *Server) findReferenceLocations(result *compileResult, obj types.Object)
 
 // handleMethodReferences finds all references to a method, including interface
 // implementations and interface method references.
-func (s *Server) handleMethodReferences(result *compileResult, fn *types.Func) []Location {
+func (s *Server) handleMethodReferences(result *compileResult, fn *gotypes.Func) []Location {
 	var locations []Location
-	recvType := fn.Type().(*types.Signature).Recv().Type()
-	if types.IsInterface(recvType) {
-		iface, ok := recvType.(*types.Interface)
+	recvType := fn.Type().(*gotypes.Signature).Recv().Type()
+	if gotypes.IsInterface(recvType) {
+		iface, ok := recvType.(*gotypes.Interface)
 		if !ok {
 			return nil
 		}
@@ -94,38 +94,38 @@ func (s *Server) handleMethodReferences(result *compileResult, fn *types.Func) [
 
 // findEmbeddedInterfaceReferences finds references to methods in interfaces
 // that embed the given interface.
-func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *types.Interface, methodName string) []Location {
+func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *gotypes.Interface, methodName string) []Location {
 	var locations []Location
-	seenIfaces := make(map[*types.Interface]bool)
+	seenIfaces := make(map[*gotypes.Interface]bool)
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return locations
 	}
 
 	astPkg, _ := result.proj.ASTPackage()
-	var find func(*types.Interface)
-	find = func(current *types.Interface) {
+	var find func(*gotypes.Interface)
+	find = func(current *gotypes.Interface) {
 		if seenIfaces[current] {
 			return
 		}
 		seenIfaces[current] = true
 
-		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec xgoast.Spec) {
-			typeSpec := spec.(*xgoast.TypeSpec)
+		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+			typeSpec := spec.(*ast.TypeSpec)
 			typeName := typeInfo.ObjectOf(typeSpec.Name)
 			if typeName == nil {
 				return
 			}
-			embedIface, ok := typeName.Type().Underlying().(*types.Interface)
+			embedIface, ok := typeName.Type().Underlying().(*gotypes.Interface)
 			if !ok {
 				return
 			}
 
 			for typ := range embedIface.EmbeddedTypes() {
-				if types.Identical(typ, current) {
-					selection, ok := types.LookupSelection(embedIface, false, typeName.Pkg(), methodName)
+				if gotypes.Identical(typ, current) {
+					selection, ok := gotypes.LookupSelection(embedIface, false, typeName.Pkg(), methodName)
 					if ok {
-						method, ok := selection.Obj().(*types.Func)
+						method, ok := selection.Obj().(*gotypes.Func)
 						if ok {
 							locations = append(locations, s.findReferenceLocations(result, method)...)
 						}
@@ -141,29 +141,29 @@ func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *t
 
 // findImplementingMethodReferences finds references to all methods that
 // implement the given interface method.
-func (s *Server) findImplementingMethodReferences(result *compileResult, iface *types.Interface, methodName string) []Location {
+func (s *Server) findImplementingMethodReferences(result *compileResult, iface *gotypes.Interface, methodName string) []Location {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 	var locations []Location
 	astPkg, _ := result.proj.ASTPackage()
-	xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec xgoast.Spec) {
-		typeSpec := spec.(*xgoast.TypeSpec)
+	xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+		typeSpec := spec.(*ast.TypeSpec)
 		typeName := typeInfo.ObjectOf(typeSpec.Name)
 		if typeName == nil {
 			return
 		}
-		named, ok := typeName.Type().(*types.Named)
-		if !ok || !types.Implements(named, iface) {
+		named, ok := typeName.Type().(*gotypes.Named)
+		if !ok || !gotypes.Implements(named, iface) {
 			return
 		}
 
-		selection, ok := types.LookupSelection(named, false, named.Obj().Pkg(), methodName)
+		selection, ok := gotypes.LookupSelection(named, false, named.Obj().Pkg(), methodName)
 		if !ok {
 			return
 		}
-		method, ok := selection.Obj().(*types.Func)
+		method, ok := selection.Obj().(*gotypes.Func)
 		if !ok {
 			return
 		}
@@ -174,33 +174,33 @@ func (s *Server) findImplementingMethodReferences(result *compileResult, iface *
 
 // findInterfaceMethodReferences finds references to interface methods that this
 // method implements, including methods from embedded interfaces.
-func (s *Server) findInterfaceMethodReferences(result *compileResult, fn *types.Func) []Location {
+func (s *Server) findInterfaceMethodReferences(result *compileResult, fn *gotypes.Func) []Location {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 	var locations []Location
-	recvType := fn.Type().(*types.Signature).Recv().Type()
-	seenIfaces := make(map[*types.Interface]bool)
+	recvType := fn.Type().(*gotypes.Signature).Recv().Type()
+	seenIfaces := make(map[*gotypes.Interface]bool)
 	astPkg, _ := result.proj.ASTPackage()
 
-	xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec xgoast.Spec) {
-		typeSpec := spec.(*xgoast.TypeSpec)
+	xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+		typeSpec := spec.(*ast.TypeSpec)
 		typeName := typeInfo.ObjectOf(typeSpec.Name)
 		if typeName == nil {
 			return
 		}
-		ifaceType, ok := typeName.Type().Underlying().(*types.Interface)
-		if !ok || !types.Implements(recvType, ifaceType) || seenIfaces[ifaceType] {
+		ifaceType, ok := typeName.Type().Underlying().(*gotypes.Interface)
+		if !ok || !gotypes.Implements(recvType, ifaceType) || seenIfaces[ifaceType] {
 			return
 		}
 		seenIfaces[ifaceType] = true
 
-		selection, ok := types.LookupSelection(ifaceType, false, typeName.Pkg(), fn.Name())
+		selection, ok := gotypes.LookupSelection(ifaceType, false, typeName.Pkg(), fn.Name())
 		if !ok {
 			return
 		}
-		method, ok := selection.Obj().(*types.Func)
+		method, ok := selection.Obj().(*gotypes.Func)
 		if !ok {
 			return
 		}
@@ -211,27 +211,27 @@ func (s *Server) findInterfaceMethodReferences(result *compileResult, fn *types.
 }
 
 // handleEmbeddedFieldReferences finds all references through embedded fields.
-func (s *Server) handleEmbeddedFieldReferences(result *compileResult, obj types.Object) []Location {
+func (s *Server) handleEmbeddedFieldReferences(result *compileResult, obj gotypes.Object) []Location {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 	var locations []Location
-	if fn, ok := obj.(*types.Func); ok {
-		recv := fn.Type().(*types.Signature).Recv()
+	if fn, ok := obj.(*gotypes.Func); ok {
+		recv := fn.Type().(*gotypes.Signature).Recv()
 		if recv == nil {
 			return nil
 		}
 
-		seenTypes := make(map[types.Type]bool)
+		seenTypes := make(map[gotypes.Type]bool)
 		astPkg, _ := result.proj.ASTPackage()
-		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec xgoast.Spec) {
-			typeSpec := spec.(*xgoast.TypeSpec)
+		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+			typeSpec := spec.(*ast.TypeSpec)
 			typeName := typeInfo.ObjectOf(typeSpec.Name)
 			if typeName == nil {
 				return
 			}
-			named, ok := typeName.Type().(*types.Named)
+			named, ok := typeName.Type().(*gotypes.Named)
 			if !ok {
 				return
 			}
@@ -244,13 +244,13 @@ func (s *Server) handleEmbeddedFieldReferences(result *compileResult, obj types.
 
 // findEmbeddedMethodReferences recursively finds all references to a method
 // through embedded fields.
-func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *types.Func, named *types.Named, targetType types.Type, seenTypes map[types.Type]bool) []Location {
+func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *gotypes.Func, named *gotypes.Named, targetType gotypes.Type, seenTypes map[gotypes.Type]bool) []Location {
 	if seenTypes[named] {
 		return nil
 	}
 	seenTypes[named] = true
 
-	st, ok := named.Underlying().(*types.Struct)
+	st, ok := named.Underlying().(*gotypes.Struct)
 	if !ok {
 		return nil
 	}
@@ -262,21 +262,21 @@ func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *types.F
 			continue
 		}
 
-		if types.Identical(field.Type(), targetType) {
+		if gotypes.Identical(field.Type(), targetType) {
 			hasEmbed = true
 
-			selection, ok := types.LookupSelection(named, false, fn.Pkg(), fn.Name())
+			selection, ok := gotypes.LookupSelection(named, false, fn.Pkg(), fn.Name())
 			if !ok {
 				continue
 			}
-			method, ok := selection.Obj().(*types.Func)
+			method, ok := selection.Obj().(*gotypes.Func)
 			if !ok {
 				continue
 			}
 			locations = append(locations, s.findReferenceLocations(result, method)...)
 		}
 
-		if fieldNamed, ok := field.Type().(*types.Named); ok {
+		if fieldNamed, ok := field.Type().(*gotypes.Named); ok {
 			locations = append(locations, s.findEmbeddedMethodReferences(result, fn, fieldNamed, targetType, seenTypes)...)
 		}
 	}
@@ -286,13 +286,13 @@ func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *types.F
 			return nil
 		}
 		astPkg, _ := result.proj.ASTPackage()
-		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec xgoast.Spec) {
-			typeSpec := spec.(*xgoast.TypeSpec)
+		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+			typeSpec := spec.(*ast.TypeSpec)
 			typeName := typeInfo.ObjectOf(typeSpec.Name)
 			if typeName == nil {
 				return
 			}
-			named, ok := typeName.Type().(*types.Named)
+			named, ok := typeName.Type().(*gotypes.Named)
 			if !ok {
 				return
 			}

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"slices"
 
-	xgoast "github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -129,13 +129,13 @@ func (s *Server) spxRenameResourceAtRefs(result *compileResult, id SpxResourceID
 		nodePos := fset.Position(node.Pos())
 		nodeEnd := fset.Position(node.End())
 
-		if expr, ok := node.(xgoast.Expr); ok && types.AssignableTo(typeInfo.TypeOf(expr), types.Typ[types.String]) {
-			if ident, ok := expr.(*xgoast.Ident); ok {
+		if expr, ok := node.(ast.Expr); ok && gotypes.AssignableTo(typeInfo.TypeOf(expr), gotypes.Typ[gotypes.String]) {
+			if ident, ok := expr.(*ast.Ident); ok {
 				// It has to be a constant. So we must find its declaration site and
 				// use the position of its value instead.
 				defIdent := typeInfo.ObjToDef[typeInfo.ObjectOf(ident)]
 				if defIdent != nil && xgoutil.NodeTokenFile(result.proj.Fset, defIdent) != nil {
-					parent, ok := defIdent.Obj.Decl.(*xgoast.ValueSpec)
+					parent, ok := defIdent.Obj.Decl.(*ast.ValueSpec)
 					if ok && slices.Contains(parent.Names, defIdent) && len(parent.Values) > 0 {
 						node = parent.Values[0]
 						nodePos = fset.Position(node.Pos())

--- a/internal/server/rename_test.go
+++ b/internal/server/rename_test.go
@@ -332,7 +332,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/backdrops/backdrop1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameBackdropResource(result, id.(SpxBackdropResourceID), "backdrop2")
+		changes, err := s.spxRenameBackdropResource(result, requireValueAs[SpxBackdropResourceID](t, id), "backdrop2")
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 
@@ -378,7 +378,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/backdrops/backdrop1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameBackdropResource(result, id.(SpxBackdropResourceID), "backdrop2")
+		changes, err := s.spxRenameBackdropResource(result, requireValueAs[SpxBackdropResourceID](t, id), "backdrop2")
 		require.NoError(t, err)
 		require.Len(t, changes, 1)
 
@@ -393,7 +393,7 @@ onStart => {
 		})
 
 		mySpriteSpxChanges := changes[s.toDocumentURI("MySprite.spx")]
-		require.Len(t, mySpriteSpxChanges, 0)
+		require.Empty(t, mySpriteSpxChanges)
 	})
 
 	t.Run("TypedConstantName", func(t *testing.T) {
@@ -417,7 +417,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/backdrops/backdrop1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameBackdropResource(result, id.(SpxBackdropResourceID), "backdrop2")
+		changes, err := s.spxRenameBackdropResource(result, requireValueAs[SpxBackdropResourceID](t, id), "backdrop2")
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 
@@ -464,7 +464,7 @@ onBackdrop "backdrop1", func() {}
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/backdrops/backdrop1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameBackdropResource(result, id.(SpxBackdropResourceID), "backdrop2")
+		changes, err := s.spxRenameBackdropResource(result, requireValueAs[SpxBackdropResourceID](t, id), "backdrop2")
 		require.EqualError(t, err, `backdrop resource "backdrop2" already exists`)
 		require.Nil(t, changes)
 	})
@@ -493,7 +493,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sounds/Sound1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSoundResource(result, id.(SpxSoundResourceID), "Sound2")
+		changes, err := s.spxRenameSoundResource(result, requireValueAs[SpxSoundResourceID](t, id), "Sound2")
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 
@@ -535,7 +535,7 @@ play "Sound1"
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sounds/Sound1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSoundResource(result, id.(SpxSoundResourceID), "Sound2")
+		changes, err := s.spxRenameSoundResource(result, requireValueAs[SpxSoundResourceID](t, id), "Sound2")
 		require.EqualError(t, err, `sound resource "Sound2" already exists`)
 		require.Nil(t, changes)
 	})
@@ -563,7 +563,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/Sprite1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteResource(result, id.(SpxSpriteResourceID), "Sprite2")
+		changes, err := s.spxRenameSpriteResource(result, requireValueAs[SpxSpriteResourceID](t, id), "Sprite2")
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 
@@ -616,7 +616,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/Sprite1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteResource(result, id.(SpxSpriteResourceID), "Sprite2")
+		changes, err := s.spxRenameSpriteResource(result, requireValueAs[SpxSpriteResourceID](t, id), "Sprite2")
 		require.EqualError(t, err, `sprite resource "Sprite2" already exists`)
 		require.Nil(t, changes)
 	})
@@ -646,7 +646,7 @@ func invalidFunc() {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/Sprite1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteResource(result, id.(SpxSpriteResourceID), "Sprite2")
+		changes, err := s.spxRenameSpriteResource(result, requireValueAs[SpxSpriteResourceID](t, id), "Sprite2")
 		require.NoError(t, err)
 		require.Len(t, changes, 1)
 
@@ -684,7 +684,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/MySprite/costumes/costume1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteCostumeResource(result, id.(SpxSpriteCostumeResourceID), "costume2")
+		changes, err := s.spxRenameSpriteCostumeResource(result, requireValueAs[SpxSpriteCostumeResourceID](t, id), "costume2")
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 
@@ -730,7 +730,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/MySprite/costumes/costume1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteCostumeResource(result, id.(SpxSpriteCostumeResourceID), "costume2")
+		changes, err := s.spxRenameSpriteCostumeResource(result, requireValueAs[SpxSpriteCostumeResourceID](t, id), "costume2")
 		require.EqualError(t, err, `sprite costume resource "costume2" already exists`)
 		require.Nil(t, changes)
 	})
@@ -756,7 +756,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/NonExistentSprite/costumes/costume1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteCostumeResource(result, id.(SpxSpriteCostumeResourceID), "costume2")
+		changes, err := s.spxRenameSpriteCostumeResource(result, requireValueAs[SpxSpriteCostumeResourceID](t, id), "costume2")
 		require.EqualError(t, err, `sprite resource "NonExistentSprite" not found`)
 		require.Nil(t, changes)
 	})
@@ -784,7 +784,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/MySprite/animations/anim1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteAnimationResource(result, id.(SpxSpriteAnimationResourceID), "anim2")
+		changes, err := s.spxRenameSpriteAnimationResource(result, requireValueAs[SpxSpriteAnimationResourceID](t, id), "anim2")
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 
@@ -830,7 +830,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/MySprite/animations/anim1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteAnimationResource(result, id.(SpxSpriteAnimationResourceID), "anim2")
+		changes, err := s.spxRenameSpriteAnimationResource(result, requireValueAs[SpxSpriteAnimationResourceID](t, id), "anim2")
 		require.EqualError(t, err, `sprite animation resource "anim2" already exists`)
 		require.Nil(t, changes)
 	})
@@ -856,7 +856,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/sprites/NonExistentSprite/animations/anim1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameSpriteAnimationResource(result, id.(SpxSpriteAnimationResourceID), "anim2")
+		changes, err := s.spxRenameSpriteAnimationResource(result, requireValueAs[SpxSpriteAnimationResourceID](t, id), "anim2")
 		require.EqualError(t, err, `sprite resource "NonExistentSprite" not found`)
 		require.Nil(t, changes)
 	})
@@ -882,7 +882,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/widgets/widget1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameWidgetResource(result, id.(SpxWidgetResourceID), "widget2")
+		changes, err := s.spxRenameWidgetResource(result, requireValueAs[SpxWidgetResourceID](t, id), "widget2")
 		require.NoError(t, err)
 		require.Len(t, changes, 1)
 
@@ -916,7 +916,7 @@ onStart => {
 		id, err := ParseSpxResourceURI(SpxResourceURI("spx://resources/widgets/widget1"))
 		require.NoError(t, err)
 
-		changes, err := s.spxRenameWidgetResource(result, id.(SpxWidgetResourceID), "widget2")
+		changes, err := s.spxRenameWidgetResource(result, requireValueAs[SpxWidgetResourceID](t, id), "widget2")
 		require.EqualError(t, err, `widget resource "widget2" already exists`)
 		require.Nil(t, changes)
 	})

--- a/internal/server/semantic_token.go
+++ b/internal/server/semantic_token.go
@@ -1,13 +1,13 @@
 package server
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"slices"
 	"sort"
 	"strings"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -64,8 +64,8 @@ func getSemanticTokenModifiersMask(modifiers []SemanticTokenModifiers) uint32 {
 
 // semanticTokenInfo represents the information of a semantic token.
 type semanticTokenInfo struct {
-	startPos       xgotoken.Pos
-	endPos         xgotoken.Pos
+	startPos       token.Pos
+	endPos         token.Pos
 	tokenType      SemanticTokenTypes
 	tokenModifiers []SemanticTokenModifiers
 }
@@ -86,7 +86,7 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 
 	fset := result.proj.Fset
 	var tokenInfos []semanticTokenInfo
-	addToken := func(startPos, endPos xgotoken.Pos, tokenType SemanticTokenTypes, tokenModifiers []SemanticTokenModifiers) {
+	addToken := func(startPos, endPos token.Pos, tokenType SemanticTokenTypes, tokenModifiers []SemanticTokenModifiers) {
 		if !startPos.IsValid() || !endPos.IsValid() {
 			return
 		}
@@ -105,26 +105,26 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 		})
 	}
 
-	xgoast.Inspect(astFile, func(node xgoast.Node) bool {
+	ast.Inspect(astFile, func(node ast.Node) bool {
 		if node == nil || !node.Pos().IsValid() {
 			return true
 		}
 
 		switch node := node.(type) {
-		case *xgoast.Comment:
+		case *ast.Comment:
 			addToken(node.Pos(), node.End(), CommentType, nil)
-		case *xgoast.BadExpr:
+		case *ast.BadExpr:
 			addToken(node.From, node.To, OperatorType, nil)
-		case *xgoast.BadStmt:
+		case *ast.BadStmt:
 			addToken(node.From, node.To, OperatorType, nil)
-		case *xgoast.EmptyStmt:
+		case *ast.EmptyStmt:
 			if !node.Implicit {
 				addToken(node.Semicolon, node.Semicolon+1, OperatorType, nil)
 			}
-		case *xgoast.Ident:
+		case *ast.Ident:
 			obj := typeInfo.ObjectOf(node)
 			if obj == nil {
-				if xgotoken.Lookup(node.Name).IsKeyword() {
+				if token.Lookup(node.Name).IsKeyword() {
 					addToken(node.Pos(), node.End(), KeywordType, nil)
 				}
 				return true
@@ -135,15 +135,15 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 				modifiers []SemanticTokenModifiers
 			)
 			switch obj := obj.(type) {
-			case *types.Builtin:
+			case *gotypes.Builtin:
 				tokenType = KeywordType
 				modifiers = append(modifiers, ModDefaultLibrary)
-			case *types.TypeName:
+			case *gotypes.TypeName:
 				if named := resolvedNamedType(obj.Type()); named != nil {
 					switch named.Underlying().(type) {
-					case *types.Struct:
+					case *gotypes.Struct:
 						tokenType = StructType
-					case *types.Interface:
+					case *gotypes.Interface:
 						tokenType = InterfaceType
 					default:
 						tokenType = TypeType
@@ -151,9 +151,9 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 				} else {
 					tokenType = TypeType
 				}
-			case *types.Var:
+			case *gotypes.Var:
 				switch obj.Kind() {
-				case types.FieldVar:
+				case gotypes.FieldVar:
 					typeInfo, _ := result.proj.TypeInfo()
 					astPkg, _ := result.proj.ASTPackage()
 					if xgoutil.IsInMainPkg(obj) && xgoutil.IsDefinedInClassFieldsDecl(result.proj.Fset, typeInfo, astPkg, obj) {
@@ -161,7 +161,7 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 					} else {
 						tokenType = PropertyType
 					}
-				case types.PackageVar:
+				case gotypes.PackageVar:
 					defIdent := typeInfo.ObjToDef[obj]
 					if defIdent == node {
 						tokenType = ParameterType
@@ -171,18 +171,18 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 				default:
 					tokenType = VariableType
 				}
-			case *types.Const:
+			case *gotypes.Const:
 				tokenType = VariableType
 				modifiers = append(modifiers, ModStatic, ModReadonly)
-			case *types.Func:
-				if obj.Type().(*types.Signature).Recv() != nil {
+			case *gotypes.Func:
+				if obj.Type().(*gotypes.Signature).Recv() != nil {
 					tokenType = MethodType
 				} else {
 					tokenType = FunctionType
 				}
-			case *types.PkgName:
+			case *gotypes.PkgName:
 				tokenType = NamespaceType
-			case *types.Label:
+			case *gotypes.Label:
 				tokenType = LabelType
 			}
 			if typeInfo.ObjToDef[obj] == node {
@@ -192,127 +192,127 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 				modifiers = append(modifiers, ModDefaultLibrary)
 			}
 			addToken(node.Pos(), node.End(), tokenType, modifiers)
-		case *xgoast.BasicLit:
+		case *ast.BasicLit:
 			var tokenType SemanticTokenTypes
 			switch node.Kind {
-			case xgotoken.STRING, xgotoken.CHAR, xgotoken.CSTRING:
+			case token.STRING, token.CHAR, token.CSTRING:
 				tokenType = StringType
-			case xgotoken.INT, xgotoken.FLOAT, xgotoken.IMAG, xgotoken.RAT:
+			case token.INT, token.FLOAT, token.IMAG, token.RAT:
 				tokenType = NumberType
 			}
-			addToken(node.ValuePos, node.ValuePos+xgotoken.Pos(len(node.Value)), tokenType, nil)
+			addToken(node.ValuePos, node.ValuePos+token.Pos(len(node.Value)), tokenType, nil)
 
 			if node.Extra != nil && len(node.Extra.Parts) > 0 {
 				pos := node.ValuePos
 				for _, part := range node.Extra.Parts {
 					switch v := part.(type) {
 					case string:
-						nextPos := xgoast.NextPartPos(pos, v)
+						nextPos := ast.NextPartPos(pos, v)
 						addToken(pos, nextPos, StringType, nil)
 						pos = nextPos
-					case xgoast.Expr:
+					case ast.Expr:
 						pos = v.End()
 					}
 				}
 			}
-		case *xgoast.CompositeLit:
+		case *ast.CompositeLit:
 			addToken(node.Lbrace, node.Lbrace+1, OperatorType, nil)
 			addToken(node.Rbrace, node.Rbrace+1, OperatorType, nil)
-		case *xgoast.FuncLit:
-			addToken(node.Type.Func, node.Type.Func+xgotoken.Pos(len("func")), KeywordType, nil)
-		case *xgoast.SliceLit:
+		case *ast.FuncLit:
+			addToken(node.Type.Func, node.Type.Func+token.Pos(len("func")), KeywordType, nil)
+		case *ast.SliceLit:
 			addToken(node.Lbrack, node.Lbrack+1, OperatorType, nil)
 			addToken(node.Rbrack, node.Rbrack+1, OperatorType, nil)
-		case *xgoast.MatrixLit:
+		case *ast.MatrixLit:
 			addToken(node.Lbrack, node.Lbrack+1, OperatorType, nil)
 			addToken(node.Rbrack, node.Rbrack+1, OperatorType, nil)
-		case *xgoast.StarExpr:
+		case *ast.StarExpr:
 			addToken(node.Star, node.Star+1, OperatorType, nil)
-		case *xgoast.UnaryExpr:
+		case *ast.UnaryExpr:
 			opLen := len(node.Op.String())
-			addToken(node.OpPos, node.OpPos+xgotoken.Pos(opLen), OperatorType, nil)
-		case *xgoast.BinaryExpr:
+			addToken(node.OpPos, node.OpPos+token.Pos(opLen), OperatorType, nil)
+		case *ast.BinaryExpr:
 			opLen := len(node.Op.String())
-			addToken(node.OpPos, node.OpPos+xgotoken.Pos(opLen), OperatorType, nil)
-		case *xgoast.ParenExpr:
+			addToken(node.OpPos, node.OpPos+token.Pos(opLen), OperatorType, nil)
+		case *ast.ParenExpr:
 			addToken(node.Lparen, node.Lparen+1, OperatorType, nil)
 			addToken(node.Rparen, node.Rparen+1, OperatorType, nil)
-		case *xgoast.SelectorExpr:
+		case *ast.SelectorExpr:
 			addToken(node.Sel.Pos()-1, node.Sel.Pos(), OperatorType, nil)
-		case *xgoast.IndexExpr:
+		case *ast.IndexExpr:
 			addToken(node.Lbrack, node.Lbrack+1, OperatorType, nil)
 			addToken(node.Rbrack, node.Rbrack+1, OperatorType, nil)
-		case *xgoast.IndexListExpr:
+		case *ast.IndexListExpr:
 			addToken(node.Lbrack, node.Lbrack+1, OperatorType, nil)
 			addToken(node.Rbrack, node.Rbrack+1, OperatorType, nil)
-		case *xgoast.SliceExpr:
+		case *ast.SliceExpr:
 			addToken(node.Lbrack, node.Lbrack+1, OperatorType, nil)
 			addToken(node.Rbrack, node.Rbrack+1, OperatorType, nil)
-		case *xgoast.TypeAssertExpr:
+		case *ast.TypeAssertExpr:
 			addToken(node.Lparen-1, node.Lparen, OperatorType, nil)
 			addToken(node.Lparen, node.Lparen+1, OperatorType, nil)
 			if node.Type == nil {
-				addToken(node.Lparen+1, node.Lparen+1+xgotoken.Pos(len("type")), KeywordType, nil)
+				addToken(node.Lparen+1, node.Lparen+1+token.Pos(len("type")), KeywordType, nil)
 			}
 			addToken(node.Rparen, node.Rparen+1, OperatorType, nil)
-		case *xgoast.CallExpr:
+		case *ast.CallExpr:
 			addToken(node.Lparen, node.Lparen+1, OperatorType, nil)
 			addToken(node.Rparen, node.Rparen+1, OperatorType, nil)
 			if node.Ellipsis.IsValid() {
 				addToken(node.Ellipsis, node.Ellipsis+3, OperatorType, nil)
 			}
-		case *xgoast.KeyValueExpr:
+		case *ast.KeyValueExpr:
 			addToken(node.Colon, node.Colon+1, OperatorType, nil)
-		case *xgoast.ErrWrapExpr:
+		case *ast.ErrWrapExpr:
 			addToken(node.TokPos, node.TokPos+1, OperatorType, nil)
 			if node.Default != nil {
 				addToken(node.TokPos+1, node.TokPos+2, OperatorType, nil)
 			}
-		case *xgoast.EnvExpr:
+		case *ast.EnvExpr:
 			addToken(node.TokPos, node.TokPos+1, OperatorType, nil)
 			if node.HasBrace() {
 				addToken(node.Lbrace, node.Lbrace+1, OperatorType, nil)
 				addToken(node.Rbrace, node.Rbrace+1, OperatorType, nil)
 			}
-		case *xgoast.RangeExpr:
+		case *ast.RangeExpr:
 			addToken(node.To, node.To+1, OperatorType, nil)
 			if node.Colon2.IsValid() {
 				addToken(node.Colon2, node.Colon2+1, OperatorType, nil)
 			}
-		case *xgoast.ArrayType:
+		case *ast.ArrayType:
 			addToken(node.Lbrack, node.Lbrack+1, OperatorType, nil)
 			if node.Len == nil {
 				addToken(node.Lbrack+1, node.Lbrack+2, OperatorType, nil)
 			}
-		case *xgoast.StructType:
-			addToken(node.Struct, node.Struct+xgotoken.Pos(len("struct")), KeywordType, nil)
-		case *xgoast.InterfaceType:
-			addToken(node.Interface, node.Interface+xgotoken.Pos(len("interface")), KeywordType, nil)
-		case *xgoast.FuncType:
+		case *ast.StructType:
+			addToken(node.Struct, node.Struct+token.Pos(len("struct")), KeywordType, nil)
+		case *ast.InterfaceType:
+			addToken(node.Interface, node.Interface+token.Pos(len("interface")), KeywordType, nil)
+		case *ast.FuncType:
 			if node.Func.IsValid() {
-				addToken(node.Func, node.Func+xgotoken.Pos(len("func")), KeywordType, nil)
+				addToken(node.Func, node.Func+token.Pos(len("func")), KeywordType, nil)
 			}
 			if node.TypeParams != nil {
 				addToken(node.TypeParams.Opening, node.TypeParams.Opening+1, OperatorType, nil)
 				addToken(node.TypeParams.Closing, node.TypeParams.Closing+1, OperatorType, nil)
 			}
-		case *xgoast.MapType:
-			addToken(node.Map, node.Map+xgotoken.Pos(len("map")), KeywordType, nil)
-		case *xgoast.ChanType:
-			addToken(node.Begin, node.Begin+xgotoken.Pos(len("chan")), KeywordType, nil)
+		case *ast.MapType:
+			addToken(node.Map, node.Map+token.Pos(len("map")), KeywordType, nil)
+		case *ast.ChanType:
+			addToken(node.Begin, node.Begin+token.Pos(len("chan")), KeywordType, nil)
 			if node.Arrow.IsValid() {
 				addToken(node.Arrow, node.Arrow+2, OperatorType, nil)
 			}
-		case *xgoast.GenDecl:
+		case *ast.GenDecl:
 			switch node.Tok {
-			case xgotoken.IMPORT:
-				addToken(node.TokPos, node.TokPos+xgotoken.Pos(len("import")), KeywordType, nil)
-			case xgotoken.CONST:
-				addToken(node.TokPos, node.TokPos+xgotoken.Pos(len("const")), KeywordType, nil)
-			case xgotoken.TYPE:
-				addToken(node.TokPos, node.TokPos+xgotoken.Pos(len("type")), KeywordType, nil)
-			case xgotoken.VAR:
-				addToken(node.TokPos, node.TokPos+xgotoken.Pos(len("var")), KeywordType, nil)
+			case token.IMPORT:
+				addToken(node.TokPos, node.TokPos+token.Pos(len("import")), KeywordType, nil)
+			case token.CONST:
+				addToken(node.TokPos, node.TokPos+token.Pos(len("const")), KeywordType, nil)
+			case token.TYPE:
+				addToken(node.TokPos, node.TokPos+token.Pos(len("type")), KeywordType, nil)
+			case token.VAR:
+				addToken(node.TokPos, node.TokPos+token.Pos(len("var")), KeywordType, nil)
 			}
 			if node.Lparen.IsValid() {
 				addToken(node.Lparen, node.Lparen+1, OperatorType, nil)
@@ -320,12 +320,12 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 			if node.Rparen.IsValid() {
 				addToken(node.Rparen, node.Rparen+1, OperatorType, nil)
 			}
-		case *xgoast.FuncDecl:
+		case *ast.FuncDecl:
 			if node.Shadow {
 				return true
 			}
 
-			addToken(node.Type.Func, node.Type.Func+xgotoken.Pos(len("func")), KeywordType, nil)
+			addToken(node.Type.Func, node.Type.Func+token.Pos(len("func")), KeywordType, nil)
 			if node.Recv != nil {
 				addToken(node.Recv.Opening, node.Recv.Opening+1, OperatorType, nil)
 				addToken(node.Recv.Closing, node.Recv.Closing+1, OperatorType, nil)
@@ -333,8 +333,8 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 			if node.Operator {
 				addToken(node.Name.Pos(), node.Name.End(), OperatorType, []SemanticTokenModifiers{ModDeclaration})
 			}
-		case *xgoast.OverloadFuncDecl:
-			addToken(node.Func, node.Func+xgotoken.Pos(len("func")), KeywordType, nil)
+		case *ast.OverloadFuncDecl:
+			addToken(node.Func, node.Func+token.Pos(len("func")), KeywordType, nil)
 			if node.Recv != nil {
 				addToken(node.Recv.Opening, node.Recv.Opening+1, OperatorType, nil)
 				addToken(node.Recv.Closing, node.Recv.Closing+1, OperatorType, nil)
@@ -353,75 +353,75 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 			addToken(node.Assign, node.Assign+1, OperatorType, nil)
 			addToken(node.Lparen, node.Lparen+1, OperatorType, nil)
 			addToken(node.Rparen, node.Rparen+1, OperatorType, nil)
-		case *xgoast.ImportSpec:
+		case *ast.ImportSpec:
 			if node.Path != nil {
 				addToken(node.Path.Pos(), node.Path.End(), StringType, nil)
 			}
-		case *xgoast.ValueSpec:
+		case *ast.ValueSpec:
 			if node.Type != nil {
 				addToken(node.Type.Pos(), node.Type.End(), TypeType, nil)
 			}
-		case *xgoast.FieldList:
+		case *ast.FieldList:
 			if node.Opening.IsValid() {
 				addToken(node.Opening, node.Opening+1, OperatorType, nil)
 			}
 			if node.Closing.IsValid() {
 				addToken(node.Closing, node.Closing+1, OperatorType, nil)
 			}
-		case *xgoast.LabeledStmt:
+		case *ast.LabeledStmt:
 			addToken(node.Label.Pos(), node.Label.End(), LabelType, nil)
 			addToken(node.Colon, node.Colon+1, OperatorType, nil)
-		case *xgoast.SendStmt:
+		case *ast.SendStmt:
 			addToken(node.Arrow, node.Arrow+2, OperatorType, nil)
-		case *xgoast.IncDecStmt:
+		case *ast.IncDecStmt:
 			addToken(node.TokPos, node.TokPos+2, OperatorType, nil)
-		case *xgoast.AssignStmt:
+		case *ast.AssignStmt:
 			opLen := len(node.Tok.String())
-			addToken(node.TokPos, node.TokPos+xgotoken.Pos(opLen), OperatorType, nil)
-		case *xgoast.GoStmt:
-			addToken(node.Go, node.Go+xgotoken.Pos(len("go")), KeywordType, nil)
-		case *xgoast.DeferStmt:
-			addToken(node.Defer, node.Defer+xgotoken.Pos(len("defer")), KeywordType, nil)
-		case *xgoast.ReturnStmt:
-			addToken(node.Return, node.Return+xgotoken.Pos(len("return")), KeywordType, nil)
-		case *xgoast.BranchStmt:
+			addToken(node.TokPos, node.TokPos+token.Pos(opLen), OperatorType, nil)
+		case *ast.GoStmt:
+			addToken(node.Go, node.Go+token.Pos(len("go")), KeywordType, nil)
+		case *ast.DeferStmt:
+			addToken(node.Defer, node.Defer+token.Pos(len("defer")), KeywordType, nil)
+		case *ast.ReturnStmt:
+			addToken(node.Return, node.Return+token.Pos(len("return")), KeywordType, nil)
+		case *ast.BranchStmt:
 			opLen := len(node.Tok.String())
-			addToken(node.TokPos, node.TokPos+xgotoken.Pos(opLen), KeywordType, nil)
-		case *xgoast.BlockStmt:
+			addToken(node.TokPos, node.TokPos+token.Pos(opLen), KeywordType, nil)
+		case *ast.BlockStmt:
 			addToken(node.Lbrace, node.Lbrace+1, OperatorType, nil)
 			addToken(node.Rbrace, node.Rbrace+1, OperatorType, nil)
-		case *xgoast.IfStmt:
-			addToken(node.If, node.If+xgotoken.Pos(len("if")), KeywordType, nil)
-		case *xgoast.CaseClause:
+		case *ast.IfStmt:
+			addToken(node.If, node.If+token.Pos(len("if")), KeywordType, nil)
+		case *ast.CaseClause:
 			if node.List == nil {
-				addToken(node.Case, node.Case+xgotoken.Pos(len("default")), KeywordType, nil)
+				addToken(node.Case, node.Case+token.Pos(len("default")), KeywordType, nil)
 			} else {
-				addToken(node.Case, node.Case+xgotoken.Pos(len("case")), KeywordType, nil)
+				addToken(node.Case, node.Case+token.Pos(len("case")), KeywordType, nil)
 			}
-		case *xgoast.SwitchStmt:
-			addToken(node.Switch, node.Switch+xgotoken.Pos(len("switch")), KeywordType, nil)
-		case *xgoast.TypeSwitchStmt:
-			addToken(node.Switch, node.Switch+xgotoken.Pos(len("switch")), KeywordType, nil)
-		case *xgoast.CommClause:
+		case *ast.SwitchStmt:
+			addToken(node.Switch, node.Switch+token.Pos(len("switch")), KeywordType, nil)
+		case *ast.TypeSwitchStmt:
+			addToken(node.Switch, node.Switch+token.Pos(len("switch")), KeywordType, nil)
+		case *ast.CommClause:
 			if node.Comm == nil {
-				addToken(node.Case, node.Case+xgotoken.Pos(len("default")), KeywordType, nil)
+				addToken(node.Case, node.Case+token.Pos(len("default")), KeywordType, nil)
 			} else {
-				addToken(node.Case, node.Case+xgotoken.Pos(len("case")), KeywordType, nil)
+				addToken(node.Case, node.Case+token.Pos(len("case")), KeywordType, nil)
 			}
 			addToken(node.Colon, node.Colon+1, OperatorType, nil)
-		case *xgoast.SelectStmt:
-			addToken(node.Select, node.Select+xgotoken.Pos(len("select")), KeywordType, nil)
-		case *xgoast.ForStmt:
-			addToken(node.For, node.For+xgotoken.Pos(len("for")), KeywordType, nil)
-		case *xgoast.RangeStmt:
-			addToken(node.For, node.For+xgotoken.Pos(len("for")), KeywordType, nil)
+		case *ast.SelectStmt:
+			addToken(node.Select, node.Select+token.Pos(len("select")), KeywordType, nil)
+		case *ast.ForStmt:
+			addToken(node.For, node.For+token.Pos(len("for")), KeywordType, nil)
+		case *ast.RangeStmt:
+			addToken(node.For, node.For+token.Pos(len("for")), KeywordType, nil)
 			if !node.NoRangeOp {
-				addToken(node.For+xgotoken.Pos(len("for")+1), node.For+xgotoken.Pos(len("for range")), KeywordType, nil)
+				addToken(node.For+token.Pos(len("for")+1), node.For+token.Pos(len("for range")), KeywordType, nil)
 			}
-			if node.Tok != xgotoken.ILLEGAL {
-				addToken(node.TokPos, node.TokPos+xgotoken.Pos(len(node.Tok.String())), OperatorType, nil)
+			if node.Tok != token.ILLEGAL {
+				addToken(node.TokPos, node.TokPos+token.Pos(len(node.Tok.String())), OperatorType, nil)
 			}
-		case *xgoast.LambdaExpr:
+		case *ast.LambdaExpr:
 			addToken(node.Rarrow, node.Rarrow+2, OperatorType, nil)
 			if node.LhsHasParen {
 				addToken(node.First, node.First+1, OperatorType, nil)
@@ -431,37 +431,37 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 				addToken(node.Rarrow+2, node.Rarrow+3, OperatorType, nil)
 				addToken(node.Last-1, node.Last, OperatorType, nil)
 			}
-		case *xgoast.LambdaExpr2:
+		case *ast.LambdaExpr2:
 			addToken(node.Rarrow, node.Rarrow+2, OperatorType, nil)
 			if node.LhsHasParen {
 				addToken(node.First, node.First+1, OperatorType, nil)
 				addToken(node.Rarrow-1, node.Rarrow, OperatorType, nil)
 			}
-		case *xgoast.ForPhrase:
-			addToken(node.For, node.For+xgotoken.Pos(len("for")), KeywordType, nil)
+		case *ast.ForPhrase:
+			addToken(node.For, node.For+token.Pos(len("for")), KeywordType, nil)
 			addToken(node.TokPos, node.TokPos+2, OperatorType, nil)
 			if node.IfPos.IsValid() {
-				addToken(node.IfPos, node.IfPos+xgotoken.Pos(len("if")), KeywordType, nil)
+				addToken(node.IfPos, node.IfPos+token.Pos(len("if")), KeywordType, nil)
 			}
-		case *xgoast.ForPhraseStmt:
-			addToken(node.For, node.For+xgotoken.Pos(len("for")), KeywordType, nil)
+		case *ast.ForPhraseStmt:
+			addToken(node.For, node.For+token.Pos(len("for")), KeywordType, nil)
 			addToken(node.TokPos, node.TokPos+2, OperatorType, nil)
 			if node.IfPos.IsValid() {
-				addToken(node.IfPos, node.IfPos+xgotoken.Pos(len("if")), KeywordType, nil)
+				addToken(node.IfPos, node.IfPos+token.Pos(len("if")), KeywordType, nil)
 			}
 			if node.Body != nil {
 				addToken(node.Body.Lbrace, node.Body.Lbrace+1, OperatorType, nil)
 				addToken(node.Body.Rbrace, node.Body.Rbrace+1, OperatorType, nil)
 			}
-		case *xgoast.ComprehensionExpr:
+		case *ast.ComprehensionExpr:
 			addToken(node.Lpos, node.Lpos+1, OperatorType, nil)
 			addToken(node.Rpos, node.Rpos+1, OperatorType, nil)
-			if kvExpr, ok := node.Elt.(*xgoast.KeyValueExpr); ok {
+			if kvExpr, ok := node.Elt.(*ast.KeyValueExpr); ok {
 				addToken(kvExpr.Colon, kvExpr.Colon+1, OperatorType, nil)
 			}
-		case *xgoast.Ellipsis:
+		case *ast.Ellipsis:
 			addToken(node.Ellipsis, node.Ellipsis+3, OperatorType, nil)
-		case *xgoast.ElemEllipsis:
+		case *ast.ElemEllipsis:
 			addToken(node.Ellipsis, node.Ellipsis+3, OperatorType, nil)
 		}
 		return true

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"maps"
 	"slices"
 	"strings"
@@ -13,8 +13,8 @@ import (
 
 	"github.com/goplus/mod/modload"
 	"github.com/goplus/mod/xgomod"
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/i18n"
 	"github.com/goplus/xgolsw/internal"
 	"github.com/goplus/xgolsw/internal/analysis"
@@ -330,7 +330,7 @@ func (s *Server) handleNotification(n *jsonrpc2.Notification) error {
 
 // notifyPropertyRenamed sends a notification to the client when a property is renamed.
 // This allows clients to update any monitoring or tracking of the property.
-func (s *Server) notifyPropertyRenamed(obj types.Object, params *RenameParams) error {
+func (s *Server) notifyPropertyRenamed(obj gotypes.Object, params *RenameParams) error {
 	named := findEnclosingType(obj)
 	if named == nil {
 		return fmt.Errorf("failed to find enclosing type for object: %s", obj.Name())
@@ -511,17 +511,17 @@ func (s *Server) toDocumentURI(path string) DocumentURI {
 }
 
 // posDocumentURI returns the [DocumentURI] for the given position in the project.
-func (s *Server) posDocumentURI(proj *xgo.Project, pos xgotoken.Pos) DocumentURI {
+func (s *Server) posDocumentURI(proj *xgo.Project, pos token.Pos) DocumentURI {
 	return s.toDocumentURI(xgoutil.PosFilename(proj.Fset, pos))
 }
 
 // nodeDocumentURI returns the [DocumentURI] for the given node in the project.
-func (s *Server) nodeDocumentURI(proj *xgo.Project, node xgoast.Node) DocumentURI {
+func (s *Server) nodeDocumentURI(proj *xgo.Project, node ast.Node) DocumentURI {
 	return s.posDocumentURI(proj, node.Pos())
 }
 
 // locationForPos returns the [Location] for the given position in the project.
-func (s *Server) locationForPos(proj *xgo.Project, pos xgotoken.Pos) Location {
+func (s *Server) locationForPos(proj *xgo.Project, pos token.Pos) Location {
 	return Location{
 		URI:   s.posDocumentURI(proj, pos),
 		Range: RangeForPos(proj, pos),
@@ -529,7 +529,7 @@ func (s *Server) locationForPos(proj *xgo.Project, pos xgotoken.Pos) Location {
 }
 
 // locationForNode returns the [Location] for the given node in the project.
-func (s *Server) locationForNode(proj *xgo.Project, node xgoast.Node) Location {
+func (s *Server) locationForNode(proj *xgo.Project, node ast.Node) Location {
 	return Location{
 		URI:   s.nodeDocumentURI(proj, node),
 		Range: RangeForNode(proj, node),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -28,17 +28,17 @@ func newMockReplier() *mockReplier {
 
 func (m *mockReplier) ReplyMessage(msg jsonrpc2.Message) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.messages = append(m.messages, msg)
 	m.cond.Broadcast()
+	m.mu.Unlock()
 	return nil
 }
 
 func (m *mockReplier) getMessages() []jsonrpc2.Message {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	result := make([]jsonrpc2.Message, len(m.messages))
 	copy(result, m.messages)
+	m.mu.Unlock()
 	return result
 }
 
@@ -47,23 +47,21 @@ func (m *mockReplier) waitForMessages(count int, timeout time.Duration) []jsonrp
 	if count == 0 {
 		time.Sleep(10 * time.Millisecond)
 		m.mu.Lock()
-		defer m.mu.Unlock()
 		result := make([]jsonrpc2.Message, len(m.messages))
 		copy(result, m.messages)
+		m.mu.Unlock()
 		return result
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	timedOut := false
 	timer := time.AfterFunc(timeout, func() {
 		m.mu.Lock()
-		defer m.mu.Unlock()
 		timedOut = true
 		m.cond.Broadcast()
+		m.mu.Unlock()
 	})
-	defer timer.Stop()
 
 	for len(m.messages) < count && !timedOut {
 		m.cond.Wait()
@@ -71,6 +69,8 @@ func (m *mockReplier) waitForMessages(count int, timeout time.Duration) []jsonrp
 
 	result := make([]jsonrpc2.Message, len(m.messages))
 	copy(result, m.messages)
+	m.mu.Unlock()
+	timer.Stop()
 	return result
 }
 
@@ -80,6 +80,14 @@ func newProjectWithoutModTime(files map[string][]byte) *xgo.Project {
 		fileMap[k] = &xgo.File{Content: v}
 	}
 	return xgo.NewProject(nil, fileMap, xgo.FeatAll)
+}
+
+func requireValueAs[T any](t *testing.T, value any) T {
+	t.Helper()
+
+	typed, ok := value.(T)
+	require.True(t, ok)
+	return typed
 }
 
 func fileMapGetter(files map[string][]byte) func() map[string]*xgo.File {
@@ -188,7 +196,7 @@ echo x
 	})
 }
 
-func TestHandleMessage_Call(t *testing.T) {
+func TestHandleMessageCall(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method string
@@ -197,7 +205,7 @@ func TestHandleMessage_Call(t *testing.T) {
 		msgNum int
 	}{
 		{
-			name:   "Method Not Found",
+			name:   "MethodNotFound",
 			method: "unknown/method",
 			msgNum: 1,
 		},
@@ -208,7 +216,7 @@ func TestHandleMessage_Call(t *testing.T) {
 			msgNum: 2, // 1 response + 1 notification
 		},
 		{
-			name:   "TextDocument/Hover",
+			name:   "TextDocumentHover",
 			method: "textDocument/hover",
 			params: &HoverParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -229,7 +237,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/Completion",
+			name:   "TextDocumentCompletion",
 			method: "textDocument/completion",
 			params: CompletionParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -243,7 +251,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/SignatureHelp",
+			name:   "TextDocumentSignatureHelp",
 			method: "textDocument/signatureHelp",
 			params: SignatureHelpParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -257,7 +265,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/Declaration",
+			name:   "TextDocumentDeclaration",
 			method: "textDocument/declaration",
 			params: DeclarationParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -271,7 +279,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/Definition",
+			name:   "TextDocumentDefinition",
 			method: "textDocument/definition",
 			params: DefinitionParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -285,7 +293,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/TypeDefinition",
+			name:   "TextDocumentTypeDefinition",
 			method: "textDocument/typeDefinition",
 			params: TypeDefinitionParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -299,7 +307,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/Implementation",
+			name:   "TextDocumentImplementation",
 			method: "textDocument/implementation",
 			params: ImplementationParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -313,7 +321,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/References",
+			name:   "TextDocumentReferences",
 			method: "textDocument/references",
 			params: ReferenceParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -330,7 +338,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/DocumentHighlight",
+			name:   "TextDocumentDocumentHighlight",
 			method: "textDocument/documentHighlight",
 			params: DocumentHighlightParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -344,7 +352,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/DocumentLink",
+			name:   "TextDocumentDocumentLink",
 			method: "textDocument/documentLink",
 			params: DocumentLinkParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
@@ -355,7 +363,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/Diagnostic",
+			name:   "TextDocumentDiagnostic",
 			method: "textDocument/diagnostic",
 			params: DocumentDiagnosticParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
@@ -366,7 +374,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "Workspace/Diagnostic",
+			name:   "WorkspaceDiagnostic",
 			method: "workspace/diagnostic",
 			params: WorkspaceDiagnosticParams{},
 			files: map[string][]byte{
@@ -375,7 +383,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/Formatting",
+			name:   "TextDocumentFormatting",
 			method: "textDocument/formatting",
 			params: DocumentFormattingParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
@@ -386,7 +394,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/PrepareRename",
+			name:   "TextDocumentPrepareRename",
 			method: "textDocument/prepareRename",
 			params: PrepareRenameParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
@@ -400,7 +408,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/Rename",
+			name:   "TextDocumentRename",
 			method: "textDocument/rename",
 			params: RenameParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
@@ -413,7 +421,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/SemanticTokens/Full",
+			name:   "TextDocumentSemanticTokensFull",
 			method: "textDocument/semanticTokens/full",
 			params: SemanticTokensParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
@@ -424,7 +432,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "TextDocument/InlayHint",
+			name:   "TextDocumentInlayHint",
 			method: "textDocument/inlayHint",
 			params: InlayHintParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
@@ -439,7 +447,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "Workspace/ExecuteCommand",
+			name:   "WorkspaceExecuteCommand",
 			method: "workspace/executeCommand",
 			params: ExecuteCommandParams{
 				Command: CommandXGoRenameResources,
@@ -460,7 +468,7 @@ fmt.Println("Hello, World!")
 			msgNum: 2,
 		},
 		{
-			name:   "Workspace/ExecuteCommandLegacy",
+			name:   "WorkspaceExecuteCommandLegacy",
 			method: "workspace/executeCommand",
 			params: ExecuteCommandParams{
 				Command: CommandSpxRenameResources,
@@ -503,13 +511,13 @@ fmt.Println("Hello, World!")
 
 			msgs := replier.waitForMessages(tc.msgNum, 5*time.Second)
 			assert.Len(t, msgs, tc.msgNum,
-				"Method '%s': Expected %d messages, got %d",
-				tc.method, tc.msgNum, len(msgs))
+				"method %q got %d messages, want %d",
+				tc.method, len(msgs), tc.msgNum)
 		})
 	}
 }
 
-func TestHandleMessage_Notification(t *testing.T) {
+func TestHandleMessageNotification(t *testing.T) {
 	testCases := []struct {
 		name   string
 		method string
@@ -518,19 +526,19 @@ func TestHandleMessage_Notification(t *testing.T) {
 		msgNum int
 	}{
 		{
-			name:   "initialized",
+			name:   "Initialized",
 			method: "initialized",
 			params: InitializedParams{},
 			msgNum: 1, // only telemetry event
 		},
 		{
-			name:   "exit",
+			name:   "Exit",
 			method: "exit",
 			params: nil,
 			msgNum: 0, // exit 不发送任何消息
 		},
 		{
-			name:   "$/cancelRequest",
+			name:   "CancelRequest",
 			method: "$/cancelRequest",
 			params: CancelParams{
 				ID: jsonrpc2.NewStringID("test-request"),
@@ -538,7 +546,7 @@ func TestHandleMessage_Notification(t *testing.T) {
 			msgNum: 1, // only telemetry event
 		},
 		{
-			name:   "textDocument/didOpen",
+			name:   "TextDocumentDidOpen",
 			method: "textDocument/didOpen",
 			params: DidOpenTextDocumentParams{
 				TextDocument: protocol.TextDocumentItem{
@@ -554,7 +562,7 @@ func TestHandleMessage_Notification(t *testing.T) {
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
 		{
-			name:   "textDocument/didChange",
+			name:   "TextDocumentDidChange",
 			method: "textDocument/didChange",
 			params: DidChangeTextDocumentParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
@@ -575,7 +583,7 @@ func TestHandleMessage_Notification(t *testing.T) {
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
 		{
-			name:   "textDocument/didSave",
+			name:   "TextDocumentDidSave",
 			method: "textDocument/didSave",
 			params: DidSaveTextDocumentParams{
 				TextDocument: TextDocumentIdentifier{
@@ -592,7 +600,7 @@ func TestHandleMessage_Notification(t *testing.T) {
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
 		{
-			name:   "textDocument/didClose",
+			name:   "TextDocumentDidClose",
 			method: "textDocument/didClose",
 			params: DidCloseTextDocumentParams{
 				TextDocument: TextDocumentIdentifier{
@@ -605,7 +613,7 @@ func TestHandleMessage_Notification(t *testing.T) {
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
 		{
-			name:   "Unknown Notification Method",
+			name:   "UnknownNotificationMethod",
 			method: "unknown/method",
 			params: nil,
 			msgNum: 0,
@@ -632,8 +640,8 @@ func TestHandleMessage_Notification(t *testing.T) {
 
 			msgs := replier.waitForMessages(tc.msgNum, 5*time.Second)
 			assert.Len(t, msgs, tc.msgNum,
-				"Method '%s': Expected %d messages, got %d",
-				tc.method, tc.msgNum, len(msgs))
+				"method %q got %d messages, want %d",
+				tc.method, len(msgs), tc.msgNum)
 		})
 	}
 }
@@ -671,7 +679,7 @@ var (
 
 		// Wait for messages and filter for property renamed notification
 		msgs := replier.waitForMessages(1, 1*time.Second)
-		require.Len(t, msgs, 1, "Expected 1 notification message")
+		require.Len(t, msgs, 1, "want 1 notification message")
 
 		notif, ok := msgs[0].(*jsonrpc2.Notification)
 		require.True(t, ok, "Message should be a notification")

--- a/internal/server/signature.go
+++ b/internal/server/signature.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"strings"
 
 	"github.com/goplus/xgolsw/xgo/xgoutil"
@@ -28,11 +28,11 @@ func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*Signat
 		return nil, nil
 	}
 
-	fun, ok := obj.(*types.Func)
+	fun, ok := obj.(*gotypes.Func)
 	if !ok {
 		return nil, nil
 	}
-	sig, ok := fun.Type().(*types.Signature)
+	sig, ok := fun.Type().(*gotypes.Signature)
 	if !ok {
 		return nil, nil
 	}

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"fmt"
-	"go/types"
+	gotypes "go/types"
 	"html/template"
 	"slices"
 	"strings"
@@ -18,7 +18,7 @@ import (
 type SpxDefinition struct {
 	// TypeHint represents a type hint for this definition. It may be nil if
 	// the definition has no associated type.
-	TypeHint types.Type
+	TypeHint gotypes.Type
 
 	ID       SpxDefinitionIdentifier
 	Overview string
@@ -237,7 +237,7 @@ var (
 )
 
 // GetSpxDefinitionForBuiltinObj returns the spx definition for the given object.
-func GetSpxDefinitionForBuiltinObj(obj types.Object) SpxDefinition {
+func GetSpxDefinitionForBuiltinObj(obj gotypes.Object) SpxDefinition {
 	const pkgPath = "builtin"
 
 	idName := obj.Name()
@@ -307,13 +307,13 @@ func GetSpxDefinitionForBuiltinObj(obj types.Object) SpxDefinition {
 
 // GetBuiltinSpxDefinitions returns the builtin spx definitions.
 var GetBuiltinSpxDefinitions = sync.OnceValue(func() []SpxDefinition {
-	names := types.Universe.Names()
+	names := gotypes.Universe.Names()
 	defs := make([]SpxDefinition, 0, len(names)+len(xgoBuiltinAliases))
 	for _, name := range names {
 		if _, ok := xgoBuiltinAliases[name]; ok {
 			continue
 		}
-		if obj := types.Universe.Lookup(name); obj != nil && obj.Pkg() == nil {
+		if obj := gotypes.Universe.Lookup(name); obj != nil && obj.Pkg() == nil {
 			defs = append(defs, GetSpxDefinitionForBuiltinObj(obj))
 		}
 	}
@@ -354,9 +354,9 @@ func getSpxDefinitionForXGoBuiltinAlias(alias string) (SpxDefinition, error) {
 	}
 	var def SpxDefinition
 	switch obj := obj.(type) {
-	case *types.TypeName:
+	case *gotypes.TypeName:
 		def = GetSpxDefinitionForType(obj, pkgDoc)
-	case *types.Func:
+	case *gotypes.Func:
 		def = GetSpxDefinitionForFunc(obj, "", pkgDoc)
 	default:
 		return SpxDefinition{}, fmt.Errorf("unexpected object type for xgo builtin alias %q: %T", alias, obj)
@@ -380,7 +380,7 @@ func getSpxDefinitionForXGoBuiltinAlias(alias string) (SpxDefinition, error) {
 
 var (
 	// GetMathPkg returns the math package.
-	GetMathPkg = sync.OnceValue(func() *types.Package {
+	GetMathPkg = sync.OnceValue(func() *gotypes.Package {
 		mathPkg, err := internal.Importer.Import("math")
 		if err != nil {
 			panic(fmt.Errorf("failed to import math package: %w", err))
@@ -405,7 +405,7 @@ const SpxPkgPath = "github.com/goplus/spx/v2"
 
 var (
 	// GetSpxPkg returns the spx package.
-	GetSpxPkg = sync.OnceValue(func() *types.Package {
+	GetSpxPkg = sync.OnceValue(func() *gotypes.Package {
 		spxPkg, err := internal.Importer.Import(SpxPkgPath)
 		if err != nil {
 			panic(fmt.Errorf("failed to import spx package: %w", err))
@@ -414,105 +414,105 @@ var (
 	})
 
 	// GetSpxGameType returns the [spx.Game] type.
-	GetSpxGameType = sync.OnceValue(func() *types.Named {
+	GetSpxGameType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("Game").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("Game").Type().(*gotypes.Named)
 	})
 
 	// GetSpxBackdropNameType returns the [spx.BackdropName] type.
-	GetSpxBackdropNameType = sync.OnceValue(func() *types.Alias {
+	GetSpxBackdropNameType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("BackdropName").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("BackdropName").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxSpriteType returns the [spx.Sprite] type.
-	GetSpxSpriteType = sync.OnceValue(func() *types.Named {
+	GetSpxSpriteType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("Sprite").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("Sprite").Type().(*gotypes.Named)
 	})
 
 	// GetSpxSpriteImplType returns the [spx.SpriteImpl] type.
-	GetSpxSpriteImplType = sync.OnceValue(func() *types.Named {
+	GetSpxSpriteImplType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("SpriteImpl").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("SpriteImpl").Type().(*gotypes.Named)
 	})
 
 	// GetSpxSpriteNameType returns the [spx.SpriteName] type.
-	GetSpxSpriteNameType = sync.OnceValue(func() *types.Alias {
+	GetSpxSpriteNameType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("SpriteName").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("SpriteName").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxSpriteCostumeNameType returns the [spx.SpriteCostumeName] type.
-	GetSpxSpriteCostumeNameType = sync.OnceValue(func() *types.Alias {
+	GetSpxSpriteCostumeNameType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("SpriteCostumeName").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("SpriteCostumeName").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxSpriteAnimationNameType returns the [spx.SpriteAnimationName] type.
-	GetSpxSpriteAnimationNameType = sync.OnceValue(func() *types.Alias {
+	GetSpxSpriteAnimationNameType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("SpriteAnimationName").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("SpriteAnimationName").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxSoundNameType returns the [spx.SoundName] type.
-	GetSpxSoundNameType = sync.OnceValue(func() *types.Alias {
+	GetSpxSoundNameType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("SoundName").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("SoundName").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxWidgetNameType returns the [spx.WidgetName] type.
-	GetSpxWidgetNameType = sync.OnceValue(func() *types.Alias {
+	GetSpxWidgetNameType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("WidgetName").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("WidgetName").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxDirectionType returns the [spx.Direction] type.
-	GetSpxDirectionType = sync.OnceValue(func() *types.Alias {
+	GetSpxDirectionType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("Direction").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("Direction").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxLayerActionType returns the [spx.LayerAction] type.
-	GetSpxLayerActionType = sync.OnceValue(func() *types.Named {
+	GetSpxLayerActionType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("layerAction").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("layerAction").Type().(*gotypes.Named)
 	})
 
 	// GetSpxDirActionType returns the [spx.DirLayer] type.
-	GetSpxDirActionType = sync.OnceValue(func() *types.Named {
+	GetSpxDirActionType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("dirAction").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("dirAction").Type().(*gotypes.Named)
 	})
 
 	// GetSpxEffectKindType returns the [spx.EffectKind] type.
-	GetSpxEffectKindType = sync.OnceValue(func() *types.Named {
+	GetSpxEffectKindType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("EffectKind").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("EffectKind").Type().(*gotypes.Named)
 	})
 
 	// GetSpxKeyType returns the [spx.Key] type.
-	GetSpxKeyType = sync.OnceValue(func() *types.Alias {
+	GetSpxKeyType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("Key").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("Key").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxSpecialObjType returns the [spx.SpecialObj] type.
-	GetSpxSpecialObjType = sync.OnceValue(func() *types.Named {
+	GetSpxSpecialObjType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("Edge").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("Edge").Type().(*gotypes.Named)
 	})
 
 	// GetSpxRotationStyleType returns the [spx.RotationStyle] type.
-	GetSpxRotationStyleType = sync.OnceValue(func() *types.Named {
+	GetSpxRotationStyleType = sync.OnceValue(func() *gotypes.Named {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("RotationStyle").Type().(*types.Named)
+		return spxPkg.Scope().Lookup("RotationStyle").Type().(*gotypes.Named)
 	})
 
 	// GetSpxPropertyNameType returns the [spx.PropertyName] type.
-	GetSpxPropertyNameType = sync.OnceValue(func() *types.Alias {
+	GetSpxPropertyNameType = sync.OnceValue(func() *gotypes.Alias {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("PropertyName").Type().(*types.Alias)
+		return spxPkg.Scope().Lookup("PropertyName").Type().(*gotypes.Alias)
 	})
 
 	// GetSpxPkgDefinitions returns the spx definitions for the spx package.
@@ -527,24 +527,23 @@ var (
 	})
 
 	// GetSpxHSBFunc returns the [spx.HSB] type.
-	GetSpxHSBFunc = sync.OnceValue(func() *types.Func {
+	GetSpxHSBFunc = sync.OnceValue(func() *gotypes.Func {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("HSB").(*types.Func)
+		return spxPkg.Scope().Lookup("HSB").(*gotypes.Func)
 	})
 
 	// GetSpxHSBAFunc returns the [spx.HSBA] type.
-	GetSpxHSBAFunc = sync.OnceValue(func() *types.Func {
+	GetSpxHSBAFunc = sync.OnceValue(func() *gotypes.Func {
 		spxPkg := GetSpxPkg()
-		return spxPkg.Scope().Lookup("HSBA").(*types.Func)
+		return spxPkg.Scope().Lookup("HSBA").(*gotypes.Func)
 	})
-
 )
 
 // nonMainPkgSpxDefsCache is a cache of non-main package spx definitions.
 var nonMainPkgSpxDefsCache sync.Map // map[*types.Package][]SpxDefinition
 
 // GetSpxDefinitionsForPkg returns the spx definitions for the given package.
-func GetSpxDefinitionsForPkg(pkg *types.Package, pkgDoc *pkgdoc.PkgDoc) (defs []SpxDefinition) {
+func GetSpxDefinitionsForPkg(pkg *gotypes.Package, pkgDoc *pkgdoc.PkgDoc) (defs []SpxDefinition) {
 	if !xgoutil.IsMainPkg(pkg) {
 		if defsIface, ok := nonMainPkgSpxDefsCache.Load(pkg); ok {
 			return defsIface.([]SpxDefinition)
@@ -559,13 +558,13 @@ func GetSpxDefinitionsForPkg(pkg *types.Package, pkgDoc *pkgdoc.PkgDoc) (defs []
 	for _, name := range names {
 		if obj := pkg.Scope().Lookup(name); obj != nil && obj.Exported() {
 			switch obj := obj.(type) {
-			case *types.Var:
+			case *gotypes.Var:
 				defs = append(defs, GetSpxDefinitionForVar(obj, "", false, pkgDoc))
-			case *types.Const:
+			case *gotypes.Const:
 				defs = append(defs, GetSpxDefinitionForConst(obj, pkgDoc))
-			case *types.TypeName:
+			case *gotypes.TypeName:
 				defs = append(defs, GetSpxDefinitionForType(obj, pkgDoc))
-			case *types.Func:
+			case *gotypes.Func:
 				if funcOverloads := xgoutil.ExpandXGoOverloadableFunc(obj); funcOverloads != nil {
 					for _, funcOverload := range funcOverloads {
 						defs = append(defs, GetSpxDefinitionForFunc(funcOverload, "", pkgDoc))
@@ -573,7 +572,7 @@ func GetSpxDefinitionsForPkg(pkg *types.Package, pkgDoc *pkgdoc.PkgDoc) (defs []
 				} else {
 					defs = append(defs, GetSpxDefinitionForFunc(obj, "", pkgDoc))
 				}
-			case *types.PkgName:
+			case *gotypes.PkgName:
 				defs = append(defs, GetSpxDefinitionForPkg(obj, pkgDoc))
 			}
 		}
@@ -588,14 +587,14 @@ var nonMainPkgSpxDefCacheForVars sync.Map // map[nonMainPkgSpxDefCacheForVarsKey
 // nonMainPkgSpxDefCacheForVarsKey is the key for the non-main package spx
 // definition cache for variables.
 type nonMainPkgSpxDefCacheForVarsKey struct {
-	v                *types.Var
+	v                *gotypes.Var
 	selectorTypeName string
 }
 
 // spxMemberDefinitionPkgPath returns the package path used in definition IDs for
 // spx members. It prefers the public spx package when the member comes from an
 // internal implementation package but is surfaced through a public spx type.
-func spxMemberDefinitionPkgPath(pkg *types.Package, selectorTypeName string) string {
+func spxMemberDefinitionPkgPath(pkg *gotypes.Package, selectorTypeName string) string {
 	pkgPath := xgoutil.PkgPath(pkg)
 	if selectorTypeName == "" || !strings.HasPrefix(pkgPath, "github.com/goplus/spx/v2/internal/") {
 		return pkgPath
@@ -607,7 +606,7 @@ func spxMemberDefinitionPkgPath(pkg *types.Package, selectorTypeName string) str
 }
 
 // GetSpxDefinitionForVar returns the spx definition for the provided variable.
-func GetSpxDefinitionForVar(v *types.Var, selectorTypeName string, forceVar bool, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
+func GetSpxDefinitionForVar(v *gotypes.Var, selectorTypeName string, forceVar bool, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(v) {
 		cacheKey := nonMainPkgSpxDefCacheForVarsKey{
 			v:                v,
@@ -679,7 +678,7 @@ func GetSpxDefinitionForVar(v *types.Var, selectorTypeName string, forceVar bool
 var nonMainPkgSpxDefCacheForConsts sync.Map // map[*types.Const]SpxDefinition
 
 // GetSpxDefinitionForConst returns the spx definition for the provided constant.
-func GetSpxDefinitionForConst(c *types.Const, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
+func GetSpxDefinitionForConst(c *gotypes.Const, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(c) {
 		if defIface, ok := nonMainPkgSpxDefCacheForConsts.Load(c); ok {
 			return defIface.(SpxDefinition)
@@ -723,7 +722,7 @@ func GetSpxDefinitionForConst(c *types.Const, pkgDoc *pkgdoc.PkgDoc) (def SpxDef
 var nonMainPkgSpxDefCacheForTypes sync.Map // map[*types.TypeName]SpxDefinition
 
 // GetSpxDefinitionForType returns the spx definition for the provided type.
-func GetSpxDefinitionForType(typeName *types.TypeName, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
+func GetSpxDefinitionForType(typeName *gotypes.TypeName, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(typeName) {
 		if defIface, ok := nonMainPkgSpxDefCacheForTypes.Load(typeName); ok {
 			return defIface.(SpxDefinition)
@@ -748,9 +747,9 @@ func GetSpxDefinitionForType(typeName *types.TypeName, pkgDoc *pkgdoc.PkgDoc) (d
 	completionKind := ClassCompletion
 	if named := resolvedNamedType(typeName.Type()); named != nil {
 		switch named.Underlying().(type) {
-		case *types.Interface:
+		case *gotypes.Interface:
 			completionKind = InterfaceCompletion
-		case *types.Struct:
+		case *gotypes.Struct:
 			completionKind = StructCompletion
 		}
 	}
@@ -780,12 +779,12 @@ var nonMainPkgSpxDefCacheForFuncs sync.Map // map[nonMainPkgSpxDefCacheForFuncsK
 // nonMainPkgSpxDefCacheForFuncsKey is the key for the non-main package spx
 // definition cache for functions.
 type nonMainPkgSpxDefCacheForFuncsKey struct {
-	fun          *types.Func
+	fun          *gotypes.Func
 	recvTypeName string
 }
 
 // GetSpxDefinitionForFunc returns the spx definition for the provided function.
-func GetSpxDefinitionForFunc(fun *types.Func, recvTypeName string, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
+func GetSpxDefinitionForFunc(fun *gotypes.Func, recvTypeName string, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(fun) {
 		cacheKey := nonMainPkgSpxDefCacheForFuncsKey{
 			fun:          fun,
@@ -847,10 +846,10 @@ func GetSpxDefinitionForFunc(fun *types.Func, recvTypeName string, pkgDoc *pkgdo
 
 // makeSpxDefinitionOverviewForFunc makes an overview string for a function that
 // is used in [SpxDefinition].
-func makeSpxDefinitionOverviewForFunc(fun *types.Func) (overview, parsedRecvTypeName, parsedName string, overloadID *string) {
+func makeSpxDefinitionOverviewForFunc(fun *gotypes.Func) (overview, parsedRecvTypeName, parsedName string, overloadID *string) {
 	isXGoPkg := xgoutil.IsMarkedAsXGoPackage(fun.Pkg())
 	name := fun.Name()
-	sig := fun.Type().(*types.Signature)
+	sig := fun.Type().(*gotypes.Signature)
 
 	var sb strings.Builder
 	sb.WriteString("func ")
@@ -858,7 +857,7 @@ func makeSpxDefinitionOverviewForFunc(fun *types.Func) (overview, parsedRecvType
 	var isXGotMethod bool
 	if recv := sig.Recv(); recv != nil {
 		recvType := xgoutil.DerefType(recv.Type())
-		if named, ok := recvType.(*types.Named); ok {
+		if named, ok := recvType.(*gotypes.Named); ok {
 			parsedRecvTypeName = named.Obj().Name()
 		}
 	} else if isXGoPkg {
@@ -896,7 +895,7 @@ func makeSpxDefinitionOverviewForFunc(fun *types.Func) (overview, parsedRecvType
 
 		// Check if this is a variadic parameter.
 		if sig.Variadic() && i == sig.Params().Len()-1 {
-			if slice, ok := paramType.(*types.Slice); ok {
+			if slice, ok := paramType.(*gotypes.Slice); ok {
 				elemTypeName := GetSimplifiedTypeString(slice.Elem())
 				paramTypeName = "..." + elemTypeName
 			}
@@ -937,7 +936,7 @@ func makeSpxDefinitionOverviewForFunc(fun *types.Func) (overview, parsedRecvType
 var nonMainPkgSpxDefCacheForPkgs sync.Map // map[*types.PkgName]SpxDefinition
 
 // GetSpxDefinitionForPkg returns the spx definition for the provided package.
-func GetSpxDefinitionForPkg(pkgName *types.PkgName, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
+func GetSpxDefinitionForPkg(pkgName *gotypes.PkgName, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(pkgName) {
 		if defIface, ok := nonMainPkgSpxDefCacheForPkgs.Load(pkgName); ok {
 			return defIface.(SpxDefinition)
@@ -975,7 +974,7 @@ var nonMainPkgSpxResourceNameTypeFuncCache sync.Map // map[*types.Func]bool
 
 // HasSpxResourceNameTypeParams reports if a function has parameters of spx
 // resource name types.
-func HasSpxResourceNameTypeParams(fun *types.Func) (has bool) {
+func HasSpxResourceNameTypeParams(fun *gotypes.Func) (has bool) {
 	if fun == nil {
 		return false
 	}
@@ -994,14 +993,14 @@ func HasSpxResourceNameTypeParams(fun *types.Func) (has bool) {
 		}()
 	}
 
-	funcSig, ok := fun.Type().(*types.Signature)
+	funcSig, ok := fun.Type().(*gotypes.Signature)
 	if !ok {
 		return false
 	}
 
 	for param := range funcSig.Params().Variables() {
 		paramType := xgoutil.DerefType(param.Type())
-		if slice, ok := paramType.(*types.Slice); ok {
+		if slice, ok := paramType.(*gotypes.Slice); ok {
 			paramType = slice.Elem()
 		}
 		if IsSpxResourceNameType(paramType) {
@@ -1013,8 +1012,8 @@ func HasSpxResourceNameTypeParams(fun *types.Func) (has bool) {
 
 // canonicalSpxResourceNameType resolves aliases until it finds a canonical spx
 // resource name type. It returns nil if typ does not represent one.
-func canonicalSpxResourceNameType(typ types.Type) types.Type {
-	seen := make(map[types.Type]struct{})
+func canonicalSpxResourceNameType(typ gotypes.Type) gotypes.Type {
+	seen := make(map[gotypes.Type]struct{})
 	for typ != nil {
 		if _, ok := seen[typ]; ok {
 			return nil
@@ -1036,7 +1035,7 @@ func canonicalSpxResourceNameType(typ types.Type) types.Type {
 			return GetSpxWidgetNameType()
 		}
 
-		alias, ok := typ.(*types.Alias)
+		alias, ok := typ.(*gotypes.Alias)
 		if !ok {
 			return nil
 		}
@@ -1051,14 +1050,14 @@ func canonicalSpxResourceNameType(typ types.Type) types.Type {
 }
 
 // IsSpxResourceNameType reports whether the given type is a spx resource name type.
-func IsSpxResourceNameType(typ types.Type) bool {
+func IsSpxResourceNameType(typ gotypes.Type) bool {
 	return canonicalSpxResourceNameType(typ) != nil
 }
 
 // IsSpxPropertyNameType reports whether the given type is or is an alias of
 // [spx.PropertyName], resolving alias chains before comparing.
-func IsSpxPropertyNameType(typ types.Type) bool {
-	seen := make(map[types.Type]struct{})
+func IsSpxPropertyNameType(typ gotypes.Type) bool {
+	seen := make(map[gotypes.Type]struct{})
 	for typ != nil {
 		if _, ok := seen[typ]; ok {
 			return false
@@ -1069,7 +1068,7 @@ func IsSpxPropertyNameType(typ types.Type) bool {
 			return true
 		}
 
-		alias, ok := typ.(*types.Alias)
+		alias, ok := typ.(*gotypes.Alias)
 		if !ok {
 			return false
 		}

--- a/internal/server/spx_definition_test.go
+++ b/internal/server/spx_definition_test.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 	"sync"
 	"testing"
 
+	"github.com/goplus/xgo/token"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHasSpxResourceNameTypeParams(t *testing.T) {
@@ -14,164 +15,164 @@ func TestHasSpxResourceNameTypeParams(t *testing.T) {
 
 	for _, tt := range []struct {
 		name string
-		fun  func() *types.Func
+		fun  func() *gotypes.Func
 		want bool
 	}{
 		{
 			name: "NilFunction",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				return nil
 			},
 			want: false,
 		},
 		{
 			name: "FunctionWithNoParameters",
-			fun: func() *types.Func {
-				pkg := types.NewPackage("test", "test")
-				sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "noParams", sig)
+			fun: func() *gotypes.Func {
+				pkg := gotypes.NewPackage("test", "test")
+				sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "noParams", sig)
 			},
 			want: false,
 		},
 		{
 			name: "FunctionWithBasicTypeParameters",
-			fun: func() *types.Func {
-				pkg := types.NewPackage("test", "test")
-				param1 := types.NewParam(token.NoPos, pkg, "p1", types.Typ[types.Int])
-				param2 := types.NewParam(token.NoPos, pkg, "p2", types.Typ[types.String])
-				params := types.NewTuple(param1, param2)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "basicParams", sig)
+			fun: func() *gotypes.Func {
+				pkg := gotypes.NewPackage("test", "test")
+				param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+				param2 := gotypes.NewParam(token.NoPos, pkg, "p2", gotypes.Typ[gotypes.String])
+				params := gotypes.NewTuple(param1, param2)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "basicParams", sig)
 			},
 			want: false,
 		},
 		{
 			name: "FunctionWithBackdropNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				param := types.NewParam(token.NoPos, pkg, "backdrop", GetSpxBackdropNameType())
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withBackdrop", sig)
+				param := gotypes.NewParam(token.NoPos, pkg, "backdrop", GetSpxBackdropNameType())
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withBackdrop", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithSpriteNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				param := types.NewParam(token.NoPos, pkg, "sprite", GetSpxSpriteNameType())
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withSprite", sig)
+				param := gotypes.NewParam(token.NoPos, pkg, "sprite", GetSpxSpriteNameType())
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withSprite", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithSpriteCostumeNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				param := types.NewParam(token.NoPos, pkg, "costume", GetSpxSpriteCostumeNameType())
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withCostume", sig)
+				param := gotypes.NewParam(token.NoPos, pkg, "costume", GetSpxSpriteCostumeNameType())
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withCostume", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithSpriteAnimationNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				param := types.NewParam(token.NoPos, pkg, "animation", GetSpxSpriteAnimationNameType())
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withAnimation", sig)
+				param := gotypes.NewParam(token.NoPos, pkg, "animation", GetSpxSpriteAnimationNameType())
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withAnimation", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithSoundNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				param := types.NewParam(token.NoPos, pkg, "sound", GetSpxSoundNameType())
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withSound", sig)
+				param := gotypes.NewParam(token.NoPos, pkg, "sound", GetSpxSoundNameType())
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withSound", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithWidgetNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				param := types.NewParam(token.NoPos, pkg, "widget", GetSpxWidgetNameType())
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withWidget", sig)
+				param := gotypes.NewParam(token.NoPos, pkg, "widget", GetSpxWidgetNameType())
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withWidget", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithAliasToSoundNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				aliasType := types.NewAlias(
-					types.NewTypeName(token.NoPos, pkg, "MySoundName", nil),
+				aliasType := gotypes.NewAlias(
+					gotypes.NewTypeName(token.NoPos, pkg, "MySoundName", nil),
 					GetSpxSoundNameType(),
 				)
-				param := types.NewParam(token.NoPos, pkg, "sound", aliasType)
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withAliasSound", sig)
+				param := gotypes.NewParam(token.NoPos, pkg, "sound", aliasType)
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withAliasSound", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithPointerToBackdropNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				ptrType := types.NewPointer(GetSpxBackdropNameType())
-				param := types.NewParam(token.NoPos, pkg, "backdrop", ptrType)
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withBackdropPtr", sig)
+				ptrType := gotypes.NewPointer(GetSpxBackdropNameType())
+				param := gotypes.NewParam(token.NoPos, pkg, "backdrop", ptrType)
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withBackdropPtr", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithSliceOfSpriteNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				sliceType := types.NewSlice(GetSpxSpriteNameType())
-				param := types.NewParam(token.NoPos, pkg, "sprites", sliceType)
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withSpriteSlice", sig)
+				sliceType := gotypes.NewSlice(GetSpxSpriteNameType())
+				param := gotypes.NewParam(token.NoPos, pkg, "sprites", sliceType)
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withSpriteSlice", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithVariadicSoundNameParameter",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				sliceType := types.NewSlice(GetSpxSoundNameType())
-				param := types.NewParam(token.NoPos, pkg, "sounds", sliceType)
-				params := types.NewTuple(param)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, true) // variadic = true
-				return types.NewFunc(token.NoPos, pkg, "withVariadicSounds", sig)
+				sliceType := gotypes.NewSlice(GetSpxSoundNameType())
+				param := gotypes.NewParam(token.NoPos, pkg, "sounds", sliceType)
+				params := gotypes.NewTuple(param)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, true) // variadic = true
+				return gotypes.NewFunc(token.NoPos, pkg, "withVariadicSounds", sig)
 			},
 			want: true,
 		},
 		{
 			name: "FunctionWithMixedParameters",
-			fun: func() *types.Func {
+			fun: func() *gotypes.Func {
 				pkg := GetSpxPkg()
-				param1 := types.NewParam(token.NoPos, pkg, "id", types.Typ[types.Int])
-				param2 := types.NewParam(token.NoPos, pkg, "backdrop", GetSpxBackdropNameType())
-				param3 := types.NewParam(token.NoPos, pkg, "name", types.Typ[types.String])
-				params := types.NewTuple(param1, param2, param3)
-				sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-				return types.NewFunc(token.NoPos, pkg, "withMixed", sig)
+				param1 := gotypes.NewParam(token.NoPos, pkg, "id", gotypes.Typ[gotypes.Int])
+				param2 := gotypes.NewParam(token.NoPos, pkg, "backdrop", GetSpxBackdropNameType())
+				param3 := gotypes.NewParam(token.NoPos, pkg, "name", gotypes.Typ[gotypes.String])
+				params := gotypes.NewTuple(param1, param2, param3)
+				sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+				return gotypes.NewFunc(token.NoPos, pkg, "withMixed", sig)
 			},
 			want: true,
 		},
@@ -189,17 +190,18 @@ func TestHasSpxResourceNameTypeParamsCaching(t *testing.T) {
 
 	t.Run("SpxPackageFunctionIsCached", func(t *testing.T) {
 		pkg := GetSpxPkg()
-		param := types.NewParam(token.NoPos, pkg, "backdrop", GetSpxBackdropNameType())
-		params := types.NewTuple(param)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		param := gotypes.NewParam(token.NoPos, pkg, "backdrop", GetSpxBackdropNameType())
+		params := gotypes.NewTuple(param)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
 
 		result1 := HasSpxResourceNameTypeParams(fun)
 		assert.True(t, result1)
 
 		cached, ok := nonMainPkgSpxResourceNameTypeFuncCache.Load(fun)
-		assert.True(t, ok)
-		assert.True(t, cached.(bool))
+		require.True(t, ok)
+		cachedValue := requireValueAs[bool](t, cached)
+		assert.True(t, cachedValue)
 
 		result2 := HasSpxResourceNameTypeParams(fun)
 		assert.True(t, result2)
@@ -207,11 +209,11 @@ func TestHasSpxResourceNameTypeParamsCaching(t *testing.T) {
 	})
 
 	t.Run("MainPackageFunctionIsNotCached", func(t *testing.T) {
-		mainPkg := types.NewPackage("main", "main")
-		param := types.NewParam(token.NoPos, mainPkg, "backdrop", GetSpxBackdropNameType())
-		params := types.NewTuple(param)
-		sig := types.NewSignatureType(nil, nil, nil, params, nil, false)
-		fun := types.NewFunc(token.NoPos, mainPkg, "mainFunc", sig)
+		mainPkg := gotypes.NewPackage("main", "main")
+		param := gotypes.NewParam(token.NoPos, mainPkg, "backdrop", GetSpxBackdropNameType())
+		params := gotypes.NewTuple(param)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		fun := gotypes.NewFunc(token.NoPos, mainPkg, "mainFunc", sig)
 
 		result := HasSpxResourceNameTypeParams(fun)
 		assert.True(t, result)
@@ -222,20 +224,20 @@ func TestHasSpxResourceNameTypeParamsCaching(t *testing.T) {
 }
 
 func TestCanonicalSpxResourceNameType(t *testing.T) {
-	pkg := types.NewPackage("example.com/pkg", "pkg")
-	soundAlias := types.NewAlias(
-		types.NewTypeName(token.NoPos, pkg, "MySoundName", nil),
+	pkg := gotypes.NewPackage("example.com/pkg", "pkg")
+	soundAlias := gotypes.NewAlias(
+		gotypes.NewTypeName(token.NoPos, pkg, "MySoundName", nil),
 		GetSpxSoundNameType(),
 	)
-	soundAliasChain := types.NewAlias(
-		types.NewTypeName(token.NoPos, pkg, "MySoundNameChain", nil),
+	soundAliasChain := gotypes.NewAlias(
+		gotypes.NewTypeName(token.NoPos, pkg, "MySoundNameChain", nil),
 		soundAlias,
 	)
 
 	for _, tt := range []struct {
 		name string
-		typ  types.Type
-		want types.Type
+		typ  gotypes.Type
+		want gotypes.Type
 	}{
 		{
 			name: "Nil",
@@ -259,12 +261,12 @@ func TestCanonicalSpxResourceNameType(t *testing.T) {
 		},
 		{
 			name: "BasicString",
-			typ:  types.Typ[types.String],
+			typ:  gotypes.Typ[gotypes.String],
 			want: nil,
 		},
 		{
 			name: "AliasToBasicString",
-			typ:  types.NewAlias(types.NewTypeName(token.NoPos, pkg, "MyString", nil), types.Typ[types.String]),
+			typ:  gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "MyString", nil), gotypes.Typ[gotypes.String]),
 			want: nil,
 		},
 	} {

--- a/internal/server/spx_reference_pkg.go
+++ b/internal/server/spx_reference_pkg.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	xgoast "github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/pkgdoc"
 )
 
@@ -9,5 +9,5 @@ import (
 type SpxReferencePkg struct {
 	PkgPath string
 	Pkg     *pkgdoc.PkgDoc
-	Node    *xgoast.ImportSpec
+	Node    *ast.ImportSpec
 }

--- a/internal/server/spx_resource.go
+++ b/internal/server/spx_resource.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	xgoast "github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/xgo"
 )
 
@@ -25,7 +25,7 @@ type SpxResourceID interface {
 type SpxResourceRef struct {
 	ID   SpxResourceID
 	Kind SpxResourceRefKind
-	Node xgoast.Node
+	Node ast.Node
 }
 
 // SpxResourceRefKind is the kind of an spx resource reference.

--- a/internal/server/spx_util.go
+++ b/internal/server/spx_util.go
@@ -1,14 +1,14 @@
 package server
 
 import (
-	"go/types"
+	gotypes "go/types"
 	"path"
 	"regexp"
 	"strings"
 
-	xgoast "github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/xgo"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -23,14 +23,14 @@ func IsSpxEventHandlerFuncName(name string) bool {
 }
 
 // IsInSpxPkg reports whether the given object is defined in the spx package.
-func IsInSpxPkg(obj types.Object) bool {
+func IsInSpxPkg(obj gotypes.Object) bool {
 	return obj != nil && obj.Pkg() == GetSpxPkg()
 }
 
 // GetSimplifiedTypeString returns the string representation of the given type,
 // with the spx package name omitted while other packages use their short names.
-func GetSimplifiedTypeString(typ types.Type) string {
-	return types.TypeString(typ, func(p *types.Package) string {
+func GetSimplifiedTypeString(typ gotypes.Type) string {
+	return gotypes.TypeString(typ, func(p *gotypes.Package) string {
 		if p == GetSpxPkg() {
 			return ""
 		}
@@ -40,19 +40,19 @@ func GetSimplifiedTypeString(typ types.Type) string {
 
 // resolvedNamedType resolves aliases and pointer indirections until it reaches
 // a named type. It returns nil if typ does not resolve to a named type.
-func resolvedNamedType(typ types.Type) *types.Named {
-	seen := make(map[types.Type]struct{})
+func resolvedNamedType(typ gotypes.Type) *gotypes.Named {
+	seen := make(map[gotypes.Type]struct{})
 	for typ != nil {
 		if _, ok := seen[typ]; ok {
 			return nil
 		}
 		seen[typ] = struct{}{}
 
-		typ = types.Unalias(typ)
+		typ = gotypes.Unalias(typ)
 		switch t := typ.(type) {
-		case *types.Named:
+		case *gotypes.Named:
 			return t
-		case *types.Pointer:
+		case *gotypes.Pointer:
 			typ = t.Elem()
 		default:
 			return nil
@@ -63,7 +63,7 @@ func resolvedNamedType(typ types.Type) *types.Named {
 
 // SelectorTypeNameForIdent returns the selector type name for the given
 // identifier. It returns empty string if no selector can be inferred.
-func SelectorTypeNameForIdent(proj *xgo.Project, ident *xgoast.Ident) string {
+func SelectorTypeNameForIdent(proj *xgo.Project, ident *ast.Ident) string {
 	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return ""
@@ -89,7 +89,7 @@ func SelectorTypeNameForIdent(proj *xgo.Project, ident *xgoast.Ident) string {
 }
 
 // tryGetSpxImplicitReceiver handles spx package's special implicit receiver semantics.
-func tryGetSpxImplicitReceiver(proj *xgo.Project, astFile *xgoast.File, ident *xgoast.Ident, obj types.Object) string {
+func tryGetSpxImplicitReceiver(proj *xgo.Project, astFile *ast.File, ident *ast.Ident, obj gotypes.Object) string {
 	if !IsInSpxPkg(obj) {
 		return ""
 	}
@@ -115,15 +115,15 @@ func tryGetSpxImplicitReceiver(proj *xgo.Project, astFile *xgoast.File, ident *x
 }
 
 // getTypeFromObject infers type from the identifier's object.
-func getTypeFromObject(typeInfo *xgotypes.Info, obj types.Object) string {
+func getTypeFromObject(typeInfo *types.Info, obj gotypes.Object) string {
 	switch obj := obj.(type) {
-	case *types.Var:
+	case *gotypes.Var:
 		if !obj.IsField() {
 			return ""
 		}
 		return findFieldOwnerType(typeInfo, obj)
-	case *types.Func:
-		sig, ok := obj.Type().(*types.Signature)
+	case *gotypes.Func:
+		sig, ok := obj.Type().(*gotypes.Signature)
 		if !ok {
 			return ""
 		}
@@ -137,16 +137,16 @@ func getTypeFromObject(typeInfo *xgotypes.Info, obj types.Object) string {
 }
 
 // extractTypeName extracts a clean type name from a types.Type.
-func extractTypeName(typ types.Type) string {
+func extractTypeName(typ gotypes.Type) string {
 	switch typ := typ.(type) {
-	case *types.Named:
+	case *gotypes.Named:
 		obj := typ.Obj()
 		typeName := obj.Name()
 		if IsInSpxPkg(obj) && typeName == "SpriteImpl" {
 			return "Sprite"
 		}
 		return typeName
-	case *types.Interface:
+	case *gotypes.Interface:
 		if typ.String() == "interface{}" {
 			return ""
 		}
@@ -156,7 +156,7 @@ func extractTypeName(typ types.Type) string {
 }
 
 // findFieldOwnerType finds the type that owns a given field.
-func findFieldOwnerType(typeInfo *xgotypes.Info, field *types.Var) string {
+func findFieldOwnerType(typeInfo *types.Info, field *gotypes.Var) string {
 	if !field.IsField() {
 		return ""
 	}
@@ -170,12 +170,12 @@ func findFieldOwnerType(typeInfo *xgotypes.Info, field *types.Var) string {
 	scope := fieldPkg.Scope()
 	for _, name := range scope.Names() {
 		obj := scope.Lookup(name)
-		typeName, ok := obj.(*types.TypeName)
+		typeName, ok := obj.(*gotypes.TypeName)
 		if !ok {
 			continue
 		}
 
-		named, ok := xgoutil.DerefType(typeName.Type()).(*types.Named)
+		named, ok := xgoutil.DerefType(typeName.Type()).(*gotypes.Named)
 		if !ok || !xgoutil.IsNamedStructType(named) {
 			continue
 		}
@@ -191,13 +191,13 @@ func findFieldOwnerType(typeInfo *xgotypes.Info, field *types.Var) string {
 }
 
 // checkStructForField checks if a struct type contains the given field.
-func checkStructForField(named *types.Named, field *types.Var, fieldPkg *types.Package) string {
-	selection, ok := types.LookupSelection(named, false, fieldPkg, field.Name())
+func checkStructForField(named *gotypes.Named, field *gotypes.Var, fieldPkg *gotypes.Package) string {
+	selection, ok := gotypes.LookupSelection(named, false, fieldPkg, field.Name())
 	if !ok {
 		return ""
 	}
 
-	foundField, ok := selection.Obj().(*types.Var)
+	foundField, ok := selection.Obj().(*gotypes.Var)
 	if !ok || foundField != field {
 		return ""
 	}
@@ -225,8 +225,8 @@ func checkStructForField(named *types.Named, field *types.Var, fieldPkg *types.P
 // mainSpxFile is the main entry file (e.g. "main.spx").
 //
 // Returns nil when the target cannot be determined.
-func PropertyTargetNamedTypeForCall(typeInfo *xgotypes.Info, call *xgoast.CallExpr, spxFile, mainSpxFile string) *types.Named {
-	if sel, ok := call.Fun.(*xgoast.SelectorExpr); ok {
+func PropertyTargetNamedTypeForCall(typeInfo *types.Info, call *ast.CallExpr, spxFile, mainSpxFile string) *gotypes.Named {
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
 		if tv, ok := typeInfo.Types[sel.X]; ok && tv.Type != nil {
 			return resolvedNamedType(tv.Type)
 		}
@@ -247,7 +247,7 @@ func PropertyTargetNamedTypeForCall(typeInfo *xgotypes.Info, call *xgoast.CallEx
 	if obj == nil {
 		return nil
 	}
-	tn, ok := obj.(*types.TypeName)
+	tn, ok := obj.(*gotypes.TypeName)
 	if !ok {
 		return nil
 	}
@@ -255,14 +255,14 @@ func PropertyTargetNamedTypeForCall(typeInfo *xgotypes.Info, call *xgoast.CallEx
 }
 
 // searchAllDefsForField is a fallback method that searches all type definitions.
-func searchAllDefsForField(typeInfo *xgotypes.Info, field *types.Var) string {
+func searchAllDefsForField(typeInfo *types.Info, field *gotypes.Var) string {
 	fieldPkg := field.Pkg()
 	for _, def := range typeInfo.Defs {
 		if def == nil || def.Pkg() != fieldPkg {
 			continue
 		}
 
-		named, ok := xgoutil.DerefType(def.Type()).(*types.Named)
+		named, ok := xgoutil.DerefType(def.Type()).(*gotypes.Named)
 		if !ok || !xgoutil.IsNamedStructType(named) {
 			continue
 		}

--- a/internal/server/spx_util_test.go
+++ b/internal/server/spx_util_test.go
@@ -1,28 +1,28 @@
 package server
 
 import (
-	"go/token"
-	"go/types"
+	gotypes "go/types"
 	"testing"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotypes "github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestResolvedNamedType(t *testing.T) {
-	pkg := types.NewPackage("example.com/pkg", "pkg")
-	named := types.NewNamed(types.NewTypeName(token.NoPos, pkg, "Point", nil), types.NewStruct(nil, nil), nil)
-	aliasToNamed := types.NewAlias(types.NewTypeName(token.NoPos, pkg, "PointAlias", nil), named)
-	aliasChainToNamed := types.NewAlias(types.NewTypeName(token.NoPos, pkg, "PointAliasChain", nil), aliasToNamed)
-	aliasToBasic := types.NewAlias(types.NewTypeName(token.NoPos, pkg, "StringAlias", nil), types.Typ[types.String])
-	aliasToPointerNamed := types.NewAlias(types.NewTypeName(token.NoPos, pkg, "PointPtrAlias", nil), types.NewPointer(named))
-	aliasChainToPointerNamed := types.NewAlias(types.NewTypeName(token.NoPos, pkg, "PointPtrAliasChain", nil), aliasToPointerNamed)
+	pkg := gotypes.NewPackage("example.com/pkg", "pkg")
+	named := gotypes.NewNamed(gotypes.NewTypeName(token.NoPos, pkg, "Point", nil), gotypes.NewStruct(nil, nil), nil)
+	aliasToNamed := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "PointAlias", nil), named)
+	aliasChainToNamed := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "PointAliasChain", nil), aliasToNamed)
+	aliasToBasic := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "StringAlias", nil), gotypes.Typ[gotypes.String])
+	aliasToPointerNamed := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "PointPtrAlias", nil), gotypes.NewPointer(named))
+	aliasChainToPointerNamed := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "PointPtrAliasChain", nil), aliasToPointerNamed)
 
 	for _, tt := range []struct {
 		name string
-		typ  types.Type
-		want *types.Named
+		typ  gotypes.Type
+		want *gotypes.Named
 	}{
 		{
 			name: "Nil",
@@ -36,7 +36,7 @@ func TestResolvedNamedType(t *testing.T) {
 		},
 		{
 			name: "PointerToNamed",
-			typ:  types.NewPointer(named),
+			typ:  gotypes.NewPointer(named),
 			want: named,
 		},
 		{
@@ -46,7 +46,7 @@ func TestResolvedNamedType(t *testing.T) {
 		},
 		{
 			name: "PointerToAliasToNamed",
-			typ:  types.NewPointer(aliasToNamed),
+			typ:  gotypes.NewPointer(aliasToNamed),
 			want: named,
 		},
 		{
@@ -56,7 +56,7 @@ func TestResolvedNamedType(t *testing.T) {
 		},
 		{
 			name: "Basic",
-			typ:  types.Typ[types.Int],
+			typ:  gotypes.Typ[gotypes.Int],
 			want: nil,
 		},
 		{
@@ -87,29 +87,29 @@ func TestResolvedNamedType(t *testing.T) {
 }
 
 func TestPropertyTargetNamedTypeForCall(t *testing.T) {
-	newNamed := func(pkg *types.Package, name string) *types.Named {
-		return types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), types.NewStruct(nil, nil), nil)
+	newNamed := func(pkg *gotypes.Package, name string) *gotypes.Named {
+		return gotypes.NewNamed(gotypes.NewTypeName(token.NoPos, pkg, name, nil), gotypes.NewStruct(nil, nil), nil)
 	}
 
 	for _, tt := range []struct {
 		name       string
-		build      func() (*xgotypes.Info, *xgoast.CallExpr, string, string)
+		build      func() (*types.Info, *ast.CallExpr, string, string)
 		wantName   string
 		wantResult bool
 	}{
 		{
 			name: "SelectorReceiverNamed",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
 				sprite := newNamed(pkg, "Sprite")
 
-				recvIdent := &xgoast.Ident{Name: "sprite"}
-				info := &xgotypes.Info{Pkg: pkg}
-				info.Types = map[xgoast.Expr]types.TypeAndValue{
+				recvIdent := &ast.Ident{Name: "sprite"}
+				info := &types.Info{Pkg: pkg}
+				info.Types = map[ast.Expr]gotypes.TypeAndValue{
 					recvIdent: {Type: sprite},
 				}
 
-				call := &xgoast.CallExpr{Fun: &xgoast.SelectorExpr{X: recvIdent, Sel: &xgoast.Ident{Name: "Show"}}}
+				call := &ast.CallExpr{Fun: &ast.SelectorExpr{X: recvIdent, Sel: &ast.Ident{Name: "Show"}}}
 				return info, call, "Sprite.spx", "main.spx"
 			},
 			wantName:   "Sprite",
@@ -117,17 +117,17 @@ func TestPropertyTargetNamedTypeForCall(t *testing.T) {
 		},
 		{
 			name: "SelectorReceiverPointer",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
 				sprite := newNamed(pkg, "Sprite")
 
-				recvIdent := &xgoast.Ident{Name: "sprite"}
-				info := &xgotypes.Info{Pkg: pkg}
-				info.Types = map[xgoast.Expr]types.TypeAndValue{
-					recvIdent: {Type: types.NewPointer(sprite)},
+				recvIdent := &ast.Ident{Name: "sprite"}
+				info := &types.Info{Pkg: pkg}
+				info.Types = map[ast.Expr]gotypes.TypeAndValue{
+					recvIdent: {Type: gotypes.NewPointer(sprite)},
 				}
 
-				call := &xgoast.CallExpr{Fun: &xgoast.SelectorExpr{X: recvIdent, Sel: &xgoast.Ident{Name: "Show"}}}
+				call := &ast.CallExpr{Fun: &ast.SelectorExpr{X: recvIdent, Sel: &ast.Ident{Name: "Show"}}}
 				return info, call, "Sprite.spx", "main.spx"
 			},
 			wantName:   "Sprite",
@@ -135,17 +135,17 @@ func TestPropertyTargetNamedTypeForCall(t *testing.T) {
 		},
 		{
 			name: "SelectorReceiverCallExpr",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
 				sprite := newNamed(pkg, "Sprite")
 
-				getSprite := &xgoast.CallExpr{Fun: &xgoast.Ident{Name: "getSprite"}}
-				info := &xgotypes.Info{Pkg: pkg}
-				info.Types = map[xgoast.Expr]types.TypeAndValue{
+				getSprite := &ast.CallExpr{Fun: &ast.Ident{Name: "getSprite"}}
+				info := &types.Info{Pkg: pkg}
+				info.Types = map[ast.Expr]gotypes.TypeAndValue{
 					getSprite: {Type: sprite},
 				}
 
-				call := &xgoast.CallExpr{Fun: &xgoast.SelectorExpr{X: getSprite, Sel: &xgoast.Ident{Name: "Show"}}}
+				call := &ast.CallExpr{Fun: &ast.SelectorExpr{X: getSprite, Sel: &ast.Ident{Name: "Show"}}}
 				return info, call, "Sprite.spx", "main.spx"
 			},
 			wantName:   "Sprite",
@@ -153,42 +153,42 @@ func TestPropertyTargetNamedTypeForCall(t *testing.T) {
 		},
 		{
 			name: "SelectorReceiverMissingType",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
 
-				recvIdent := &xgoast.Ident{Name: "sprite"}
-				info := &xgotypes.Info{Pkg: pkg}
+				recvIdent := &ast.Ident{Name: "sprite"}
+				info := &types.Info{Pkg: pkg}
 
-				call := &xgoast.CallExpr{Fun: &xgoast.SelectorExpr{X: recvIdent, Sel: &xgoast.Ident{Name: "Show"}}}
+				call := &ast.CallExpr{Fun: &ast.SelectorExpr{X: recvIdent, Sel: &ast.Ident{Name: "Show"}}}
 				return info, call, "Sprite.spx", "main.spx"
 			},
 			wantResult: false,
 		},
 		{
 			name: "SelectorReceiverNonNamedType",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
 
-				recvIdent := &xgoast.Ident{Name: "s"}
-				info := &xgotypes.Info{Pkg: pkg}
-				info.Types = map[xgoast.Expr]types.TypeAndValue{
-					recvIdent: {Type: types.Typ[types.String]},
+				recvIdent := &ast.Ident{Name: "s"}
+				info := &types.Info{Pkg: pkg}
+				info.Types = map[ast.Expr]gotypes.TypeAndValue{
+					recvIdent: {Type: gotypes.Typ[gotypes.String]},
 				}
 
-				call := &xgoast.CallExpr{Fun: &xgoast.SelectorExpr{X: recvIdent, Sel: &xgoast.Ident{Name: "Show"}}}
+				call := &ast.CallExpr{Fun: &ast.SelectorExpr{X: recvIdent, Sel: &ast.Ident{Name: "Show"}}}
 				return info, call, "Sprite.spx", "main.spx"
 			},
 			wantResult: false,
 		},
 		{
 			name: "ImplicitMainSpxResolvesGame",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
 				game := newNamed(pkg, "Game")
 				_ = pkg.Scope().Insert(game.Obj())
 
-				info := &xgotypes.Info{Pkg: pkg}
-				call := &xgoast.CallExpr{Fun: &xgoast.Ident{Name: "showVar"}}
+				info := &types.Info{Pkg: pkg}
+				call := &ast.CallExpr{Fun: &ast.Ident{Name: "showVar"}}
 				return info, call, "dir/main.spx", "main.spx"
 			},
 			wantName:   "Game",
@@ -196,13 +196,13 @@ func TestPropertyTargetNamedTypeForCall(t *testing.T) {
 		},
 		{
 			name: "ImplicitSpriteFileResolvesTypeByFileName",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
 				hero := newNamed(pkg, "Hero")
 				_ = pkg.Scope().Insert(hero.Obj())
 
-				info := &xgotypes.Info{Pkg: pkg}
-				call := &xgoast.CallExpr{Fun: &xgoast.Ident{Name: "showVar"}}
+				info := &types.Info{Pkg: pkg}
+				call := &ast.CallExpr{Fun: &ast.Ident{Name: "showVar"}}
 				return info, call, "dir/Hero.spx", "main.spx"
 			},
 			wantName:   "Hero",
@@ -210,22 +210,22 @@ func TestPropertyTargetNamedTypeForCall(t *testing.T) {
 		},
 		{
 			name: "ImplicitLookupNotTypeName",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
-				_ = pkg.Scope().Insert(types.NewVar(token.NoPos, pkg, "Enemy", types.Typ[types.Int]))
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
+				_ = pkg.Scope().Insert(gotypes.NewVar(token.NoPos, pkg, "Enemy", gotypes.Typ[gotypes.Int]))
 
-				info := &xgotypes.Info{Pkg: pkg}
-				call := &xgoast.CallExpr{Fun: &xgoast.Ident{Name: "showVar"}}
+				info := &types.Info{Pkg: pkg}
+				call := &ast.CallExpr{Fun: &ast.Ident{Name: "showVar"}}
 				return info, call, "dir/Enemy.spx", "main.spx"
 			},
 			wantResult: false,
 		},
 		{
 			name: "ImplicitEmptyTypeName",
-			build: func() (*xgotypes.Info, *xgoast.CallExpr, string, string) {
-				pkg := types.NewPackage("example.com/test", "test")
-				info := &xgotypes.Info{Pkg: pkg}
-				call := &xgoast.CallExpr{Fun: &xgoast.Ident{Name: "showVar"}}
+			build: func() (*types.Info, *ast.CallExpr, string, string) {
+				pkg := gotypes.NewPackage("example.com/test", "test")
+				info := &types.Info{Pkg: pkg}
+				call := &ast.CallExpr{Fun: &ast.Ident{Name: "showVar"}}
 				return info, call, "dir/.spx", "main.spx"
 			},
 			wantResult: false,

--- a/internal/server/text_synchronization.go
+++ b/internal/server/text_synchronization.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/goplus/gogen"
-	xgoscanner "github.com/goplus/xgo/scanner"
+	"github.com/goplus/xgo/scanner"
 	"github.com/goplus/xgo/x/typesutil"
 	"github.com/goplus/xgolsw/jsonrpc2"
 	"github.com/goplus/xgolsw/protocol"
@@ -203,7 +203,7 @@ func (s *Server) getDiagnostics(path string) ([]Diagnostic, error) {
 	astFile, err := proj.ASTFile(path)
 	if err != nil {
 		var (
-			errorList xgoscanner.ErrorList
+			errorList scanner.ErrorList
 			codeError *gogen.CodeError
 		)
 		if errors.As(err, &errorList) {

--- a/internal/server/text_synchronization_test.go
+++ b/internal/server/text_synchronization_test.go
@@ -2,14 +2,15 @@ package server
 
 import (
 	"errors"
-	"go/token"
 	"testing"
 	"time"
 
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/jsonrpc2"
 	"github.com/goplus/xgolsw/protocol"
 	"github.com/goplus/xgolsw/xgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockReplier implements a message replier for testing
@@ -39,10 +40,10 @@ func TestModifyFiles(t *testing.T) {
 		name    string
 		initial map[string]*xgo.File
 		changes []FileChange
-		want    map[string]string // path -> expected content
+		want    map[string]string // path -> want content
 	}{
 		{
-			name:    "add new files",
+			name:    "AddNewFiles",
 			initial: map[string]*xgo.File{},
 			changes: []FileChange{
 				{
@@ -56,7 +57,7 @@ func TestModifyFiles(t *testing.T) {
 			},
 		},
 		{
-			name: "update existing file with newer version",
+			name: "UpdateExistingFileWithNewerVersion",
 			initial: map[string]*xgo.File{
 				"main.go": {
 					Content: []byte("old content"),
@@ -75,7 +76,7 @@ func TestModifyFiles(t *testing.T) {
 			},
 		},
 		{
-			name: "ignore older version update",
+			name: "IgnoreOlderVersionUpdate",
 			initial: map[string]*xgo.File{
 				"main.go": {
 					Content: []byte("current content"),
@@ -94,7 +95,7 @@ func TestModifyFiles(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple file changes",
+			name: "MultipleFileChanges",
 			initial: map[string]*xgo.File{
 				"file1.go": {
 					Content: []byte("content1"),
@@ -141,26 +142,17 @@ func TestModifyFiles(t *testing.T) {
 			// Verify results
 			for path, wantContent := range tt.want {
 				file, ok := proj.File(path)
-				if !ok {
-					t.Errorf("file %s not found", path)
-					continue
-				}
-				if got := string(file.Content); got != wantContent {
-					t.Errorf("%s file %s content = %q, want %q", tt.name, path, got, wantContent)
-				}
+				require.True(t, ok)
+				assert.Equal(t, wantContent, string(file.Content))
 			}
 
 			// Verify no extra files exist
 			count := 0
 			for path := range proj.Files() {
 				count++
-				if _, ok := tt.want[path]; !ok {
-					t.Errorf("unexpected file: %s", path)
-				}
+				assert.Contains(t, tt.want, path)
 			}
-			if count != len(tt.want) {
-				t.Errorf("got %d files, want %d", count, len(tt.want))
-			}
+			assert.Len(t, tt.want, count)
 		})
 	}
 }
@@ -168,14 +160,14 @@ func TestModifyFiles(t *testing.T) {
 // TestDidOpen tests the didOpen handler functionality
 func TestDidOpen(t *testing.T) {
 	tests := []struct {
-		name            string
-		params          *protocol.DidOpenTextDocumentParams
-		expectedPath    string
-		expectedContent string
-		wantErr         bool
+		name        string
+		params      *protocol.DidOpenTextDocumentParams
+		wantPath    string
+		wantContent string
+		wantErr     bool
 	}{
 		{
-			name: "basic open",
+			name: "BasicOpen",
 			params: &protocol.DidOpenTextDocumentParams{
 				TextDocument: protocol.TextDocumentItem{
 					URI:     "file://workspace/echo.spx",
@@ -183,12 +175,12 @@ func TestDidOpen(t *testing.T) {
 					Text:    "echo \"100\"",
 				},
 			},
-			expectedPath:    "echo.spx",
-			expectedContent: "echo \"100\"",
-			wantErr:         false,
+			wantPath:    "echo.spx",
+			wantContent: "echo \"100\"",
+			wantErr:     false,
 		},
 		{
-			name: "open file with function",
+			name: "OpenFileWithFunction",
 			params: &protocol.DidOpenTextDocumentParams{
 				TextDocument: protocol.TextDocumentItem{
 					URI:     "file://workspace/test_func.spx",
@@ -196,12 +188,12 @@ func TestDidOpen(t *testing.T) {
 					Text:    "onStart {\n say \"Hello, World!\"\n}",
 				},
 			},
-			expectedPath:    "test_func.spx",
-			expectedContent: "onStart {\n say \"Hello, World!\"\n}",
-			wantErr:         false,
+			wantPath:    "test_func.spx",
+			wantContent: "onStart {\n say \"Hello, World!\"\n}",
+			wantErr:     false,
 		},
 		{
-			name: "open file with unicode content",
+			name: "OpenFileWithUnicodeContent",
 			params: &protocol.DidOpenTextDocumentParams{
 				TextDocument: protocol.TextDocumentItem{
 					URI:     "file://workspace/i18n.spx",
@@ -209,12 +201,12 @@ func TestDidOpen(t *testing.T) {
 					Text:    "onStart {\n say \"你好，世界!\"\n}",
 				},
 			},
-			expectedPath:    "i18n.spx",
-			expectedContent: "onStart {\n say \"你好，世界!\"\n}",
-			wantErr:         false,
+			wantPath:    "i18n.spx",
+			wantContent: "onStart {\n say \"你好，世界!\"\n}",
+			wantErr:     false,
 		},
 		{
-			name: "URI conversion error",
+			name: "URIConversionError",
 			params: &protocol.DidOpenTextDocumentParams{
 				TextDocument: protocol.TextDocumentItem{
 					URI:     "file://error_workspace/error.spx",
@@ -225,7 +217,7 @@ func TestDidOpen(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty file content",
+			name: "EmptyFileContent",
 			params: &protocol.DidOpenTextDocumentParams{
 				TextDocument: protocol.TextDocumentItem{
 					URI:     "file://workspace/empty.spx",
@@ -233,9 +225,9 @@ func TestDidOpen(t *testing.T) {
 					Text:    "",
 				},
 			},
-			expectedPath:    "empty.spx",
-			expectedContent: "",
-			wantErr:         false,
+			wantPath:    "empty.spx",
+			wantContent: "",
+			wantErr:     false,
 		},
 	}
 
@@ -243,7 +235,7 @@ func TestDidOpen(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup test environment with real Project instead of MockProject
 			proj := xgo.NewProject(token.NewFileSet(), make(map[string]*xgo.File), 0)
-			proj.PutFile(tt.expectedPath, file("mock content"))
+			proj.PutFile(tt.wantPath, file("mock content"))
 			mockReplier := &MockReplier{}
 
 			// Create a TestServer that extends the real Server
@@ -257,30 +249,18 @@ func TestDidOpen(t *testing.T) {
 			err := server.didOpen(tt.params)
 
 			// Verify results
-			if (err != nil) != tt.wantErr {
-				t.Errorf("didOpen() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			if !tt.wantErr {
 				// Verify file was correctly added to the project
-				file, ok := proj.File(tt.expectedPath)
-				if !ok {
-					t.Errorf("File not found in project: %s", tt.expectedPath)
-					return
-				}
-
-				if string(file.Content) != tt.expectedContent {
-					t.Errorf("File %s content = %q, want %q", tt.expectedPath, string(file.Content), tt.expectedContent)
-				}
-
-				// If available, check file version
-				if _, ok := proj.File(tt.expectedPath); ok {
-					expectedVersion := int(tt.params.TextDocument.Version)
-					// Note: In a real test, you might need to extract the version from the FileImpl
-					// This depends on how version is stored in your implementation
-					t.Logf("File opened with version: %d", expectedVersion)
-				}
+				file, ok := proj.File(tt.wantPath)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantContent, string(file.Content))
+				assert.Equal(t, int(tt.params.TextDocument.Version), file.Version)
 			}
 		})
 	}
@@ -289,15 +269,15 @@ func TestDidOpen(t *testing.T) {
 // TestDidChange tests the didChange handler functionality
 func TestDidChange(t *testing.T) {
 	tests := []struct {
-		name            string
-		initialContent  string
-		params          *protocol.DidChangeTextDocumentParams
-		convertError    error
-		expectedContent string
-		wantErr         bool
+		name           string
+		initialContent string
+		params         *protocol.DidChangeTextDocumentParams
+		convertError   error
+		wantContent    string
+		wantErr        bool
 	}{
 		{
-			name:           "full document replacement",
+			name:           "FullDocumentReplacement",
 			initialContent: "package main",
 			params: &protocol.DidChangeTextDocumentParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
@@ -310,11 +290,11 @@ func TestDidChange(t *testing.T) {
 					{Text: "package main\n\nfunc main() {}"},
 				},
 			},
-			expectedContent: "package main\n\nfunc main() {}",
-			wantErr:         false,
+			wantContent: "package main\n\nfunc main() {}",
+			wantErr:     false,
 		},
 		{
-			name:           "incremental change",
+			name:           "IncrementalChange",
 			initialContent: "package main\n\nfunc main() {\n\t\n}",
 			params: &protocol.DidChangeTextDocumentParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
@@ -333,11 +313,11 @@ func TestDidChange(t *testing.T) {
 					},
 				},
 			},
-			expectedContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
-			wantErr:         false,
+			wantContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
+			wantErr:     false,
 		},
 		{
-			name:           "multiple incremental changes",
+			name:           "MultipleIncrementalChanges",
 			initialContent: "package main\n\nfunc main() {\n\t\n}",
 			params: &protocol.DidChangeTextDocumentParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
@@ -363,11 +343,11 @@ func TestDidChange(t *testing.T) {
 					},
 				},
 			},
-			expectedContent: "package main\n\nfunc main() {\n\tfmt.Print(\"Hello, World!\")\n}",
-			wantErr:         false,
+			wantContent: "package main\n\nfunc main() {\n\tfmt.Print(\"Hello, World!\")\n}",
+			wantErr:     false,
 		},
 		{
-			name:           "URI conversion error",
+			name:           "URIConversionError",
 			initialContent: "package main",
 			params: &protocol.DidChangeTextDocumentParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
@@ -384,7 +364,7 @@ func TestDidChange(t *testing.T) {
 			wantErr:      true,
 		},
 		{
-			name:           "empty changes array",
+			name:           "EmptyChangesArray",
 			initialContent: "package main",
 			params: &protocol.DidChangeTextDocumentParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
@@ -424,27 +404,18 @@ func TestDidChange(t *testing.T) {
 			err := server.didChange(tt.params)
 
 			// Verify results
-			if (err != nil) != tt.wantErr {
-				t.Errorf("%s didChange() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			if !tt.wantErr {
 				// Verify file content was updated
 				file, ok := proj.File(path)
-				if !ok {
-					t.Errorf("%s File not found in project: %s", tt.name, path)
-					return
-				}
-
-				if string(file.Content) != tt.expectedContent {
-					t.Errorf("%s File content = %q, want %q", tt.name, string(file.Content), tt.expectedContent)
-				}
-
-				// If available, check file version
-				expectedVersion := int(tt.params.TextDocument.Version)
-				// Note: For a real implementation, verify the version is stored correctly
-				t.Logf("%s File changed with version: %d", tt.name, expectedVersion)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantContent, string(file.Content))
+				assert.Equal(t, int(tt.params.TextDocument.Version), file.Version)
 			}
 		})
 	}
@@ -453,15 +424,15 @@ func TestDidChange(t *testing.T) {
 // TestDidSave tests the didSave handler functionality
 func TestDidSave(t *testing.T) {
 	tests := []struct {
-		name            string
-		initialContent  string
-		params          *protocol.DidSaveTextDocumentParams
-		expectedContent string
-		contentChanged  bool
-		wantErr         bool
+		name           string
+		initialContent string
+		params         *protocol.DidSaveTextDocumentParams
+		wantContent    string
+		contentChanged bool
+		wantErr        bool
 	}{
 		{
-			name:           "save with text",
+			name:           "SaveWithText",
 			initialContent: "package main",
 			params: &protocol.DidSaveTextDocumentParams{
 				TextDocument: protocol.TextDocumentIdentifier{
@@ -469,12 +440,12 @@ func TestDidSave(t *testing.T) {
 				},
 				Text: strPtr("package main\n\nfunc main() {}"),
 			},
-			expectedContent: "package main\n\nfunc main() {}",
-			contentChanged:  true,
-			wantErr:         false,
+			wantContent:    "package main\n\nfunc main() {}",
+			contentChanged: true,
+			wantErr:        false,
 		},
 		{
-			name:           "save without text",
+			name:           "SaveWithoutText",
 			initialContent: "package main",
 			params: &protocol.DidSaveTextDocumentParams{
 				TextDocument: protocol.TextDocumentIdentifier{
@@ -482,12 +453,12 @@ func TestDidSave(t *testing.T) {
 				},
 				Text: nil,
 			},
-			expectedContent: "package main", // Content should not change
-			contentChanged:  false,
-			wantErr:         false,
+			wantContent:    "package main", // Content should not change
+			contentChanged: false,
+			wantErr:        false,
 		},
 		{
-			name:           "URI conversion error",
+			name:           "URIConversionError",
 			initialContent: "package main",
 			params: &protocol.DidSaveTextDocumentParams{
 				TextDocument: protocol.TextDocumentIdentifier{
@@ -503,7 +474,7 @@ func TestDidSave(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup test environment
-			fset := xgotoken.NewFileSet()
+			fset := token.NewFileSet()
 			files := make(map[string]*xgo.File)
 			path := "test.xgo"
 
@@ -526,22 +497,17 @@ func TestDidSave(t *testing.T) {
 			err := server.didSave(tt.params)
 
 			// Verify results
-			if (err != nil) != tt.wantErr {
-				t.Errorf("%s didSave() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			if !tt.wantErr {
 				// Verify file content
 				file, ok := proj.File(path)
-				if !ok {
-					t.Errorf("%s File not found in project: %s", tt.name, path)
-					return
-				}
-
-				if string(file.Content) != tt.expectedContent {
-					t.Errorf("%s File content = %q, want %q", tt.name, string(file.Content), tt.expectedContent)
-				}
+				require.True(t, ok)
+				assert.Equal(t, tt.wantContent, string(file.Content))
 			}
 		})
 	}
@@ -555,7 +521,7 @@ func TestDidClose(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "close document",
+			name: "CloseDocument",
 			params: &protocol.DidCloseTextDocumentParams{
 				TextDocument: protocol.TextDocumentIdentifier{
 					URI: "file://workspace/test.xgo",
@@ -568,7 +534,7 @@ func TestDidClose(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup test environment
-			fset := xgotoken.NewFileSet()
+			fset := token.NewFileSet()
 			files := make(map[string]*xgo.File)
 			path := "/test.xgo"
 
@@ -591,9 +557,10 @@ func TestDidClose(t *testing.T) {
 			err := server.didClose(tt.params)
 
 			// Verify results
-			if (err != nil) != tt.wantErr {
-				t.Errorf("didClose() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -609,7 +576,7 @@ func TestChangedText(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name:           "full document replacement",
+			name:           "FullDocumentReplacement",
 			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -620,7 +587,7 @@ func TestChangedText(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "incremental change - add comma",
+			name:           "IncrementalChangeAddComma",
 			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -635,7 +602,7 @@ func TestChangedText(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "incremental change - replace word",
+			name:           "IncrementalChangeReplaceWord",
 			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -650,7 +617,7 @@ func TestChangedText(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "multiple incremental changes",
+			name:           "MultipleIncrementalChanges",
 			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -672,14 +639,14 @@ func TestChangedText(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "empty changes array",
+			name:           "EmptyChangesArray",
 			initialContent: "package main",
 			changes:        []protocol.TextDocumentContentChangeEvent{},
 			want:           "",
 			wantErr:        true,
 		},
 		{
-			name:           "invalid range - end before start",
+			name:           "InvalidRangeEndBeforeStart",
 			initialContent: "package main",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -698,7 +665,7 @@ func TestChangedText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup test environment
-			fset := xgotoken.NewFileSet()
+			fset := token.NewFileSet()
 			files := make(map[string]*xgo.File)
 			path := "/test.xgo"
 
@@ -713,9 +680,7 @@ func TestChangedText(t *testing.T) {
 			// For AST parsing to work, we need a real file with content
 			// parsed into the AST before we can apply changes
 			_, err := proj.ASTFile(path)
-			if err != nil {
-				t.Fatalf("Failed to setup test: %v", err)
-			}
+			require.NoError(t, err)
 
 			server := &Server{
 				workspaceRootFS: proj,
@@ -725,15 +690,14 @@ func TestChangedText(t *testing.T) {
 			got, err := server.changedText(path, tt.changes)
 
 			// Verify results
-			if (err != nil) != tt.wantErr {
-				t.Errorf("changedText() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			if !tt.wantErr {
-				if string(got) != tt.want {
-					t.Errorf("%s changedText() = %q, want %q", tt.name, string(got), tt.want)
-				}
+				assert.Equal(t, tt.want, string(got))
 			}
 		})
 	}
@@ -749,7 +713,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name:           "add text at beginning",
+			name:           "AddTextAtBeginning",
 			initialContent: "func main() {}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -764,7 +728,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "add text in middle",
+			name:           "AddTextInMiddle",
 			initialContent: "func main() {}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -779,7 +743,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "delete text",
+			name:           "DeleteText",
 			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -794,7 +758,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "replace entire line",
+			name:           "ReplaceEntireLine",
 			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -809,7 +773,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "nil range",
+			name:           "NilRange",
 			initialContent: "package main",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -821,7 +785,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:           "non-existent file",
+			name:           "NonExistentFile",
 			initialContent: "",
 			changes: []protocol.TextDocumentContentChangeEvent{
 				{
@@ -840,7 +804,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup test environment
-			fset := xgotoken.NewFileSet()
+			fset := token.NewFileSet()
 			files := make(map[string]*xgo.File)
 			path := "/test.xgo"
 
@@ -856,9 +820,7 @@ func TestApplyIncrementalChanges(t *testing.T) {
 			// For tests with content, ensure we have AST
 			if tt.initialContent != "" {
 				_, err := proj.ASTFile(path)
-				if err != nil {
-					t.Fatalf("Failed to setup test: %v", err)
-				}
+				require.NoError(t, err)
 			}
 
 			server := &Server{
@@ -869,15 +831,14 @@ func TestApplyIncrementalChanges(t *testing.T) {
 			got, err := server.applyIncrementalChanges(path, tt.changes)
 
 			// Verify results
-			if (err != nil) != tt.wantErr {
-				t.Errorf("applyIncrementalChanges() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
 			if !tt.wantErr {
-				if string(got) != tt.want {
-					t.Errorf("%s applyIncrementalChanges() = %q, want %q", tt.name, string(got), tt.want)
-				}
+				assert.Equal(t, tt.want, string(got))
 			}
 		})
 	}
@@ -894,7 +855,7 @@ func TestGetDiagnostics(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name:           "import errors",
+			name:           "ImportErrors",
 			content:        "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
 			path:           "/test.xgo",
 			wantDiagCount:  1,
@@ -902,7 +863,7 @@ func TestGetDiagnostics(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "syntax error",
+			name:           "SyntaxError",
 			content:        "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\"\n}", // Missing closing parenthesis
 			path:           "/syntax_error.xgo",
 			wantDiagCount:  8,
@@ -910,7 +871,7 @@ func TestGetDiagnostics(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "type error",
+			name:           "TypeError",
 			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n}", // Type mismatch
 			path:           "/type_error.xgo",
 			wantDiagCount:  1,
@@ -918,7 +879,7 @@ func TestGetDiagnostics(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "no error",
+			name:           "NoError",
 			content:        "package main\n\nfunc main() {\n\t}",
 			path:           "/code_error.xgo",
 			wantDiagCount:  0,
@@ -926,7 +887,7 @@ func TestGetDiagnostics(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "multiple type errors",
+			name:           "MultipleTypeErrors",
 			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n\tvar y bool = 42\n}",
 			path:           "/multiple_errors.xgo",
 			wantDiagCount:  2,
@@ -938,7 +899,7 @@ func TestGetDiagnostics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup test environment
-			fset := xgotoken.NewFileSet()
+			fset := token.NewFileSet()
 			files := make(map[string]*xgo.File)
 
 			// Create the test file
@@ -956,28 +917,20 @@ func TestGetDiagnostics(t *testing.T) {
 			diagnostics, err := server.getDiagnostics(tt.path)
 
 			// Verify results
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getDiagnostics() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
-			// for _, d := range diagnostics {
-			// 	t.Logf("%s Diagnostic: %v; Range: %d/%d %d/%d", tt.name, d.Message,
-			// 		d.Range.Start.Line, d.Range.Start.Character, d.Range.End.Line, d.Range.End.Character)
-			// }
-
-			if len(diagnostics) != tt.wantDiagCount {
-				t.Errorf("%s getDiagnostics() returned %v diagnostics, want %d", tt.name, len(diagnostics), tt.wantDiagCount)
-			}
+			assert.Len(t, diagnostics, tt.wantDiagCount)
 
 			// Check diagnostic severities
 			for i, diag := range diagnostics {
 				if i >= len(tt.wantSeverities) {
 					break
 				}
-				if diag.Severity != tt.wantSeverities[i] {
-					t.Errorf("diagnostic[%d] severity = %d, want %d", i, diag.Severity, tt.wantSeverities[i])
-				}
+				assert.Equal(t, tt.wantSeverities[i], diag.Severity)
 			}
 		})
 	}

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -5,8 +5,8 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
@@ -121,8 +121,8 @@ func PositionOffset(content []byte, position Position) int {
 	return lineOffset + utf8Offset
 }
 
-// FromPosition converts a [xgotoken.Position] to a [Position].
-func FromPosition(proj *xgo.Project, astFile *xgoast.File, position xgotoken.Position) Position {
+// FromPosition converts a [token.Position] to a [Position].
+func FromPosition(proj *xgo.Project, astFile *ast.File, position token.Position) Position {
 	tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile)
 
 	line := min(max(position.Line, 1), tokenFile.LineCount())
@@ -148,8 +148,8 @@ func FromPosition(proj *xgo.Project, astFile *xgoast.File, position xgotoken.Pos
 	}
 }
 
-// ToPosition converts a [Position] to a [xgotoken.Position].
-func ToPosition(proj *xgo.Project, astFile *xgoast.File, position Position) xgotoken.Position {
+// ToPosition converts a [Position] to a [token.Position].
+func ToPosition(proj *xgo.Project, astFile *ast.File, position Position) token.Position {
 	tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile)
 
 	line := min(int(position.Line)+1, tokenFile.LineCount())
@@ -162,7 +162,7 @@ func ToPosition(proj *xgo.Project, astFile *xgoast.File, position Position) xgot
 	utf8Offset := UTF16PosToUTF8Offset(string(lineContent), int(position.Character))
 	column := utf8Offset + 1
 
-	return xgotoken.Position{
+	return token.Position{
 		Filename: tokenFile.Name(),
 		Offset:   relLineStart + utf8Offset,
 		Line:     line,
@@ -170,24 +170,24 @@ func ToPosition(proj *xgo.Project, astFile *xgoast.File, position Position) xgot
 	}
 }
 
-// PosAt returns the [xgotoken.Pos] of the given position in the given AST file.
-func PosAt(proj *xgo.Project, astFile *xgoast.File, position Position) xgotoken.Pos {
+// PosAt returns the [token.Pos] of the given position in the given AST file.
+func PosAt(proj *xgo.Project, astFile *ast.File, position Position) token.Pos {
 	tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile)
 	if int(position.Line) > tokenFile.LineCount()-1 {
-		return xgotoken.Pos(tokenFile.Base() + tokenFile.Size()) // EOF
+		return token.Pos(tokenFile.Base() + tokenFile.Size()) // EOF
 	}
 	return tokenFile.Pos(ToPosition(proj, astFile, position).Offset)
 }
 
-// RangeForASTFilePosition returns a [Range] for the given [xgotoken.Position]
+// RangeForASTFilePosition returns a [Range] for the given [token.Position]
 // in the given AST file.
-func RangeForASTFilePosition(proj *xgo.Project, astFile *xgoast.File, position xgotoken.Position) Range {
+func RangeForASTFilePosition(proj *xgo.Project, astFile *ast.File, position token.Position) Range {
 	p := FromPosition(proj, astFile, position)
 	return Range{Start: p, End: p}
 }
 
 // RangeForASTFileNode returns the [Range] for the given node in the given AST file.
-func RangeForASTFileNode(proj *xgo.Project, astFile *xgoast.File, node xgoast.Node) Range {
+func RangeForASTFileNode(proj *xgo.Project, astFile *ast.File, node ast.Node) Range {
 	fset := proj.Fset
 	return Range{
 		Start: FromPosition(proj, astFile, fset.Position(node.Pos())),
@@ -196,13 +196,13 @@ func RangeForASTFileNode(proj *xgo.Project, astFile *xgoast.File, node xgoast.No
 }
 
 // RangeForPos returns the [Range] for the given position.
-func RangeForPos(proj *xgo.Project, pos xgotoken.Pos) Range {
+func RangeForPos(proj *xgo.Project, pos token.Pos) Range {
 	astPkg, _ := proj.ASTPackage()
 	return RangeForASTFilePosition(proj, xgoutil.PosASTFile(proj.Fset, astPkg, pos), proj.Fset.Position(pos))
 }
 
 // RangeForPosEnd returns the [Range] for the given pos and end positions.
-func RangeForPosEnd(proj *xgo.Project, pos, end xgotoken.Pos) Range {
+func RangeForPosEnd(proj *xgo.Project, pos, end token.Pos) Range {
 	astPkg, _ := proj.ASTPackage()
 	astFile := xgoutil.PosASTFile(proj.Fset, astPkg, pos)
 	return Range{
@@ -212,7 +212,7 @@ func RangeForPosEnd(proj *xgo.Project, pos, end xgotoken.Pos) Range {
 }
 
 // RangeForNode returns the [Range] for the given node.
-func RangeForNode(proj *xgo.Project, node xgoast.Node) Range {
+func RangeForNode(proj *xgo.Project, node ast.Node) Range {
 	astPkg, _ := proj.ASTPackage()
 	return RangeForASTFileNode(proj, xgoutil.NodeASTFile(proj.Fset, astPkg, node), node)
 }

--- a/internal/server/util_test.go
+++ b/internal/server/util_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"testing"
 
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,13 +223,13 @@ func TestFromPosition(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		code     string
-		position xgotoken.Position
+		position token.Position
 		want     Position
 	}{
 		{
 			name: "FirstCharacterOfFile",
 			code: "package main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 1,
 			},
@@ -241,7 +241,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "MiddleOfFirstLine",
 			code: "package main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 8,
 			},
@@ -253,7 +253,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "EndOfFirstLine",
 			code: "package main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 13,
 			},
@@ -265,7 +265,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "SecondLineStart",
 			code: "package main\nimport \"fmt\"",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   2,
 				Column: 1,
 			},
@@ -277,7 +277,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "SecondLineMiddle",
 			code: "package main\nimport \"fmt\"",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   2,
 				Column: 7,
 			},
@@ -289,7 +289,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "WithCJKCharacters",
 			code: "// 世界\npackage main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 4, // After "// "
 			},
@@ -301,7 +301,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "AfterCJKCharacters",
 			code: "// 世界\npackage main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 8, // After "// 世界" (UTF-8: 3 + 3 + 3 = 9 bytes, but column is 8)
 			},
@@ -313,7 +313,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "WithEmoji",
 			code: "// 😀\npackage main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 4, // After "// "
 			},
@@ -325,7 +325,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "AfterEmoji",
 			code: "// 😀\npackage main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 8, // After "// 😀" (UTF-8: 3 + 4 = 7 bytes, column would be 8)
 			},
@@ -337,7 +337,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "EmptyLine",
 			code: "package main\n\nfunc main() {}",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   2,
 				Column: 1,
 			},
@@ -349,7 +349,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "WithTabs",
 			code: "\tpackage main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 2,
 			},
@@ -361,7 +361,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "ColumnExceedsLineLength",
 			code: "abc",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 10, // Beyond the line length
 			},
@@ -373,7 +373,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "ZeroLineAndColumn",
 			code: "package main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   0, // Invalid line (will be corrected to 1)
 				Column: 0, // Invalid column (will be corrected to 1)
 			},
@@ -385,7 +385,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "NegativeLineAndColumn",
 			code: "package main",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   -1, // Invalid line (will be corrected to 1)
 				Column: -1, // Invalid column (will be corrected to 1)
 			},
@@ -397,7 +397,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "ColumnExceedsLineLengthWithNewline",
 			code: "abc\ndef",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 10, // Beyond the first line length
 			},
@@ -409,7 +409,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "ColumnExceedsLineLengthMultiLine",
 			code: "first\nsecond line\nthird",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 20, // Way beyond the first line
 			},
@@ -421,7 +421,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "ColumnExactlyAtNewline",
 			code: "test\nnext",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 5, // Points to the newline character position
 			},
@@ -433,7 +433,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "ColumnAfterNewline",
 			code: "line1\nline2",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 6, // Points after the newline character
 			},
@@ -445,7 +445,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "LastLineWithoutNewline",
 			code: "first\nlast",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   2,
 				Column: 5, // Points to end of last line (no newline after it)
 			},
@@ -457,7 +457,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "LineExceedsFileLineCount",
 			code: "line1\nline2",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   5, // File only has 2 lines
 				Column: 1,
 			},
@@ -469,7 +469,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "MultiByteCharacterMidLine",
 			code: "var café = 1",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 5, // After "var "
 			},
@@ -481,7 +481,7 @@ func TestFromPosition(t *testing.T) {
 		{
 			name: "AfterAccentedCharacter",
 			code: "var café = 1",
-			position: xgotoken.Position{
+			position: token.Position{
 				Line:   1,
 				Column: 9, // After "var café"
 			},
@@ -492,7 +492,7 @@ func TestFromPosition(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fset := xgotoken.NewFileSet()
+			fset := token.NewFileSet()
 			files := map[string]*xgo.File{
 				"test.gop": {Content: []byte(tt.code)},
 			}

--- a/pkgdoc/doc.go
+++ b/pkgdoc/doc.go
@@ -17,11 +17,11 @@
 package pkgdoc
 
 import (
-	"go/ast"
-	"go/doc"
-	"go/token"
+	goast "go/ast"
+	godoc "go/doc"
 	"strings"
 
+	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -56,8 +56,8 @@ type TypeDoc struct {
 }
 
 // NewGo creates a new [PkgDoc] from the given Go [ast.Package].
-func NewGo(pkgPath string, pkg *ast.Package) *PkgDoc {
-	docPkg := doc.New(pkg, pkgPath, doc.AllDecls|doc.AllMethods|doc.PreserveAST)
+func NewGo(pkgPath string, pkg *goast.Package) *PkgDoc {
+	docPkg := godoc.New(pkg, pkgPath, godoc.AllDecls|godoc.AllMethods|godoc.PreserveAST)
 	pkgDoc := &PkgDoc{
 		Doc:    docPkg.Doc,
 		Path:   pkgPath,
@@ -111,17 +111,17 @@ func NewGo(pkgPath string, pkg *ast.Package) *PkgDoc {
 		typeDoc := pkgDoc.typeDoc(t.Name)
 		typeDoc.Doc = t.Doc
 		for _, spec := range t.Decl.Specs {
-			typeSpec, ok := spec.(*ast.TypeSpec)
+			typeSpec, ok := spec.(*goast.TypeSpec)
 			if !ok {
 				continue
 			}
-			structType, ok := typeSpec.Type.(*ast.StructType)
+			structType, ok := typeSpec.Type.(*goast.StructType)
 			if !ok {
 				continue
 			}
 			for _, field := range structType.Fields.List {
 				if len(field.Names) == 0 {
-					if ident, ok := field.Type.(*ast.Ident); ok && token.IsExported(ident.Name) {
+					if ident, ok := field.Type.(*goast.Ident); ok && token.IsExported(ident.Name) {
 						typeDoc.Fields[ident.Name] = field.Doc.Text()
 					}
 				} else {

--- a/pkgdoc/xgodoc.go
+++ b/pkgdoc/xgodoc.go
@@ -20,12 +20,12 @@ import (
 	"path"
 	"strings"
 
-	xgoast "github.com/goplus/xgo/ast"
-	xgotoken "github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
 )
 
 // NewXGo creates a new [PkgDoc] for an XGo package.
-func NewXGo(pkgPath string, pkg *xgoast.Package) *PkgDoc {
+func NewXGo(pkgPath string, pkg *ast.Package) *PkgDoc {
 	pkgDoc := &PkgDoc{
 		Path:   pkgPath,
 		Name:   pkg.Name,
@@ -51,26 +51,26 @@ func NewXGo(pkgPath string, pkg *xgoast.Package) *PkgDoc {
 		}
 		spxBaseSelectorTypeDoc := pkgDoc.typeDoc(spxBaseSelectorTypeName)
 
-		var firstVarBlock *xgoast.GenDecl
+		var firstVarBlock *ast.GenDecl
 		for _, decl := range astFile.Decls {
 			switch decl := decl.(type) {
-			case *xgoast.GenDecl:
-				if firstVarBlock == nil && decl.Tok == xgotoken.VAR {
+			case *ast.GenDecl:
+				if firstVarBlock == nil && decl.Tok == token.VAR {
 					firstVarBlock = decl
 				}
 
 				for _, spec := range decl.Specs {
 					var doc string
 					switch spec := spec.(type) {
-					case *xgoast.ValueSpec:
+					case *ast.ValueSpec:
 						if spec.Doc != nil {
 							doc = spec.Doc.Text()
 						}
-					case *xgoast.TypeSpec:
+					case *ast.TypeSpec:
 						if spec.Doc != nil {
 							doc = spec.Doc.Text()
 						}
-					case *xgoast.ImportSpec:
+					case *ast.ImportSpec:
 						if spec.Doc != nil {
 							doc = spec.Doc.Text()
 						}
@@ -80,21 +80,21 @@ func NewXGo(pkgPath string, pkg *xgoast.Package) *PkgDoc {
 					}
 
 					switch spec := spec.(type) {
-					case *xgoast.ValueSpec:
+					case *ast.ValueSpec:
 						for _, name := range spec.Names {
 							switch decl.Tok {
-							case xgotoken.VAR:
+							case token.VAR:
 								if decl == firstVarBlock {
 									spxBaseSelectorTypeDoc.Fields[name.Name] = doc
 								} else {
 									pkgDoc.Vars[name.Name] = doc
 								}
-							case xgotoken.CONST:
+							case token.CONST:
 								pkgDoc.Consts[name.Name] = doc
 							}
 						}
-					case *xgoast.TypeSpec:
-						if structType, ok := spec.Type.(*xgoast.StructType); ok {
+					case *ast.TypeSpec:
+						if structType, ok := spec.Type.(*ast.StructType); ok {
 							typeDoc := pkgDoc.typeDoc(spec.Name.Name)
 							typeDoc.Doc = doc
 							for _, field := range structType.Fields.List {
@@ -104,7 +104,7 @@ func NewXGo(pkgPath string, pkg *xgoast.Package) *PkgDoc {
 								}
 
 								if len(field.Names) == 0 {
-									ident, ok := field.Type.(*xgoast.Ident)
+									ident, ok := field.Type.(*ast.Ident)
 									if !ok {
 										continue
 									}
@@ -118,7 +118,7 @@ func NewXGo(pkgPath string, pkg *xgoast.Package) *PkgDoc {
 						}
 					}
 				}
-			case *xgoast.FuncDecl:
+			case *ast.FuncDecl:
 				if decl.Shadow {
 					continue
 				}
@@ -133,10 +133,10 @@ func NewXGo(pkgPath string, pkg *xgoast.Package) *PkgDoc {
 					recvTypeDoc = spxBaseSelectorTypeDoc
 				} else if len(decl.Recv.List) == 1 {
 					recvType := decl.Recv.List[0].Type
-					if star, ok := recvType.(*xgoast.StarExpr); ok {
+					if star, ok := recvType.(*ast.StarExpr); ok {
 						recvType = star.X
 					}
-					if recvIdent, ok := recvType.(*xgoast.Ident); ok {
+					if recvIdent, ok := recvType.(*ast.Ident); ok {
 						recvTypeDoc = pkgDoc.typeDoc(recvIdent.Name)
 					}
 				}

--- a/xgo/ast_test.go
+++ b/xgo/ast_test.go
@@ -90,8 +90,10 @@ func Test() {
 		require.NoError(t, err2)
 		require.NotNil(t, cache2)
 
-		astFileCache1 := cache1.(*astFileCache)
-		astFileCache2 := cache2.(*astFileCache)
+		astFileCache1, ok := cache1.(*astFileCache)
+		require.True(t, ok)
+		astFileCache2, ok := cache2.(*astFileCache)
+		require.True(t, ok)
 		assert.NotNil(t, astFileCache1.astFile)
 		assert.NotNil(t, astFileCache2.astFile)
 	})

--- a/xgo/cache_test.go
+++ b/xgo/cache_test.go
@@ -28,6 +28,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func requireMapStringAny(t *testing.T, data any) map[string]any {
+	t.Helper()
+
+	result, ok := data.(map[string]any)
+	require.True(t, ok, "want map[string]any, got %T", data)
+	return result
+}
+
 func TestProjectRegisterCacheBuilder(t *testing.T) {
 	t.Run("RegisterNewCacheBuilder", func(t *testing.T) {
 		proj := NewProject(nil, nil, 0)
@@ -145,7 +153,7 @@ func TestProjectRegisterCacheBuilder(t *testing.T) {
 		data, err := proj.Cache(testCacheKind{})
 		require.NoError(t, err)
 
-		result := data.(map[string]any)
+		result := requireMapStringAny(t, data)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
 		assert.Equal(t, 2, result["file_count"])
 	})
@@ -277,7 +285,7 @@ func TestProjectRegisterFileCacheBuilder(t *testing.T) {
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
 		require.NoError(t, err)
 
-		result := data.(map[string]any)
+		result := requireMapStringAny(t, data)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
 		assert.Equal(t, "test.go", result["file_path"])
 		assert.Equal(t, len("package test\n\nfunc test() {}"), result["content_len"])
@@ -440,11 +448,11 @@ func TestProjectCache(t *testing.T) {
 		data, err := proj.Cache(testCacheKind{})
 		require.NoError(t, err)
 
-		result := data.(map[string]any)
+		result := requireMapStringAny(t, data)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
 		assert.Equal(t, 2, result["file_count"])
-		expectedSize := len("package main") + len("package main\n\nfunc test() {}")
-		assert.Equal(t, expectedSize, result["total_size"])
+		wantSize := len("package main") + len("package main\n\nfunc test() {}")
+		assert.Equal(t, wantSize, result["total_size"])
 	})
 
 	t.Run("ConcurrentCacheBuildingPreventsDuplication", func(t *testing.T) {
@@ -724,7 +732,7 @@ func TestProjectFileCache(t *testing.T) {
 		data, err := proj.FileCache(testCacheKind{}, "test.go")
 		require.NoError(t, err)
 
-		result := data.(map[string]any)
+		result := requireMapStringAny(t, data)
 		assert.Equal(t, "example.com/test", result["pkg_path"])
 		assert.Equal(t, "test.go", result["file_path"])
 		assert.Equal(t, "package test\n\nfunc test() {}", result["content"])

--- a/xgo/project_test.go
+++ b/xgo/project_test.go
@@ -38,7 +38,7 @@ func TestNewProject(t *testing.T) {
 		require.NotNil(t, proj)
 		assert.NotNil(t, proj.Fset)
 		assert.NotNil(t, proj.files)
-		assert.Len(t, proj.files, 0)
+		assert.Empty(t, proj.files)
 		assert.NotNil(t, proj.cacheBuilders)
 		assert.NotNil(t, proj.caches)
 		assert.NotNil(t, proj.fileCacheBuilders)
@@ -55,7 +55,7 @@ func TestNewProject(t *testing.T) {
 	t.Run("WithNilFiles", func(t *testing.T) {
 		proj := NewProject(nil, nil, 0)
 		assert.NotNil(t, proj.files)
-		assert.Len(t, proj.files, 0)
+		assert.Empty(t, proj.files)
 	})
 
 	t.Run("WithProvidedFiles", func(t *testing.T) {
@@ -79,8 +79,8 @@ func TestNewProject(t *testing.T) {
 
 	t.Run("WithNoFeatures", func(t *testing.T) {
 		proj := NewProject(nil, nil, 0)
-		assert.Len(t, proj.cacheBuilders, 0)
-		assert.Len(t, proj.fileCacheBuilders, 0)
+		assert.Empty(t, proj.cacheBuilders)
+		assert.Empty(t, proj.fileCacheBuilders)
 	})
 
 	t.Run("WithAllFeatures", func(t *testing.T) {
@@ -189,8 +189,8 @@ func TestProjectSnapshot(t *testing.T) {
 		snapshot := proj.Snapshot()
 
 		// Verify cache builders are copied.
-		assert.Equal(t, len(proj.cacheBuilders), len(snapshot.cacheBuilders))
-		assert.Equal(t, len(proj.fileCacheBuilders), len(snapshot.fileCacheBuilders))
+		assert.Len(t, snapshot.cacheBuilders, len(proj.cacheBuilders))
+		assert.Len(t, snapshot.fileCacheBuilders, len(proj.fileCacheBuilders))
 	})
 
 	t.Run("CachesAreCopied", func(t *testing.T) {
@@ -211,8 +211,8 @@ func TestProjectSnapshot(t *testing.T) {
 		snapshot := proj.Snapshot()
 
 		// Verify caches are copied.
-		assert.Equal(t, len(proj.caches), len(snapshot.caches))
-		assert.Equal(t, len(proj.fileCaches), len(snapshot.fileCaches))
+		assert.Len(t, snapshot.caches, len(proj.caches))
+		assert.Len(t, snapshot.fileCaches, len(proj.fileCaches))
 	})
 
 	t.Run("FilesSnapshotIsUpdated", func(t *testing.T) {
@@ -537,7 +537,10 @@ func TestProjectFile(t *testing.T) {
 		for range 100 {
 			wg.Go(func() {
 				f, ok := proj.File("test.go")
-				assert.True(t, ok)
+				if !ok {
+					assert.Fail(t, "file not found")
+					return
+				}
 				assert.Equal(t, []byte("package test"), f.Content)
 			})
 		}
@@ -634,7 +637,7 @@ func TestProjectPutFile(t *testing.T) {
 
 		// Get snapshot before adding.
 		snapshotBefore := proj.filesSnapshot.Load()
-		assert.Len(t, *snapshotBefore, 0)
+		assert.Empty(t, *snapshotBefore)
 
 		proj.PutFile("main.go", file("package main"))
 
@@ -744,7 +747,7 @@ func TestProjectDeleteFile(t *testing.T) {
 
 		// Verify files snapshot is empty.
 		snapshot := proj.filesSnapshot.Load()
-		assert.Len(t, *snapshot, 0)
+		assert.Empty(t, *snapshot)
 	})
 
 	t.Run("DeleteSameFileTwice", func(t *testing.T) {
@@ -1047,7 +1050,7 @@ func TestProjectUpdateFiles(t *testing.T) {
 
 		// Verify files snapshot is empty.
 		snapshot := proj.filesSnapshot.Load()
-		assert.Len(t, *snapshot, 0)
+		assert.Empty(t, *snapshot)
 	})
 
 	t.Run("UpdateFilesWithNilMap", func(t *testing.T) {
@@ -1073,7 +1076,7 @@ func TestProjectUpdateFiles(t *testing.T) {
 
 		// Get snapshot before update.
 		snapshotBefore := proj.filesSnapshot.Load()
-		assert.Len(t, *snapshotBefore, 0)
+		assert.Empty(t, *snapshotBefore)
 
 		newFiles := map[string]*File{
 			"main.go": file("package main"),
@@ -1171,14 +1174,14 @@ func TestProjectUpdateFilesSnapshot(t *testing.T) {
 
 		snapshot := proj.filesSnapshot.Load()
 		require.NotNil(t, snapshot)
-		assert.Len(t, *snapshot, 0)
+		assert.Empty(t, *snapshot)
 
 		// Update snapshot on empty project.
 		proj.updateFilesSnapshot()
 
 		updatedSnapshot := proj.filesSnapshot.Load()
 		require.NotNil(t, updatedSnapshot)
-		assert.Len(t, *updatedSnapshot, 0)
+		assert.Empty(t, *updatedSnapshot)
 	})
 
 	t.Run("SnapshotAfterFileRemoval", func(t *testing.T) {
@@ -1228,8 +1231,7 @@ func TestProjectUpdateFilesSnapshot(t *testing.T) {
 			for range 1000 {
 				currentSnapshot := snapshot
 				assert.Len(t, *currentSnapshot, 1)
-				_, ok := (*currentSnapshot)["initial.go"]
-				assert.True(t, ok)
+				assert.Contains(t, *currentSnapshot, "initial.go")
 			}
 		})
 

--- a/xgo/xgoutil/call_expr_test.go
+++ b/xgo/xgoutil/call_expr_test.go
@@ -155,7 +155,7 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 		got := CreateCallExprFromBranchStmt(typeInfo, stmt)
 		require.NotNil(t, got)
 		assert.Equal(t, ident, got.Fun)
-		assert.Len(t, got.Args, 1)
+		require.Len(t, got.Args, 1)
 		assert.Equal(t, stmt.Label, got.Args[0])
 	})
 }
@@ -318,7 +318,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 
 		WalkCallExprArgs(typeInfo, expr, walkFn)
 
-		assert.Len(t, walkCalls, 2)
+		require.Len(t, walkCalls, 2)
 		assert.Equal(t, 0, walkCalls[0].paramIndex)
 		assert.Equal(t, 0, walkCalls[0].argIndex)
 		assert.Equal(t, arg1, walkCalls[0].arg)
@@ -363,7 +363,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 
 		WalkCallExprArgs(typeInfo, expr, walkFn)
 
-		assert.Len(t, walkCalls, 3)
+		require.Len(t, walkCalls, 3)
 		assert.Equal(t, 0, walkCalls[0].paramIndex) // First param
 		assert.Equal(t, 0, walkCalls[0].argIndex)
 		assert.Equal(t, 1, walkCalls[1].paramIndex) // Variadic param
@@ -439,7 +439,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 		WalkCallExprArgs(typeInfo, expr, walkFn)
 
 		// Should skip the receiver parameter.
-		assert.Len(t, walkCalls, 1)
+		require.Len(t, walkCalls, 1)
 		assert.Equal(t, 0, walkCalls[0].paramIndex) // First non-receiver param index in new tuple.
 		assert.Equal(t, 0, walkCalls[0].argIndex)   // First arg.
 	})
@@ -511,7 +511,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 			return true
 		})
 
-		assert.Len(t, walkCalls, 2)
+		require.Len(t, walkCalls, 2)
 		assert.Equal(t, "T", walkCalls[0].paramName)
 		assert.Equal(t, 0, walkCalls[0].paramIndex)
 		assert.Equal(t, 0, walkCalls[0].argIndex)
@@ -556,7 +556,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 		WalkCallExprArgs(typeInfo, expr, walkFn)
 
 		// Should only process one argument since function is not variadic.
-		assert.Len(t, walkCalls, 1)
+		require.Len(t, walkCalls, 1)
 		assert.Equal(t, 0, walkCalls[0].paramIndex)
 		assert.Equal(t, 0, walkCalls[0].argIndex)
 	})

--- a/xgo/xgoutil/file_test.go
+++ b/xgo/xgoutil/file_test.go
@@ -30,7 +30,7 @@ func TestPosFilename(t *testing.T) {
 		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
-		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
+		xPos := requireValueSpec(t, requireGenDecl(t, astFile.Decls[0]).Specs[0]).Names[0].Pos()
 		filename := PosFilename(fset, xPos)
 		assert.Equal(t, "main.xgo", filename)
 	})
@@ -52,7 +52,7 @@ func TestNodeFilename(t *testing.T) {
 		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
-		xDecl := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0]
+		xDecl := requireValueSpec(t, requireGenDecl(t, astFile.Decls[0]).Specs[0]).Names[0]
 		filename := NodeFilename(fset, xDecl)
 		assert.Equal(t, "main.xgo", filename)
 	})
@@ -74,7 +74,7 @@ func TestPosTokenFile(t *testing.T) {
 		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
-		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
+		xPos := requireValueSpec(t, requireGenDecl(t, astFile.Decls[0]).Specs[0]).Names[0].Pos()
 		file := PosTokenFile(fset, xPos)
 		require.NotNil(t, file)
 		assert.Equal(t, "main.xgo", file.Name())
@@ -97,7 +97,7 @@ func TestNodeTokenFile(t *testing.T) {
 		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
-		xDecl := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0]
+		xDecl := requireValueSpec(t, requireGenDecl(t, astFile.Decls[0]).Specs[0]).Names[0]
 		file := NodeTokenFile(fset, xDecl)
 		require.NotNil(t, file)
 		assert.Equal(t, "main.xgo", file.Name())
@@ -121,7 +121,7 @@ func TestPosASTFile(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
+		xPos := requireValueSpec(t, requireGenDecl(t, astFile.Decls[0]).Specs[0]).Names[0].Pos()
 		file := PosASTFile(fset, astPkg, xPos)
 		assert.Equal(t, astFile, file)
 	})
@@ -152,7 +152,7 @@ func TestNodeASTFile(t *testing.T) {
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		xDecl := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0]
+		xDecl := requireValueSpec(t, requireGenDecl(t, astFile.Decls[0]).Specs[0]).Names[0]
 		file := NodeASTFile(fset, astPkg, xDecl)
 		assert.Equal(t, astFile, file)
 	})

--- a/xgo/xgoutil/func_test.go
+++ b/xgo/xgoutil/func_test.go
@@ -141,7 +141,7 @@ func TestSplitXGoxFuncName(t *testing.T) {
 	t.Run("OnlyPrefix", func(t *testing.T) {
 		funcName, ok := SplitXGoxFuncName("XGox_")
 		require.True(t, ok)
-		assert.Equal(t, "", funcName)
+		assert.Empty(t, funcName)
 	})
 
 	t.Run("EmptyString", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestParseXGoFuncName(t *testing.T) {
 
 	t.Run("EmptyString", func(t *testing.T) {
 		parsedName, overloadID := ParseXGoFuncName("")
-		assert.Equal(t, "", parsedName)
+		assert.Empty(t, parsedName)
 		assert.Nil(t, overloadID)
 	})
 
@@ -345,7 +345,7 @@ func TestExpandXGoOverloadableFunc(t *testing.T) {
 		fun := gogen.NewOverloadFunc(token.NoPos, pkg, "TestFunc", overload1, overload2)
 
 		expanded := ExpandXGoOverloadableFunc(fun)
-		assert.Len(t, expanded, 2)
+		require.Len(t, expanded, 2)
 		assert.Same(t, overload1, expanded[0])
 		assert.Same(t, overload2, expanded[1])
 	})

--- a/xgo/xgoutil/scope_test.go
+++ b/xgo/xgoutil/scope_test.go
@@ -61,7 +61,7 @@ func TestInnermostScopeAt(t *testing.T) {
 			astFile: packageScope,
 		}
 
-		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
+		xPos := requireValueSpec(t, requireGenDecl(t, astFile.Decls[0]).Specs[0]).Names[0].Pos()
 		scope := InnermostScopeAt(fset, typeInfo, astPkg, xPos)
 		require.NotNil(t, scope)
 
@@ -81,7 +81,7 @@ func TestInnermostScopeAt(t *testing.T) {
 		functionScope.Insert(yVar)
 
 		typeInfo := newTestTypeInfo(nil, nil)
-		funcDecl := astFile.Decls[0].(*ast.FuncDecl)
+		funcDecl := requireFuncDecl(t, astFile.Decls[0])
 		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile:       packageScope,
 			funcDecl.Body: functionScope,
@@ -107,7 +107,7 @@ func TestInnermostScopeAt(t *testing.T) {
 		blockScope.Insert(zVar)
 
 		// Find the if statement body.
-		funcDecl := astFile.Decls[0].(*ast.FuncDecl)
+		funcDecl := requireFuncDecl(t, astFile.Decls[0])
 		var ifBody *ast.BlockStmt
 		for _, stmt := range funcDecl.Body.List {
 			if ifStmt, ok := stmt.(*ast.IfStmt); ok {
@@ -142,7 +142,7 @@ func TestInnermostScopeAt(t *testing.T) {
 		paramVar := gotypes.NewVar(token.NoPos, pkg, "param", gotypes.Typ[gotypes.Int])
 		functionScope.Insert(paramVar)
 
-		funcDecl := astFile.Decls[0].(*ast.FuncDecl)
+		funcDecl := requireFuncDecl(t, astFile.Decls[0])
 		typeInfo := newTestTypeInfo(nil, nil)
 		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
 			astFile:       packageScope,
@@ -168,9 +168,9 @@ func TestInnermostScopeAt(t *testing.T) {
 		functionScope.Insert(paramVar)
 
 		// Extract the function literal from the variable declaration.
-		genDecl := astFile.Decls[0].(*ast.GenDecl)
-		valueSpec := genDecl.Specs[0].(*ast.ValueSpec)
-		funcLit := valueSpec.Values[0].(*ast.FuncLit)
+		genDecl := requireGenDecl(t, astFile.Decls[0])
+		valueSpec := requireValueSpec(t, genDecl.Specs[0])
+		funcLit := requireFuncLit(t, valueSpec.Values[0])
 
 		typeInfo := newTestTypeInfo(nil, nil)
 		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
@@ -197,9 +197,9 @@ func TestInnermostScopeAt(t *testing.T) {
 		functionScope.Insert(localVar)
 
 		// Extract the function literal from the variable declaration.
-		genDecl := astFile.Decls[0].(*ast.GenDecl)
-		valueSpec := genDecl.Specs[0].(*ast.ValueSpec)
-		funcLit := valueSpec.Values[0].(*ast.FuncLit)
+		genDecl := requireGenDecl(t, astFile.Decls[0])
+		valueSpec := requireValueSpec(t, genDecl.Specs[0])
+		funcLit := requireFuncLit(t, valueSpec.Values[0])
 
 		typeInfo := newTestTypeInfo(nil, nil)
 		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{
@@ -225,9 +225,9 @@ func TestInnermostScopeAt(t *testing.T) {
 		functionScope := gotypes.NewScope(packageScope, token.NoPos, token.NoPos, "function")
 		functionScope.Insert(gotypes.NewVar(token.NoPos, pkg, "local", gotypes.Typ[gotypes.Int]))
 
-		genDecl := astFile.Decls[0].(*ast.GenDecl)
-		valueSpec := genDecl.Specs[0].(*ast.ValueSpec)
-		funcLit := valueSpec.Values[0].(*ast.FuncLit)
+		genDecl := requireGenDecl(t, astFile.Decls[0])
+		valueSpec := requireValueSpec(t, genDecl.Specs[0])
+		funcLit := requireFuncLit(t, valueSpec.Values[0])
 
 		typeInfo := newTestTypeInfo(nil, nil)
 		typeInfo.Scopes = map[ast.Node]*gotypes.Scope{

--- a/xgo/xgoutil/xgoutil_test.go
+++ b/xgo/xgoutil/xgoutil_test.go
@@ -71,6 +71,54 @@ func newTestTypeInfo(defs map[*ast.Ident]gotypes.Object, uses map[*ast.Ident]got
 	}
 }
 
+func requireTypeSpec(t *testing.T, spec ast.Spec) *ast.TypeSpec {
+	t.Helper()
+
+	typeSpec, ok := spec.(*ast.TypeSpec)
+	require.True(t, ok, "want *ast.TypeSpec, got %T", spec)
+	return typeSpec
+}
+
+func requireGenDecl(t *testing.T, decl ast.Decl) *ast.GenDecl {
+	t.Helper()
+
+	genDecl, ok := decl.(*ast.GenDecl)
+	require.True(t, ok, "want *ast.GenDecl, got %T", decl)
+	return genDecl
+}
+
+func requireFuncDecl(t *testing.T, decl ast.Decl) *ast.FuncDecl {
+	t.Helper()
+
+	funcDecl, ok := decl.(*ast.FuncDecl)
+	require.True(t, ok, "want *ast.FuncDecl, got %T", decl)
+	return funcDecl
+}
+
+func requireValueSpec(t *testing.T, spec ast.Spec) *ast.ValueSpec {
+	t.Helper()
+
+	valueSpec, ok := spec.(*ast.ValueSpec)
+	require.True(t, ok, "want *ast.ValueSpec, got %T", spec)
+	return valueSpec
+}
+
+func requireFuncLit(t *testing.T, expr ast.Expr) *ast.FuncLit {
+	t.Helper()
+
+	funcLit, ok := expr.(*ast.FuncLit)
+	require.True(t, ok, "want *ast.FuncLit, got %T", expr)
+	return funcLit
+}
+
+func requireImportSpec(t *testing.T, spec ast.Spec) *ast.ImportSpec {
+	t.Helper()
+
+	importSpec, ok := spec.(*ast.ImportSpec)
+	require.True(t, ok, "want *ast.ImportSpec, got %T", spec)
+	return importSpec
+}
+
 func newTestFuncExSignature(pkg *gotypes.Package, recv *gotypes.Var, typ gotypes.Type) *gotypes.Signature {
 	methodSig := gotypes.NewSignatureType(gotypes.NewVar(token.NoPos, nil, "", typ), nil, nil, nil, nil, false)
 	paramType := gotypes.NewInterfaceType([]*gotypes.Func{
@@ -127,7 +175,7 @@ func TestRangeASTSpecs(t *testing.T) {
 		})
 
 		require.Len(t, specs, 1)
-		ts := specs[0].(*ast.TypeSpec)
+		ts := requireTypeSpec(t, specs[0])
 		assert.Equal(t, "A", ts.Name.Name)
 		assert.NotEqual(t, token.NoPos, ts.Assign)
 	})
@@ -153,7 +201,7 @@ type (
 		require.Len(t, specs, 3)
 		names := make([]string, len(specs))
 		for i, spec := range specs {
-			ts := spec.(*ast.TypeSpec)
+			ts := requireTypeSpec(t, spec)
 			names[i] = ts.Name.Name
 		}
 		assert.Contains(t, names, "A")
@@ -179,7 +227,7 @@ var (
 		require.Len(t, specs, 2)
 		names := make([]string, len(specs))
 		for i, spec := range specs {
-			vs := spec.(*ast.ValueSpec)
+			vs := requireValueSpec(t, spec)
 			names[i] = vs.Names[0].Name
 		}
 		assert.Contains(t, names, "x")
@@ -204,7 +252,7 @@ const (
 		require.Len(t, specs, 2)
 		names := make([]string, len(specs))
 		for i, spec := range specs {
-			vs := spec.(*ast.ValueSpec)
+			vs := requireValueSpec(t, spec)
 			names[i] = vs.Names[0].Name
 		}
 		assert.Contains(t, names, "Pi")
@@ -230,7 +278,7 @@ const (
 		require.Len(t, specs, 2)
 		names := make([]string, len(specs))
 		for i, spec := range specs {
-			ts := spec.(*ast.TypeSpec)
+			ts := requireTypeSpec(t, spec)
 			names[i] = ts.Name.Name
 		}
 		assert.Contains(t, names, "MainType")
@@ -247,7 +295,7 @@ const (
 			specs = append(specs, spec)
 		})
 
-		assert.Len(t, specs, 0)
+		assert.Empty(t, specs)
 	})
 
 	t.Run("EmptyPackage", func(t *testing.T) {
@@ -258,7 +306,7 @@ const (
 			specs = append(specs, spec)
 		})
 
-		assert.Len(t, specs, 0)
+		assert.Empty(t, specs)
 	})
 
 	t.Run("MixedDeclarations", func(t *testing.T) {
@@ -285,13 +333,13 @@ func myFunc() {}`)
 			constSpecs = append(constSpecs, spec)
 		})
 
-		assert.Len(t, typeSpecs, 1)
-		assert.Len(t, varSpecs, 1)
-		assert.Len(t, constSpecs, 1)
+		require.Len(t, typeSpecs, 1)
+		require.Len(t, varSpecs, 1)
+		require.Len(t, constSpecs, 1)
 
-		assert.Equal(t, "MyType", typeSpecs[0].(*ast.TypeSpec).Name.Name)
-		assert.Equal(t, "myVar", varSpecs[0].(*ast.ValueSpec).Names[0].Name)
-		assert.Equal(t, "myConst", constSpecs[0].(*ast.ValueSpec).Names[0].Name)
+		assert.Equal(t, "MyType", requireTypeSpec(t, typeSpecs[0]).Name.Name)
+		assert.Equal(t, "myVar", requireValueSpec(t, varSpecs[0]).Names[0].Name)
+		assert.Equal(t, "myConst", requireValueSpec(t, constSpecs[0]).Names[0].Name)
 	})
 
 	t.Run("ImportSpecs", func(t *testing.T) {
@@ -312,7 +360,7 @@ import (
 		require.Len(t, specs, 2)
 		paths := make([]string, len(specs))
 		for i, spec := range specs {
-			is := spec.(*ast.ImportSpec)
+			is := requireImportSpec(t, spec)
 			paths[i] = is.Path.Value
 		}
 		assert.Contains(t, paths, `"fmt"`)
@@ -325,7 +373,7 @@ import (
 			specs = append(specs, spec)
 		})
 
-		assert.Len(t, specs, 0)
+		assert.Empty(t, specs)
 	})
 }
 
@@ -494,7 +542,7 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 			nodes = append(nodes, node)
 			return false // Stop after first node.
 		})
-		assert.Len(t, nodes, 1)
+		require.Len(t, nodes, 1)
 	})
 
 	t.Run("EmptyInterval", func(t *testing.T) {
@@ -506,7 +554,7 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 			nodes = append(nodes, node)
 			return true
 		})
-		assert.Len(t, nodes, 1) // Should still return at least the file node.
+		require.Len(t, nodes, 1) // Should still return at least the file node.
 	})
 
 	t.Run("WalkBackward", func(t *testing.T) {
@@ -537,7 +585,7 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 
 		require.NotEmpty(t, forwardNodes)
 		require.NotEmpty(t, backwardNodes)
-		require.Equal(t, len(forwardNodes), len(backwardNodes))
+		require.Len(t, backwardNodes, len(forwardNodes))
 
 		// Backward walk should return nodes in reverse order.
 		for i := range forwardNodes {
@@ -765,7 +813,7 @@ func test() {
 		path, _ := PathEnclosingInterval(astFile, xIdent.Pos(), xIdent.End())
 		block := EnclosingNode[*ast.BlockStmt](path)
 		require.NotNil(t, block)
-		assert.Len(t, block.List, 1)
+		require.Len(t, block.List, 1)
 	})
 
 	t.Run("FunctionLiteral", func(t *testing.T) {
@@ -1006,7 +1054,7 @@ func foo() string {
 
 func TestToLowerCamelCase(t *testing.T) {
 	t.Run("EmptyString", func(t *testing.T) {
-		assert.Equal(t, "", ToLowerCamelCase(""))
+		assert.Empty(t, ToLowerCamelCase(""))
 	})
 
 	t.Run("SingleCharacterUpper", func(t *testing.T) {
@@ -1047,7 +1095,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 
 		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(strLit, tv)
-		require.True(t, ok)
+		require.True(t, ok, "want string literal to be accepted")
 		assert.Equal(t, "literal", value)
 	})
 
@@ -1056,7 +1104,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 		tv := gotypes.TypeAndValue{Value: constant.MakeString("constant value")}
 
 		value, ok := StringLitOrConstValue(ident, tv)
-		require.True(t, ok)
+		require.True(t, ok, "want string constant to be accepted")
 		assert.Equal(t, "constant value", value)
 	})
 
@@ -1066,7 +1114,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
-		assert.Equal(t, "", value)
+		assert.Empty(t, value)
 	})
 
 	t.Run("NonStringLiteral", func(t *testing.T) {
@@ -1078,7 +1126,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(intLit, tv)
 		assert.False(t, ok)
-		assert.Equal(t, "", value)
+		assert.Empty(t, value)
 	})
 
 	t.Run("NonStringConstant", func(t *testing.T) {
@@ -1087,7 +1135,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
-		assert.Equal(t, "", value)
+		assert.Empty(t, value)
 	})
 
 	t.Run("InvalidStringLiteral", func(t *testing.T) {
@@ -1099,7 +1147,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(invalidLit, tv)
 		assert.False(t, ok)
-		assert.Equal(t, "", value)
+		assert.Empty(t, value)
 	})
 
 	t.Run("UnsupportedExpression", func(t *testing.T) {
@@ -1112,7 +1160,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 		tv := gotypes.TypeAndValue{}
 		value, ok := StringLitOrConstValue(binExpr, tv)
 		assert.False(t, ok)
-		assert.Equal(t, "", value)
+		assert.Empty(t, value)
 	})
 
 	t.Run("IdentWithNilValue", func(t *testing.T) {
@@ -1120,7 +1168,7 @@ func TestStringLitOrConstValue(t *testing.T) {
 		tv := gotypes.TypeAndValue{Value: nil}
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
-		assert.Equal(t, "", value)
+		assert.Empty(t, value)
 	})
 
 	t.Run("IdentWithNonStringConstant", func(t *testing.T) {
@@ -1128,6 +1176,6 @@ func TestStringLitOrConstValue(t *testing.T) {
 		tv := gotypes.TypeAndValue{Value: constant.MakeInt64(42)}
 		value, ok := StringLitOrConstValue(ident, tv)
 		assert.False(t, ok)
-		assert.Equal(t, "", value)
+		assert.Empty(t, value)
 	})
 }


### PR DESCRIPTION
Apply the project-wide import alias convention so XGo packages keep simple package names and standard library counterparts use `go`-prefixed aliases.

Update tests to follow the documented assertion, naming, helper, and type assertion conventions while preserving existing coverage.