### PR TITLE
fix(server): align signature help with spx definitions

### DIFF
--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -25,6 +25,7 @@ const (
 	CommandXGoGetProperties   = "xgo.getProperties"
 )
 
+// xgoPropertyKindPriority defines the presentation order for XGo properties.
 var xgoPropertyKindPriority = map[XGoPropertyKind]int{
 	XGoPropertyKindField:  0,
 	XGoPropertyKindMethod: 1,
@@ -272,7 +273,7 @@ func walkPropertyMembers(namedType *gotypes.Named, pkgDocFor func(*gotypes.Packa
 			continue
 		}
 		seenNames[name] = true
-		sig := method.Type().(*gotypes.Signature)
+		sig := method.Signature()
 		onMember(propertyMember{
 			Name:   name,
 			Type:   sig.Results().At(0).Type(),
@@ -361,10 +362,7 @@ func isPropertyMethod(method *gotypes.Func) bool {
 	if method.Name() != "" && unicode.IsLower(rune(method.Name()[0])) {
 		return false
 	}
-	sig, ok := method.Type().(*gotypes.Signature)
-	if !ok {
-		return false
-	}
+	sig := method.Signature()
 	// Only include methods with no parameters and exactly one return value
 	if sig.Params().Len() != 0 || sig.Results().Len() != 1 {
 		return false
@@ -453,11 +451,8 @@ func findEnclosingTypeForField(field *gotypes.Var) *gotypes.Named {
 			continue
 		}
 
-		// Check if this struct directly contains the field
-		// Use pointer equality for field comparison (most efficient)
-		numFields := structType.NumFields()
-		for i := 0; i < numFields; i++ {
-			if structType.Field(i) == field {
+		for structField := range structType.Fields() {
+			if structField == field {
 				return namedType
 			}
 		}
@@ -474,14 +469,7 @@ func findEnclosingTypeForMethod(method *gotypes.Func) *gotypes.Named {
 		return nil
 	}
 
-	// Note: According to go/types documentation, Func.Type() is always a *Signature.
-	// This check is defensive programming for potential internal errors.
-	sig, ok := method.Type().(*gotypes.Signature)
-	if !ok {
-		return nil
-	}
-
-	recv := sig.Recv()
+	recv := method.Signature().Recv()
 	if recv == nil {
 		return nil
 	}
@@ -725,7 +713,7 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 	seenNames := make(map[string]struct{})
 	addNameOf := func(obj gotypes.Object) {
 		name := obj.Name()
-		switch obj.(type) {
+		switch obj := obj.(type) {
 		case *gotypes.Var, *gotypes.Const:
 			if typ := obj.Type(); typ != nil && declaredType != nil && !gotypes.AssignableTo(typ, declaredType) {
 				return
@@ -740,7 +728,7 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 			if declaredType != nil {
 				// For functions with no parameters and exactly one return value,
 				// check if the return type is assignable to the declared type.
-				funcSig := obj.Type().(*gotypes.Signature)
+				funcSig := obj.Signature()
 				if funcSig.Params().Len() != 0 || funcSig.Results().Len() != 1 {
 					return
 				}
@@ -793,7 +781,7 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 					case *gotypes.Func:
 						// Add methods with no parameters and exactly one return value.
 						// For example, the method `Game.BackdropName` can be used in `echo backdropname`.
-						funcSig := member.Type().(*gotypes.Signature)
+						funcSig := member.Signature()
 						if funcSig.Params().Len() == 0 && funcSig.Results().Len() == 1 {
 							addNameOf(member)
 						}

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -2520,22 +2520,15 @@ func onStart() {
 			}
 		}
 
-		// Test with a free function (helper function without receiver)
 		helperFuncObj := pkg.Scope().Lookup("helperFunction")
 		if helperFuncObj != nil {
 			funcObj, ok := helperFuncObj.(*gotypes.Func)
-			if ok {
-				// Check if it has a receiver
-				sig, ok := funcObj.Type().(*gotypes.Signature)
-				if ok && sig.Recv() == nil {
-					// Test findEnclosingType with free function
-					enclosingType := findEnclosingType(funcObj)
-					assert.Nil(t, enclosingType, "findEnclosingType for free function should return nil")
+			if ok && funcObj.Signature().Recv() == nil {
+				enclosingType := findEnclosingType(funcObj)
+				assert.Nil(t, enclosingType, "findEnclosingType for free function should return nil")
 
-					// Test findEnclosingTypeForMethod directly with free function
-					enclosingType = findEnclosingTypeForMethod(funcObj)
-					assert.Nil(t, enclosingType, "findEnclosingTypeForMethod for free function should return nil")
-				}
+				enclosingType = findEnclosingTypeForMethod(funcObj)
+				assert.Nil(t, enclosingType, "findEnclosingTypeForMethod for free function should return nil")
 			}
 		}
 	})

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -914,7 +914,7 @@ func (ctx *completionContext) enclosingFunction(path []ast.Node) *gotypes.Signat
 			if !ok {
 				continue
 			}
-			return fun.Type().(*gotypes.Signature)
+			return fun.Signature()
 		case *ast.FuncLit:
 			// For function literals, get the type from the type info directly.
 			if typ := ctx.typeInfo.TypeOf(n); xgoutil.IsValidType(typ) {
@@ -1215,8 +1215,8 @@ func (ctx *completionContext) resolvePropertyLikeFuncResultType(ident *ast.Ident
 				continue
 			}
 
-			sig, ok := fun.Type().(*gotypes.Signature)
-			if !ok || sig.Params().Len() != 0 || sig.Results().Len() != 1 {
+			sig := fun.Signature()
+			if sig.Params().Len() != 0 || sig.Results().Len() != 1 {
 				continue
 			}
 			return sig.Results().At(0).Type()
@@ -1340,7 +1340,7 @@ func (ctx *completionContext) collectCall() error {
 		if len(funcOverloads) > 0 {
 			expectedTypes := make([]gotypes.Type, 0, len(funcOverloads))
 			for _, funcOverload := range funcOverloads {
-				sig := funcOverload.Type().(*gotypes.Signature)
+				sig := funcOverload.Signature()
 				if argIndex < sig.Params().Len() {
 					expectedTypes = append(expectedTypes, sig.Params().At(argIndex).Type())
 				} else if sig.Variadic() && argIndex >= sig.Params().Len()-1 {

--- a/internal/server/implementation.go
+++ b/internal/server/implementation.go
@@ -27,10 +27,12 @@ func (s *Server) textDocumentImplementation(params *ImplementationParams) (any, 
 		return nil, nil
 	}
 
-	if method, ok := obj.(*gotypes.Func); ok && method.Type().(*gotypes.Signature).Recv() != nil {
-		if recv := method.Type().(*gotypes.Signature).Recv().Type(); gotypes.IsInterface(recv) {
-			locations := s.findImplementingMethodDefinitions(result, recv.(*gotypes.Interface), method.Name())
-			return DedupeLocations(locations), nil
+	if method, ok := obj.(*gotypes.Func); ok {
+		if recv := method.Signature().Recv(); recv != nil {
+			if recvType := recv.Type(); gotypes.IsInterface(recvType) {
+				locations := s.findImplementingMethodDefinitions(result, recvType.(*gotypes.Interface), method.Name())
+				return DedupeLocations(locations), nil
+			}
 		}
 	}
 

--- a/internal/server/reference.go
+++ b/internal/server/reference.go
@@ -33,7 +33,7 @@ func (s *Server) textDocumentReferences(params *ReferenceParams) ([]Location, er
 
 	locations = append(locations, s.findReferenceLocations(result, obj)...)
 
-	if fn, ok := obj.(*gotypes.Func); ok && fn.Type().(*gotypes.Signature).Recv() != nil {
+	if fn, ok := obj.(*gotypes.Func); ok && fn.Signature().Recv() != nil {
 		locations = append(locations, s.handleMethodReferences(result, fn)...)
 		locations = append(locations, s.handleEmbeddedFieldReferences(result, obj)...)
 	}
@@ -77,7 +77,7 @@ func (s *Server) findReferenceLocations(result *compileResult, obj gotypes.Objec
 // implementations and interface method references.
 func (s *Server) handleMethodReferences(result *compileResult, fn *gotypes.Func) []Location {
 	var locations []Location
-	recvType := fn.Type().(*gotypes.Signature).Recv().Type()
+	recvType := fn.Signature().Recv().Type()
 	if gotypes.IsInterface(recvType) {
 		iface, ok := recvType.(*gotypes.Interface)
 		if !ok {
@@ -180,7 +180,7 @@ func (s *Server) findInterfaceMethodReferences(result *compileResult, fn *gotype
 		return nil
 	}
 	var locations []Location
-	recvType := fn.Type().(*gotypes.Signature).Recv().Type()
+	recvType := fn.Signature().Recv().Type()
 	seenIfaces := make(map[*gotypes.Interface]bool)
 	astPkg, _ := result.proj.ASTPackage()
 
@@ -218,7 +218,7 @@ func (s *Server) handleEmbeddedFieldReferences(result *compileResult, obj gotype
 	}
 	var locations []Location
 	if fn, ok := obj.(*gotypes.Func); ok {
-		recv := fn.Type().(*gotypes.Signature).Recv()
+		recv := fn.Signature().Recv()
 		if recv == nil {
 			return nil
 		}

--- a/internal/server/semantic_token.go
+++ b/internal/server/semantic_token.go
@@ -175,7 +175,7 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 				tokenType = VariableType
 				modifiers = append(modifiers, ModStatic, ModReadonly)
 			case *gotypes.Func:
-				if obj.Type().(*gotypes.Signature).Recv() != nil {
+				if obj.Signature().Recv() != nil {
 					tokenType = MethodType
 				} else {
 					tokenType = FunctionType

--- a/internal/server/signature.go
+++ b/internal/server/signature.go
@@ -32,42 +32,27 @@ func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*Signat
 	if !ok {
 		return nil, nil
 	}
-	sig, ok := fun.Type().(*gotypes.Signature)
-	if !ok {
-		return nil, nil
-	}
 
-	var paramsInfo []ParameterInformation
-	for param := range sig.Params().Variables() {
-		paramsInfo = append(paramsInfo, ParameterInformation{
-			Label: param.Name() + " " + GetSimplifiedTypeString(param.Type()),
+	return &SignatureHelp{
+		Signatures: []SignatureInformation{signatureHelpInformation(fun)},
+	}, nil
+}
+
+// signatureHelpInformation returns signature information for fun.
+func signatureHelpInformation(fun *gotypes.Func) SignatureInformation {
+	sig := fun.Signature()
+	_, displayedName, _, isXGotMethod := displayedFuncName(fun)
+	paramLabels := displayedFuncParamLabels(sig, isXGotMethod)
+	paramInfos := make([]ParameterInformation, 0, len(paramLabels))
+	for _, paramLabel := range paramLabels {
+		paramInfos = append(paramInfos, ParameterInformation{
+			Label: paramLabel,
 			// TODO: Add documentation.
 		})
 	}
 
-	label := fun.Name() + "("
-	if sig.Params().Len() > 0 {
-		var paramLabels []string
-		for _, p := range paramsInfo {
-			paramLabels = append(paramLabels, p.Label)
-		}
-		label += strings.Join(paramLabels, ", ")
+	return SignatureInformation{
+		Label:      displayedName + "(" + strings.Join(paramLabels, ", ") + ")" + displayedFuncResults(sig.Results()),
+		Parameters: paramInfos,
 	}
-	label += ")"
-
-	if results := sig.Results(); results != nil && results.Len() > 0 {
-		var returnTypes []string
-		for result := range results.Variables() {
-			returnTypes = append(returnTypes, GetSimplifiedTypeString(result.Type()))
-		}
-		label += " (" + strings.Join(returnTypes, ", ") + ")"
-	}
-
-	return &SignatureHelp{
-		Signatures: []SignatureInformation{{
-			Label: label,
-			// TODO: Add documentation.
-			Parameters: paramsInfo,
-		}},
-	}, nil
 }

--- a/internal/server/signature_test.go
+++ b/internal/server/signature_test.go
@@ -25,20 +25,121 @@ onStart => {
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
 
-		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+		fmtHelp, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
 				Position:     Position{Line: 2, Character: 10},
 			},
 		})
 		require.NoError(t, err)
+		require.NotNil(t, fmtHelp)
+		require.Len(t, fmtHelp.Signatures, 1)
+		assert.Equal(t, SignatureInformation{
+			Label: "println(a ...any) (n int, err error)",
+			Parameters: []ParameterInformation{
+				{
+					Label: "a ...any",
+				},
+			},
+		}, fmtHelp.Signatures[0])
+
+		turnHelp, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 3, Character: 10},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, turnHelp)
+		require.Len(t, turnHelp.Signatures, 1)
+		assert.Equal(t, SignatureInformation{
+			Label: "turn(dir Direction)",
+			Parameters: []ParameterInformation{
+				{
+					Label: "dir Direction",
+				},
+			},
+		}, turnHelp.Signatures[0])
+	})
+
+	t.Run("SingleResult", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+func answer() int { return 42 }
+
+onStart => {
+	answer
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 4, Character: 4},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, help)
+		require.Len(t, help.Signatures, 1)
+		assert.Equal(t, "answer() int", help.Signatures[0].Label)
+		assert.Empty(t, help.Signatures[0].Parameters)
+	})
+
+	t.Run("SingleNamedResult", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+func answer() (n int) { return 42 }
+
+onStart => {
+	answer
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 4, Character: 4},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, help)
+		require.Len(t, help.Signatures, 1)
+		assert.Equal(t, "answer() (n int)", help.Signatures[0].Label)
+		assert.Empty(t, help.Signatures[0].Parameters)
+	})
+
+	t.Run("XGoxMethod", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	getWidget Monitor, "myWidget"
+}
+`),
+			"assets/index.json": []byte(`{"zorder":[{"name":"myWidget"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 1},
+			},
+		})
+		require.NoError(t, err)
 		require.NotNil(t, help)
 		require.Len(t, help.Signatures, 1)
 		assert.Equal(t, SignatureInformation{
-			Label: "Println(a []any) (int, error)",
+			Label: "getWidget(T Type, name WidgetName) *T",
 			Parameters: []ParameterInformation{
 				{
-					Label: "a []any",
+					Label: "T Type",
+				},
+				{
+					Label: "name WidgetName",
 				},
 			},
 		}, help.Signatures[0])

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -844,29 +844,21 @@ func GetSpxDefinitionForFunc(fun *gotypes.Func, recvTypeName string, pkgDoc *pkg
 	return
 }
 
-// makeSpxDefinitionOverviewForFunc makes an overview string for a function that
-// is used in [SpxDefinition].
-func makeSpxDefinitionOverviewForFunc(fun *gotypes.Func) (overview, parsedRecvTypeName, parsedName string, overloadID *string) {
+// displayedFuncName resolves the source-facing function display name used by
+// spx UI surfaces.
+func displayedFuncName(fun *gotypes.Func) (parsedRecvTypeName, parsedName string, overloadID *string, isXGotMethod bool) {
 	isXGoPkg := xgoutil.IsMarkedAsXGoPackage(fun.Pkg())
 	name := fun.Name()
-	sig := fun.Type().(*gotypes.Signature)
+	sig := fun.Signature()
 
-	var sb strings.Builder
-	sb.WriteString("func ")
-
-	var isXGotMethod bool
 	if recv := sig.Recv(); recv != nil {
 		recvType := xgoutil.DerefType(recv.Type())
 		if named, ok := recvType.(*gotypes.Named); ok {
 			parsedRecvTypeName = named.Obj().Name()
 		}
-	} else if isXGoPkg {
-		switch {
-		case strings.HasPrefix(name, xgoutil.XGotPrefix):
-			recvTypeName, methodName, ok := xgoutil.SplitXGotMethodName(name, true)
-			if !ok {
-				break
-			}
+	} else if isXGoPkg && strings.HasPrefix(name, xgoutil.XGotPrefix) {
+		recvTypeName, methodName, ok := xgoutil.SplitXGotMethodName(name, true)
+		if ok {
 			parsedRecvTypeName = recvTypeName
 			name = methodName
 			isXGotMethod = true
@@ -879,8 +871,39 @@ func makeSpxDefinitionOverviewForFunc(fun *gotypes.Func) (overview, parsedRecvTy
 	} else if !xgoutil.IsInMainPkg(fun) {
 		parsedName = xgoutil.ToLowerCamelCase(parsedName)
 	}
-	sb.WriteString(parsedName)
-	sb.WriteString("(")
+	return
+}
+
+// displayedFuncResults formats the source-facing result list for function
+// signatures shown in spx UI surfaces.
+func displayedFuncResults(results *gotypes.Tuple) string {
+	if results.Len() == 0 {
+		return ""
+	}
+	if results.Len() == 1 && results.At(0).Name() == "" {
+		return " " + GetSimplifiedTypeString(results.At(0).Type())
+	}
+
+	var sb strings.Builder
+	sb.WriteString(" (")
+	for i := range results.Len() {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		result := results.At(i)
+		if name := result.Name(); name != "" {
+			sb.WriteString(name)
+			sb.WriteString(" ")
+		}
+		sb.WriteString(GetSimplifiedTypeString(result.Type()))
+	}
+	sb.WriteString(")")
+	return sb.String()
+}
+
+// displayedFuncParamLabels formats the source-facing parameter list for
+// function signatures shown in spx UI surfaces.
+func displayedFuncParamLabels(sig *gotypes.Signature, isXGotMethod bool) []string {
 	params := make([]string, 0, sig.TypeParams().Len()+sig.Params().Len())
 	for typeParam := range sig.TypeParams().TypeParams() {
 		params = append(params, typeParam.Obj().Name()+" Type")
@@ -889,43 +912,39 @@ func makeSpxDefinitionOverviewForFunc(fun *gotypes.Func) (overview, parsedRecvTy
 		if isXGotMethod && i == 0 {
 			continue
 		}
-		param := sig.Params().At(i)
-		paramType := param.Type()
-		paramTypeName := GetSimplifiedTypeString(paramType)
-
-		// Check if this is a variadic parameter.
-		if sig.Variadic() && i == sig.Params().Len()-1 {
-			if slice, ok := paramType.(*gotypes.Slice); ok {
-				elemTypeName := GetSimplifiedTypeString(slice.Elem())
-				paramTypeName = "..." + elemTypeName
-			}
-		}
-
-		params = append(params, param.Name()+" "+paramTypeName)
+		params = append(params, displayedFuncParamLabel(sig, i))
 	}
-	sb.WriteString(strings.Join(params, ", "))
+	return params
+}
+
+// displayedFuncParamLabel formats one source-facing function parameter label.
+func displayedFuncParamLabel(sig *gotypes.Signature, paramIndex int) string {
+	param := sig.Params().At(paramIndex)
+	paramType := param.Type()
+	paramTypeName := GetSimplifiedTypeString(paramType)
+
+	if sig.Variadic() && paramIndex == sig.Params().Len()-1 {
+		if slice, ok := paramType.(*gotypes.Slice); ok {
+			paramTypeName = "..." + GetSimplifiedTypeString(slice.Elem())
+		}
+	}
+
+	return param.Name() + " " + paramTypeName
+}
+
+// makeSpxDefinitionOverviewForFunc makes an overview string for a function that
+// is used in [SpxDefinition].
+func makeSpxDefinitionOverviewForFunc(fun *gotypes.Func) (overview, parsedRecvTypeName, parsedName string, overloadID *string) {
+	sig := fun.Signature()
+	parsedRecvTypeName, parsedName, overloadID, isXGotMethod := displayedFuncName(fun)
+
+	var sb strings.Builder
+	sb.WriteString("func ")
+	sb.WriteString(parsedName)
+	sb.WriteString("(")
+	sb.WriteString(strings.Join(displayedFuncParamLabels(sig, isXGotMethod), ", "))
 	sb.WriteString(")")
-
-	if results := sig.Results(); results.Len() > 0 {
-		if results.Len() == 1 {
-			sb.WriteString(" ")
-			sb.WriteString(GetSimplifiedTypeString(results.At(0).Type()))
-		} else {
-			sb.WriteString(" (")
-			for i := range results.Len() {
-				if i > 0 {
-					sb.WriteString(", ")
-				}
-				result := results.At(i)
-				if name := result.Name(); name != "" {
-					sb.WriteString(name)
-					sb.WriteString(" ")
-				}
-				sb.WriteString(GetSimplifiedTypeString(result.Type()))
-			}
-			sb.WriteString(")")
-		}
-	}
+	sb.WriteString(displayedFuncResults(sig.Results()))
 
 	overview = sb.String()
 	return
@@ -993,11 +1012,7 @@ func HasSpxResourceNameTypeParams(fun *gotypes.Func) (has bool) {
 		}()
 	}
 
-	funcSig, ok := fun.Type().(*gotypes.Signature)
-	if !ok {
-		return false
-	}
-
+	funcSig := fun.Signature()
 	for param := range funcSig.Params().Variables() {
 		paramType := xgoutil.DerefType(param.Type())
 		if slice, ok := paramType.(*gotypes.Slice); ok {

--- a/internal/server/spx_util.go
+++ b/internal/server/spx_util.go
@@ -123,11 +123,7 @@ func getTypeFromObject(typeInfo *types.Info, obj gotypes.Object) string {
 		}
 		return findFieldOwnerType(typeInfo, obj)
 	case *gotypes.Func:
-		sig, ok := obj.Type().(*gotypes.Signature)
-		if !ok {
-			return ""
-		}
-		recv := sig.Recv()
+		recv := obj.Signature().Recv()
 		if recv == nil {
 			return ""
 		}


### PR DESCRIPTION
Format signature help with the same source-facing signature rules used by spx definitions. This keeps XGo aliases, XGot/XGox methods, variadic parameters, type parameters, and result lists consistent across LSP surfaces.

Use `Func.Signature()` in server code where the object is already known to be a function and remove redundant signature assertions.