### PR TITLE
refactor(xgoutil): add kwargs-aware call argument resolver

### DIFF
--- a/internal/analysis/passes/propertyname/propertyname.go
+++ b/internal/analysis/passes/propertyname/propertyname.go
@@ -2,7 +2,6 @@ package propertyname
 
 import (
 	_ "embed"
-	gotypes "go/types"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
@@ -45,25 +44,25 @@ func run(pass *protocol.Pass) (any, error) {
 			validNamesSet[name] = struct{}{}
 		}
 
-		xgoutil.WalkCallExprArgs(pass.TypesInfo, call,
-			func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-				param := params.At(paramIndex)
-				if !pass.IsPropertyNameType(param.Type()) {
-					return true
-				}
+		for resolvedArg := range xgoutil.ResolvedCallExprArgs(pass.TypesInfo, call) {
+			if resolvedArg.ExpectedType == nil {
+				continue
+			}
+			if !pass.IsPropertyNameType(resolvedArg.ExpectedType) {
+				continue
+			}
 
-				// Only validate string literal / constant arguments.
-				tv := pass.TypesInfo.Types[arg]
-				propName, ok := xgoutil.StringLitOrConstValue(arg, tv)
-				if !ok {
-					return true
-				}
+			// Only validate string literal / constant arguments.
+			tv := pass.TypesInfo.Types[resolvedArg.Arg]
+			propName, ok := xgoutil.StringLitOrConstValue(resolvedArg.Arg, tv)
+			if !ok {
+				continue
+			}
 
-				if _, ok := validNamesSet[propName]; !ok {
-					pass.ReportRangef(arg, "unknown property %q", propName)
-				}
-				return true
-			})
+			if _, ok := validNamesSet[propName]; !ok {
+				pass.ReportRangef(resolvedArg.Arg, "unknown property %q", propName)
+			}
+		}
 	})
 
 	return nil, nil

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -679,23 +679,21 @@ func findInputSlotsFromCallExpr(result *compileResult, callExpr *ast.CallExpr) [
 	}
 
 	var inputSlots []SpxInputSlot
-	xgoutil.WalkCallExprArgs(typeInfo, callExpr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-		param := params.At(paramIndex)
-		if !param.Pos().IsValid() {
-			return true
+	for resolvedArg := range xgoutil.ResolvedCallExprArgs(typeInfo, callExpr) {
+		if resolvedArg.ExpectedType == nil || resolvedArg.IsTypeArg() {
+			continue
 		}
 
-		declaredType := xgoutil.DerefType(param.Type())
+		declaredType := xgoutil.DerefType(resolvedArg.ExpectedType)
 		if sliceType, ok := declaredType.(*gotypes.Slice); ok {
 			declaredType = xgoutil.DerefType(sliceType.Elem())
 		}
 
-		slot := checkValueInputSlot(result, arg, declaredType)
+		slot := checkValueInputSlot(result, resolvedArg.Arg, declaredType)
 		if slot != nil {
 			inputSlots = append(inputSlots, *slot)
 		}
-		return true
-	})
+	}
 	return inputSlots
 }
 

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -671,19 +671,20 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 			getSpriteContext := sync.OnceValue(func() *SpxSpriteResource {
 				return s.resolveSpxSpriteContextFromCallExpr(result, expr)
 			})
-			xgoutil.WalkCallExprArgs(typeInfo, expr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-				param := params.At(paramIndex)
-				paramType := xgoutil.DerefType(param.Type())
+			for resolvedArg := range xgoutil.ResolvedCallExprArgs(typeInfo, expr) {
+				if resolvedArg.ExpectedType == nil {
+					continue
+				}
+				paramType := xgoutil.DerefType(resolvedArg.ExpectedType)
 
-				if sliceLit, ok := arg.(*ast.SliceLit); ok {
+				if sliceLit, ok := resolvedArg.Arg.(*ast.SliceLit); ok {
 					for _, elt := range sliceLit.Elts {
 						s.inspectSpxResourceRefForTypeAtExpr(result, elt, paramType, getSpriteContext)
 					}
 				} else {
-					s.inspectSpxResourceRefForTypeAtExpr(result, arg, paramType, getSpriteContext)
+					s.inspectSpxResourceRefForTypeAtExpr(result, resolvedArg.Arg, paramType, getSpriteContext)
 				}
-				return true
-			})
+			}
 		}
 	}
 }

--- a/internal/server/inlay_hint.go
+++ b/internal/server/inlay_hint.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"cmp"
-	gotypes "go/types"
 	"slices"
 
 	"github.com/goplus/xgo/ast"
@@ -79,22 +78,29 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *ast.CallExpr
 	}
 
 	var inlayHints []InlayHint
-	xgoutil.WalkCallExprArgs(typeInfo, callExpr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-		if paramIndex < argIndex {
-			// Stop processing variadic arguments beyond the declared parameters.
-			return false
+	variadicParamSeen := false
+	for resolvedArg := range xgoutil.ResolvedCallExprArgs(typeInfo, callExpr) {
+		if resolvedArg.Kind != xgoutil.ResolvedCallExprArgPositional {
+			continue
+		}
+		variadicArg := resolvedArg.Fun.Signature().Variadic() && resolvedArg.ParamIndex == resolvedArg.Params.Len()-1
+		if variadicArg {
+			if variadicParamSeen {
+				break
+			}
+			variadicParamSeen = true
 		}
 
-		switch arg.(type) {
+		switch resolvedArg.Arg.(type) {
 		case *ast.LambdaExpr, *ast.LambdaExpr2:
 			// Skip lambda expressions.
-			return true
+			continue
 		}
 
 		// Create an inlay hint with the parameter name before the argument.
-		position := result.proj.Fset.Position(arg.Pos())
-		label := params.At(paramIndex).Name()
-		if fun.Signature().Variadic() && argIndex == params.Len()-1 {
+		position := result.proj.Fset.Position(resolvedArg.Arg.Pos())
+		label := xgoutil.SourceParamName(resolvedArg.Param)
+		if variadicArg {
 			label += "..."
 		}
 		hint := InlayHint{
@@ -103,8 +109,7 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *ast.CallExpr
 			Kind:     Parameter,
 		}
 		inlayHints = append(inlayHints, hint)
-		return true
-	})
+	}
 	return inlayHints
 }
 

--- a/xgo/xgoutil/call_expr.go
+++ b/xgo/xgoutil/call_expr.go
@@ -18,13 +18,110 @@ package xgoutil
 
 import (
 	gotypes "go/types"
+	"iter"
 	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/types"
 )
+
+const (
+	// xgoOptionalParamPrefix prefixes generated names for current XGo optional parameters.
+	xgoOptionalParamPrefix = "__xgo_optional_"
+
+	// gopOptionalParamPrefix prefixes generated names for legacy XGo optional parameters.
+	gopOptionalParamPrefix = "__gop_optional_"
+)
+
+// ResolvedCallExprArgKind describes how an argument is spelled in source.
+type ResolvedCallExprArgKind int
+
+const (
+	// ResolvedCallExprArgPositional identifies a positional call argument.
+	ResolvedCallExprArgPositional ResolvedCallExprArgKind = iota
+	// ResolvedCallExprArgKeyword identifies a keyword call argument value.
+	ResolvedCallExprArgKeyword
+)
+
+// ResolvedCallExprKwargTargetKind describes how a keyword argument name maps to
+// the target parameter container.
+type ResolvedCallExprKwargTargetKind int
+
+const (
+	// ResolvedCallExprKwargTargetUnknown is the zero-value sentinel for a
+	// target kind. Unresolved keyword arguments use a nil target.
+	ResolvedCallExprKwargTargetUnknown ResolvedCallExprKwargTargetKind = iota
+	// ResolvedCallExprKwargTargetMap identifies a string-keyed map target.
+	ResolvedCallExprKwargTargetMap
+	// ResolvedCallExprKwargTargetStructField identifies a struct field target.
+	ResolvedCallExprKwargTargetStructField
+	// ResolvedCallExprKwargTargetInterfaceMethod identifies a self-returning
+	// interface method target.
+	ResolvedCallExprKwargTargetInterfaceMethod
+	// ResolvedCallExprKwargTargetInterfaceSet identifies a dynamic Set method
+	// target on a self-returning interface.
+	ResolvedCallExprKwargTargetInterfaceSet
+)
+
+// ResolvedCallExprArg describes a call argument after XGo-specific mapping.
+type ResolvedCallExprArg struct {
+	Fun        *gotypes.Func
+	Params     *gotypes.Tuple
+	Param      *gotypes.Var
+	ParamIndex int
+	Arg        ast.Expr
+	// ArgIndex is the index in the resolved source argument stream. For
+	// positional arguments, it is the index in expr.Args. For keyword
+	// arguments, it is len(expr.Args) plus the index in expr.Kwargs.
+	ArgIndex int
+	Kind     ResolvedCallExprArgKind
+	Kwarg    *ast.KwargExpr
+	// ExpectedType is nil for a keyword argument whose name cannot be resolved
+	// against its kwarg target parameter.
+	ExpectedType gotypes.Type
+	// KwargTarget is non-nil only for resolved keyword arguments.
+	KwargTarget *ResolvedCallExprKwargTarget
+}
+
+// ResolvedCallExprKwarg describes the parameter slot that receives kwargs.
+type ResolvedCallExprKwarg struct {
+	Param                 *gotypes.Var
+	ParamIndex            int
+	AllowInterfaceTargets bool
+}
+
+// ResolvedCallExprKwargTarget describes a resolved keyword argument binding.
+type ResolvedCallExprKwargTarget struct {
+	Kind      ResolvedCallExprKwargTargetKind
+	Name      string
+	ValueType gotypes.Type
+	Field     *gotypes.Var
+	Method    *gotypes.Func
+}
+
+// IsTypeArg reports whether arg represents an XGox type-as-parameter argument.
+func (arg ResolvedCallExprArg) IsTypeArg() bool {
+	if arg.Kind != ResolvedCallExprArgPositional {
+		return false
+	}
+	if !IsMarkedAsXGoPackage(arg.Fun.Pkg()) {
+		return false
+	}
+	_, methodName, ok := SplitXGotMethodName(arg.Fun.Name(), false)
+	if !ok {
+		return false
+	}
+	if _, ok := SplitXGoxFuncName(methodName); !ok {
+		return false
+	}
+	typeParams := arg.Fun.Signature().TypeParams()
+	return typeParams != nil && arg.ParamIndex < typeParams.Len()
+}
 
 // CreateCallExprFromBranchStmt attempts to create a call expression from a
 // branch statement. This handles cases in spx where the `Sprite.Goto` method is
@@ -87,61 +184,563 @@ func FuncFromCallExpr(typeInfo *types.Info, expr *ast.CallExpr) *gotypes.Func {
 	return fun
 }
 
-// WalkCallExprArgs walks the arguments of a call expression and calls the
-// provided walkFn for each argument. It does nothing if the function is not
-// found or if the function is XGo FuncEx type. The walk stops if walkFn returns
-// false.
-func WalkCallExprArgs(typeInfo *types.Info, expr *ast.CallExpr, walkFn func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool) {
+// ResolveCallExprSignature resolves the callable function, its signature, and
+// the normalized parameter list for expr.
+func ResolveCallExprSignature(typeInfo *types.Info, expr *ast.CallExpr) (fun *gotypes.Func, sig *gotypes.Signature, params *gotypes.Tuple) {
 	if typeInfo == nil || expr == nil {
-		return
+		return nil, nil, nil
 	}
 
-	fun := FuncFromCallExpr(typeInfo, expr)
+	fun = FuncFromCallExpr(typeInfo, expr)
 	if fun == nil {
-		return
+		return nil, nil, nil
 	}
-	sig := fun.Signature()
+
+	sig, params = ResolveFuncSignature(fun)
+	if sig == nil {
+		return nil, nil, nil
+	}
+	return fun, sig, params
+}
+
+// ResolveFuncSignature resolves the callable signature and normalized
+// parameter list for fun.
+func ResolveFuncSignature(fun *gotypes.Func) (sig *gotypes.Signature, params *gotypes.Tuple) {
+	sig = fun.Signature()
 	if _, ok := gogen.CheckFuncEx(sig); ok {
-		return
+		return nil, nil
 	}
 
+	return sig, normalizedCallExprParams(fun, sig)
+}
+
+// normalizedCallExprParams returns the parameter list that should be exposed to
+// callers after applying XGo-specific function normalization.
+func normalizedCallExprParams(fun *gotypes.Func, sig *gotypes.Signature) *gotypes.Tuple {
 	params := sig.Params()
-	if IsMarkedAsXGoPackage(fun.Pkg()) {
-		_, methodName, ok := SplitXGotMethodName(fun.Name(), false)
-		if ok {
-			var vars []*gotypes.Var
-			if _, ok := SplitXGoxFuncName(methodName); ok {
-				typeParams := fun.Signature().TypeParams()
-				if typeParams != nil {
-					vars = slices.Grow(vars, typeParams.Len())
-					for typeParam := range typeParams.TypeParams() {
-						param := gotypes.NewParam(token.NoPos, typeParam.Obj().Pkg(), typeParam.Obj().Name(), typeParam.Constraint().Underlying())
-						vars = append(vars, param)
-					}
-				}
-			}
+	if !IsMarkedAsXGoPackage(fun.Pkg()) {
+		return params
+	}
 
-			vars = slices.Grow(vars, params.Len()-1)
-			for i := 1; i < params.Len(); i++ {
-				vars = append(vars, params.At(i))
-			}
+	_, methodName, ok := SplitXGotMethodName(fun.Name(), false)
+	if !ok {
+		return params
+	}
 
-			params = gotypes.NewTuple(vars...)
+	var vars []*gotypes.Var
+	if _, ok := SplitXGoxFuncName(methodName); ok {
+		typeParams := sig.TypeParams()
+		if typeParams != nil {
+			vars = slices.Grow(vars, typeParams.Len())
+			for typeParam := range typeParams.TypeParams() {
+				param := gotypes.NewParam(token.NoPos, typeParam.Obj().Pkg(), typeParam.Obj().Name(), typeParam.Constraint().Underlying())
+				vars = append(vars, param)
+			}
 		}
 	}
 
-	totalParams := params.Len()
-	for i, arg := range expr.Args {
-		paramIndex := i
-		if paramIndex >= totalParams {
-			if !sig.Variadic() || totalParams == 0 {
-				break
-			}
-			paramIndex = totalParams - 1
+	vars = slices.Grow(vars, params.Len()-1)
+	for i := 1; i < params.Len(); i++ {
+		vars = append(vars, params.At(i))
+	}
+	return gotypes.NewTuple(vars...)
+}
+
+// resolvedCallExprArgType returns the expected argument type at paramIndex.
+// It unwraps variadic slices to their element type unless the source argument
+// uses ellipsis.
+func resolvedCallExprArgType(sig *gotypes.Signature, params *gotypes.Tuple, paramIndex int, ellipsis bool) gotypes.Type {
+	param := params.At(paramIndex)
+	if sig.Variadic() && paramIndex == params.Len()-1 && !ellipsis {
+		return variadicValueType(param.Type())
+	}
+	return param.Type()
+}
+
+// variadicValueType returns the per-argument type for a variadic parameter.
+func variadicValueType(typ gotypes.Type) gotypes.Type {
+	if sliceType, ok := typ.(*gotypes.Slice); ok {
+		return sliceType.Elem()
+	}
+	return typ
+}
+
+// SourceParamName returns the source-facing spelling of param.
+func SourceParamName(param *gotypes.Var) string {
+	name, _ := trimOptionalParamPrefix(param.Name())
+	return name
+}
+
+// isOptionalParam reports whether param is an XGo optional parameter.
+func isOptionalParam(typeInfo *types.Info, param *gotypes.Var) bool {
+	if _, ok := trimOptionalParamPrefix(param.Name()); ok {
+		return true
+	}
+	if typeInfo == nil {
+		return false
+	}
+
+	defIdent := typeInfo.ObjToDef[param]
+	if defIdent == nil || defIdent.Obj == nil {
+		return false
+	}
+	field, ok := defIdent.Obj.Decl.(*ast.Field)
+	return ok && field.Optional.IsValid()
+}
+
+// trimOptionalParamPrefix returns the source-facing parameter name after
+// removing a generated XGo optional parameter prefix.
+func trimOptionalParamPrefix(name string) (string, bool) {
+	if name, ok := strings.CutPrefix(name, xgoOptionalParamPrefix); ok {
+		return name, true
+	}
+	if name, ok := strings.CutPrefix(name, gopOptionalParamPrefix); ok {
+		return name, true
+	}
+	return name, false
+}
+
+// anyType returns the predeclared `any` type.
+func anyType() gotypes.Type {
+	return gotypes.Universe.Lookup("any").Type()
+}
+
+// upperFirstRune uppercases the first rune in name.
+func upperFirstRune(name string) string {
+	if name == "" {
+		return ""
+	}
+	r, size := utf8.DecodeRuneInString(name)
+	return string(unicode.ToUpper(r)) + name[size:]
+}
+
+// lowerFirstRune lowercases the first rune in name.
+func lowerFirstRune(name string) string {
+	if name == "" {
+		return ""
+	}
+	r, size := utf8.DecodeRuneInString(name)
+	return string(unicode.ToLower(r)) + name[size:]
+}
+
+// upperFirstASCII uppercases the first ASCII letter in name.
+func upperFirstASCII(name string) string {
+	if name == "" {
+		return ""
+	}
+	first := name[0]
+	if first < 'a' || first > 'z' {
+		return name
+	}
+	return string(first-('a'-'A')) + name[1:]
+}
+
+// lowerFirstASCII lowercases the first ASCII letter in name.
+func lowerFirstASCII(name string) string {
+	if name == "" {
+		return ""
+	}
+	first := name[0]
+	if first < 'A' || first > 'Z' {
+		return name
+	}
+	return string(first+('a'-'A')) + name[1:]
+}
+
+// kwargSuggestedName returns the source-level keyword name for a target member.
+func kwargSuggestedName(name string, exported bool) string {
+	if !exported {
+		return name
+	}
+	return lowerFirstRune(name)
+}
+
+// lookupStructKwargField resolves name to a struct field that can be addressed
+// by kwargs.
+func lookupStructKwargField(strct *gotypes.Struct, inMainPkg bool, name string) *gotypes.Var {
+	capName := upperFirstRune(name)
+	for field := range strct.Fields() {
+		if !IsExportedOrInMainPkg(field) {
+			continue
+		}
+		if inMainPkg && field.Name() == name {
+			return field
+		}
+		if field.Exported() && field.Name() == capName {
+			return field
+		}
+	}
+	return nil
+}
+
+// structKwargType returns the struct and main-package matching mode for typ.
+func structKwargType(typ gotypes.Type) (*gotypes.Struct, bool) {
+	if ptr, ok := typ.Underlying().(*gotypes.Pointer); ok {
+		typ = ptr.Elem()
+	}
+	strct, ok := typ.Underlying().(*gotypes.Struct)
+	if !ok {
+		return nil, false
+	}
+	named, _ := typ.(*gotypes.Named)
+	return strct, named != nil && IsInMainPkg(named.Obj())
+}
+
+// structKwargTarget returns a target for field.
+func structKwargTarget(field *gotypes.Var) ResolvedCallExprKwargTarget {
+	return ResolvedCallExprKwargTarget{
+		Kind:      ResolvedCallExprKwargTargetStructField,
+		Name:      kwargSuggestedName(field.Name(), field.Exported()),
+		ValueType: field.Type(),
+		Field:     field,
+	}
+}
+
+// lookupInterfaceKwargMethodTarget resolves name to a self-returning interface
+// method target.
+func lookupInterfaceKwargMethodTarget(iface *gotypes.Interface, self *gotypes.Named, name string) *ResolvedCallExprKwargTarget {
+	methodName := upperFirstASCII(name)
+	for method := range iface.Methods() {
+		if method.Name() != methodName {
+			continue
+		}
+		target, ok := interfaceKwargMethodTarget(method, self)
+		if ok {
+			return &target
+		}
+	}
+	return nil
+}
+
+// interfaceKwargMethodTarget returns the kwarg target represented by method
+// when it is a self-returning interface method.
+func interfaceKwargMethodTarget(method *gotypes.Func, self *gotypes.Named) (ResolvedCallExprKwargTarget, bool) {
+	sig := method.Signature()
+	if sig.Params().Len() != 1 || sig.Results().Len() != 1 {
+		return ResolvedCallExprKwargTarget{}, false
+	}
+	if !gotypes.Identical(sig.Results().At(0).Type(), self) {
+		return ResolvedCallExprKwargTarget{}, false
+	}
+	valueType := sig.Params().At(0).Type()
+	if sig.Variadic() {
+		valueType = variadicValueType(valueType)
+	}
+	return ResolvedCallExprKwargTarget{
+		Kind:      ResolvedCallExprKwargTargetInterfaceMethod,
+		Name:      lowerFirstASCII(method.Name()),
+		ValueType: valueType,
+		Method:    method,
+	}, true
+}
+
+// hasInterfaceKwargSet reports whether iface exposes a `Set(string, any) Self`
+// fallback for kwargs.
+func hasInterfaceKwargSet(iface *gotypes.Interface, self *gotypes.Named) bool {
+	for method := range iface.Methods() {
+		if method.Name() != "Set" {
+			continue
+		}
+		sig := method.Signature()
+		if sig.Params().Len() != 2 || sig.Results().Len() != 1 {
+			continue
+		}
+		if !gotypes.Identical(sig.Results().At(0).Type(), self) {
+			continue
 		}
 
-		if !walkFn(fun, params, paramIndex, arg, i) {
-			break
+		keyType := sig.Params().At(0).Type()
+		valType := sig.Params().At(1).Type()
+		if isStringType(keyType) && isAnyType(valType) {
+			return true
+		}
+	}
+	return false
+}
+
+// isStringType reports whether typ is the string basic type.
+func isStringType(typ gotypes.Type) bool {
+	basic, ok := typ.(*gotypes.Basic)
+	return ok && basic.Kind() == gotypes.String
+}
+
+// isAnyType reports whether typ is an empty interface.
+func isAnyType(typ gotypes.Type) bool {
+	iface, ok := typ.(*gotypes.Interface)
+	return ok && iface.Empty()
+}
+
+// CallExprSupportsInterfaceKwargs reports whether expr can compile XGo
+// interface-based kwargs for paramType.
+func CallExprSupportsInterfaceKwargs(typeInfo *types.Info, expr *ast.CallExpr, paramType gotypes.Type) bool {
+	if typeInfo == nil {
+		return false
+	}
+	selector, ok := expr.Fun.(*ast.SelectorExpr)
+	if !ok || !isAppendableKwargReceiver(selector.X) {
+		return false
+	}
+	self, ok := paramType.(*gotypes.Named)
+	if !ok {
+		return false
+	}
+	if _, ok := self.Underlying().(*gotypes.Interface); !ok {
+		return false
+	}
+	recvType := typeInfo.TypeOf(selector.X)
+	if recvType == nil {
+		return false
+	}
+	factory, _, _ := gotypes.LookupFieldOrMethod(recvType, true, self.Obj().Pkg(), self.Obj().Name())
+	factoryFunc, ok := factory.(*gotypes.Func)
+	if !ok {
+		return false
+	}
+	sig := factoryFunc.Signature()
+	return sig.Params().Len() == 0 && sig.Results().Len() == 1 &&
+		gotypes.AssignableTo(sig.Results().At(0).Type(), self)
+}
+
+// isAppendableKwargReceiver reports whether receiver can be reused when XGo
+// compiles interface kwargs into a method chain.
+func isAppendableKwargReceiver(receiver ast.Expr) bool {
+	switch receiver := receiver.(type) {
+	case *ast.Ident:
+		return true
+	case *ast.SelectorExpr:
+		_, ok := receiver.X.(*ast.Ident)
+		return ok
+	}
+	return false
+}
+
+// ResolveCallExprKwarg returns the parameter slot that receives keyword
+// arguments, if any.
+func ResolveCallExprKwarg(typeInfo *types.Info, expr *ast.CallExpr) *ResolvedCallExprKwarg {
+	_, sig, params := ResolveCallExprSignature(typeInfo, expr)
+	if sig == nil || params == nil {
+		return nil
+	}
+
+	return resolveCallExprKwarg(typeInfo, expr, sig, params)
+}
+
+// resolveCallExprKwarg returns the parameter slot that receives keyword
+// arguments after the call signature has already been resolved.
+func resolveCallExprKwarg(typeInfo *types.Info, expr *ast.CallExpr, sig *gotypes.Signature, params *gotypes.Tuple) *ResolvedCallExprKwarg {
+	paramIndex := len(expr.Args)
+	if sig.Variadic() {
+		paramIndex = params.Len() - 2
+		if paramIndex < 0 || len(expr.Args) < paramIndex {
+			return nil
+		}
+	} else if paramIndex >= params.Len() {
+		return nil
+	}
+
+	param := params.At(paramIndex)
+	if len(expr.Kwargs) == 0 && !isOptionalParam(typeInfo, param) {
+		return nil
+	}
+
+	return &ResolvedCallExprKwarg{
+		Param:                 param,
+		ParamIndex:            paramIndex,
+		AllowInterfaceTargets: CallExprSupportsInterfaceKwargs(typeInfo, expr, param.Type()),
+	}
+}
+
+// LookupResolvedCallExprKwargTarget resolves a keyword name against the target
+// parameter slot.
+func LookupResolvedCallExprKwargTarget(kwarg *ResolvedCallExprKwarg, name string) *ResolvedCallExprKwargTarget {
+	if kwarg == nil || name == "" {
+		return nil
+	}
+
+	paramType := kwarg.Param.Type()
+	if strct, inMainPkg := structKwargType(paramType); strct != nil {
+		field := lookupStructKwargField(strct, inMainPkg, name)
+		if field == nil {
+			return nil
+		}
+		target := structKwargTarget(field)
+		return &target
+	}
+
+	switch u := paramType.Underlying().(type) {
+	case *gotypes.Interface:
+		return lookupInterfaceKwargTarget(kwarg, u, name)
+	case *gotypes.Map:
+		if acceptsStringLiteral(u.Key()) {
+			return mapKwargTarget(name, u.Elem())
+		}
+	}
+	return nil
+}
+
+// lookupInterfaceKwargTarget resolves name against an interface kwarg parameter.
+func lookupInterfaceKwargTarget(kwarg *ResolvedCallExprKwarg, iface *gotypes.Interface, name string) *ResolvedCallExprKwargTarget {
+	named, ok := kwarg.Param.Type().(*gotypes.Named)
+	if !ok {
+		if iface.Empty() {
+			return mapKwargTarget(name, anyType())
+		}
+		return nil
+	}
+
+	if !kwarg.AllowInterfaceTargets {
+		return nil
+	}
+	if target := lookupInterfaceKwargMethodTarget(iface, named, name); target != nil {
+		return target
+	}
+	if !hasInterfaceKwargSet(iface, named) {
+		return nil
+	}
+	return &ResolvedCallExprKwargTarget{
+		Kind:      ResolvedCallExprKwargTargetInterfaceSet,
+		Name:      name,
+		ValueType: anyType(),
+	}
+}
+
+// mapKwargTarget returns a dynamic string-keyed map kwarg target.
+func mapKwargTarget(name string, valueType gotypes.Type) *ResolvedCallExprKwargTarget {
+	return &ResolvedCallExprKwargTarget{
+		Kind:      ResolvedCallExprKwargTargetMap,
+		Name:      name,
+		ValueType: valueType,
+	}
+}
+
+// acceptsStringLiteral reports whether typ accepts an untyped string literal.
+func acceptsStringLiteral(typ gotypes.Type) bool {
+	return gotypes.AssignableTo(gotypes.Typ[gotypes.UntypedString], typ)
+}
+
+// ListResolvedCallExprKwargTargets lists the finite named keyword targets
+// exposed by the target parameter slot. Map-backed and dynamic `Set`-style
+// interface kwargs are not enumerated.
+func ListResolvedCallExprKwargTargets(kwarg *ResolvedCallExprKwarg) []ResolvedCallExprKwargTarget {
+	if kwarg == nil {
+		return nil
+	}
+
+	var targets []ResolvedCallExprKwargTarget
+	appendTarget := func(target ResolvedCallExprKwargTarget) {
+		if !sameResolvedCallExprKwargTarget(LookupResolvedCallExprKwargTarget(kwarg, target.Name), target) {
+			return
+		}
+		targets = append(targets, target)
+	}
+	paramType := kwarg.Param.Type()
+	if strct, _ := structKwargType(paramType); strct != nil {
+		for field := range strct.Fields() {
+			if !IsExportedOrInMainPkg(field) {
+				continue
+			}
+			appendTarget(structKwargTarget(field))
+		}
+		return targets
+	}
+
+	switch u := paramType.Underlying().(type) {
+	case *gotypes.Interface:
+		named, ok := paramType.(*gotypes.Named)
+		if !ok || !kwarg.AllowInterfaceTargets {
+			return targets
+		}
+		for method := range u.Methods() {
+			target, ok := interfaceKwargMethodTarget(method, named)
+			if !ok {
+				continue
+			}
+			appendTarget(target)
+		}
+	}
+	return targets
+}
+
+// sameResolvedCallExprKwargTarget reports whether resolved and target identify
+// the same concrete kwarg target.
+func sameResolvedCallExprKwargTarget(resolved *ResolvedCallExprKwargTarget, target ResolvedCallExprKwargTarget) bool {
+	if resolved == nil {
+		return false
+	}
+	if target.Field != nil {
+		return resolved.Field == target.Field
+	}
+	if target.Method != nil {
+		return resolved.Method == target.Method
+	}
+	return resolved.Kind == target.Kind && resolved.Name == target.Name
+}
+
+// ResolvedCallExprArgs returns an iterator over both positional arguments and
+// keyword argument values for the given call expression.
+func ResolvedCallExprArgs(typeInfo *types.Info, expr *ast.CallExpr) iter.Seq[ResolvedCallExprArg] {
+	return func(yield func(ResolvedCallExprArg) bool) {
+		fun, sig, params := ResolveCallExprSignature(typeInfo, expr)
+		if fun == nil || sig == nil || params == nil {
+			return
+		}
+
+		var kwarg *ResolvedCallExprKwarg
+		if len(expr.Kwargs) > 0 {
+			kwarg = resolveCallExprKwarg(typeInfo, expr, sig, params)
+		}
+		totalParams := params.Len()
+		for i, arg := range expr.Args {
+			ellipsis := expr.Ellipsis.IsValid() && i == len(expr.Args)-1
+			paramIndex := i
+			if kwarg != nil && i >= kwarg.ParamIndex {
+				paramIndex++
+			}
+			if paramIndex >= totalParams {
+				if !sig.Variadic() || totalParams == 0 {
+					break
+				}
+				paramIndex = totalParams - 1
+			}
+
+			if !yield(ResolvedCallExprArg{
+				Fun:          fun,
+				Params:       params,
+				Param:        params.At(paramIndex),
+				ParamIndex:   paramIndex,
+				Arg:          arg,
+				ArgIndex:     i,
+				Kind:         ResolvedCallExprArgPositional,
+				ExpectedType: resolvedCallExprArgType(sig, params, paramIndex, ellipsis),
+			}) {
+				return
+			}
+		}
+
+		if kwarg == nil {
+			return
+		}
+
+		for i, arg := range expr.Kwargs {
+			target := LookupResolvedCallExprKwargTarget(kwarg, arg.Name.Name)
+			var expectedType gotypes.Type
+			if target != nil {
+				expectedType = target.ValueType
+			}
+			if !yield(ResolvedCallExprArg{
+				Fun:          fun,
+				Params:       params,
+				Param:        kwarg.Param,
+				ParamIndex:   kwarg.ParamIndex,
+				Arg:          arg.Value,
+				ArgIndex:     len(expr.Args) + i,
+				Kind:         ResolvedCallExprArgKeyword,
+				Kwarg:        arg,
+				ExpectedType: expectedType,
+				KwargTarget:  target,
+			}) {
+				return
+			}
 		}
 	}
 }

--- a/xgo/xgoutil/call_expr_test.go
+++ b/xgo/xgoutil/call_expr_test.go
@@ -18,14 +18,81 @@ package xgoutil
 
 import (
 	gotypes "go/types"
+	"slices"
 	"testing"
 
 	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func addInterfaceKwargFactory(typeInfo *types.Info, receiver ast.Expr, receiverTypeName string, iface *gotypes.Named) {
+	pkg := iface.Obj().Pkg()
+	recvNamed := gotypes.NewNamed(
+		gotypes.NewTypeName(token.NoPos, pkg, receiverTypeName, nil),
+		gotypes.NewStruct(nil, nil),
+		nil,
+	)
+	recv := gotypes.NewVar(token.NoPos, pkg, "recv", recvNamed)
+	factory := gotypes.NewFunc(token.NoPos, pkg, iface.Obj().Name(), gotypes.NewSignatureType(
+		recv,
+		nil,
+		nil,
+		nil,
+		gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", iface)),
+		false,
+	))
+	recvNamed.AddMethod(factory)
+	typeInfo.Types[receiver] = gotypes.TypeAndValue{Type: recvNamed}
+}
+
+func newTestFunc(pkg *gotypes.Package, name string, variadic bool, params ...*gotypes.Var) *gotypes.Func {
+	return gotypes.NewFunc(token.NoPos, pkg, name, gotypes.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		gotypes.NewTuple(params...),
+		nil,
+		variadic,
+	))
+}
+
+func newTestKwarg(name, value string) *ast.KwargExpr {
+	return &ast.KwargExpr{
+		Name:  &ast.Ident{Name: name},
+		Value: &ast.Ident{Name: value},
+	}
+}
+
+func newTestEmptyInterface() *gotypes.Interface {
+	iface := gotypes.NewInterfaceType(nil, nil)
+	iface.Complete()
+	return iface
+}
+
+func newTestNamedInterface(pkg *gotypes.Package, name string) *gotypes.Named {
+	return gotypes.NewNamed(gotypes.NewTypeName(token.NoPos, pkg, name, nil), nil, nil)
+}
+
+func setTestNamedInterfaceMethods(named *gotypes.Named, methods ...*gotypes.Func) {
+	iface := gotypes.NewInterfaceType(methods, nil)
+	iface.Complete()
+	named.SetUnderlying(iface)
+}
+
+func newTestSelfReturningMethod(pkg *gotypes.Package, name string, self *gotypes.Named, paramName string, paramType gotypes.Type, variadic bool) *gotypes.Func {
+	return gotypes.NewFunc(token.NoPos, pkg, name, gotypes.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, paramName, paramType)),
+		gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", self)),
+		variadic,
+	))
+}
 
 func TestCreateCallExprFromBranchStmt(t *testing.T) {
 	t.Run("NilTypeInfo", func(t *testing.T) {
@@ -91,7 +158,7 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 		pkg := gotypes.NewPackage("test", "test")
 		variable := gotypes.NewVar(token.NoPos, pkg, "label", gotypes.Typ[gotypes.Int])
 		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
-			labelIdent: variable, // Not a label, so it won't be skipped.
+			labelIdent: variable,
 		}, nil)
 		assert.Nil(t, CreateCallExprFromBranchStmt(typeInfo, stmt))
 	})
@@ -107,7 +174,6 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 			Label:  labelIdent,
 		}
 
-		// Create ident that matches position (TokPos=10, "goto" has length 4, so End=14).
 		ident := &ast.Ident{
 			NamePos: token.Pos(10),
 			Name:    "goto",
@@ -117,9 +183,9 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 		labelVar := gotypes.NewVar(token.NoPos, pkg, "label", gotypes.Typ[gotypes.Int])
 		gotoVar := gotypes.NewVar(token.NoPos, pkg, "goto", gotypes.Typ[gotypes.Int])
 		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
-			labelIdent: labelVar, // Not a label.
+			labelIdent: labelVar,
 		}, map[*ast.Ident]gotypes.Object{
-			ident: gotoVar, // Not a function.
+			ident: gotoVar,
 		})
 
 		assert.Nil(t, CreateCallExprFromBranchStmt(typeInfo, stmt))
@@ -136,7 +202,6 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 			Label:  labelIdent,
 		}
 
-		// Create ident that matches position (TokPos=10, "goto" has length 4, so End=14).
 		ident := &ast.Ident{
 			NamePos: token.Pos(10),
 			Name:    "goto",
@@ -147,9 +212,9 @@ func TestCreateCallExprFromBranchStmt(t *testing.T) {
 		sig := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
 		fun := gotypes.NewFunc(token.NoPos, pkg, "goto", sig)
 		typeInfo := newTestTypeInfo(map[*ast.Ident]gotypes.Object{
-			labelIdent: labelVar, // Not a label.
+			labelIdent: labelVar,
 		}, map[*ast.Ident]gotypes.Object{
-			ident: fun, // Is a function.
+			ident: fun,
 		})
 
 		got := CreateCallExprFromBranchStmt(typeInfo, stmt)
@@ -252,36 +317,147 @@ func TestFuncFromCallExpr(t *testing.T) {
 	})
 }
 
-func TestWalkCallExprArgs(t *testing.T) {
+func TestResolveCallExprKwarg(t *testing.T) {
 	t.Run("NilCallExpr", func(t *testing.T) {
-		walkCalled := false
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalled = true
-			return true
-		}
+		assert.Nil(t, ResolveCallExprKwarg(nil, nil))
+	})
 
-		WalkCallExprArgs(nil, nil, walkFn)
-		assert.False(t, walkCalled)
+	t.Run("OptionalParamFromDefinition", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		paramDef := &ast.Ident{Name: "opts", Obj: &ast.Object{}}
+		paramField := &ast.Field{Optional: token.Pos(1)}
+		paramDef.Obj.Decl = paramField
+
+		pkg := gotypes.NewPackage("main", "main")
+		param := gotypes.NewParam(token.NoPos, pkg, "opts", gotypes.NewMap(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(
+			map[*ast.Ident]gotypes.Object{paramDef: param},
+			map[*ast.Ident]gotypes.Object{ident: fun},
+		)
+		typeInfo.ObjToDef = map[gotypes.Object]*ast.Ident{param: paramDef}
+
+		resolved := ResolveCallExprKwarg(typeInfo, &ast.CallExpr{Fun: ident})
+		require.NotNil(t, resolved)
+		assert.Equal(t, param, resolved.Param)
+		assert.Zero(t, resolved.ParamIndex)
+	})
+
+	t.Run("NonOptionalParam", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+
+		pkg := gotypes.NewPackage("main", "main")
+		param := gotypes.NewParam(token.NoPos, pkg, "opts", gotypes.NewMap(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		assert.Nil(t, ResolveCallExprKwarg(typeInfo, &ast.CallExpr{Fun: ident}))
+	})
+
+	t.Run("NonOptionalParamWithKwargs", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+
+		pkg := gotypes.NewPackage("main", "main")
+		param := gotypes.NewParam(token.NoPos, pkg, "opts", gotypes.NewMap(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := ResolveCallExprKwarg(typeInfo, &ast.CallExpr{
+			Fun: ident,
+			Kwargs: []*ast.KwargExpr{{
+				Name:  &ast.Ident{Name: "count"},
+				Value: &ast.BasicLit{Kind: token.INT, Value: "1"},
+			}},
+		})
+		require.NotNil(t, resolved)
+		assert.Equal(t, param, resolved.Param)
+		assert.Zero(t, resolved.ParamIndex)
+	})
+
+	t.Run("CallPositionSelectsOptionalParam", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+
+		pkg := gotypes.NewPackage("main", "main")
+		requiredParam := gotypes.NewParam(token.NoPos, pkg, "name", gotypes.Typ[gotypes.String])
+		firstOptionalParam := gotypes.NewParam(
+			token.NoPos,
+			pkg,
+			"__xgo_optional_first",
+			gotypes.NewMap(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.Int]),
+		)
+		secondOptionalParam := gotypes.NewParam(
+			token.NoPos,
+			pkg,
+			"__gop_optional_second",
+			gotypes.NewMap(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.String]),
+		)
+		sig := gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(requiredParam, firstOptionalParam, secondOptionalParam),
+			nil,
+			false,
+		)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+
+		firstResolved := ResolveCallExprKwarg(typeInfo, &ast.CallExpr{
+			Fun:  ident,
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"first"`}},
+		})
+		require.NotNil(t, firstResolved)
+		assert.Equal(t, firstOptionalParam, firstResolved.Param)
+		assert.Equal(t, 1, firstResolved.ParamIndex)
+
+		secondResolved := ResolveCallExprKwarg(typeInfo, &ast.CallExpr{
+			Fun: ident,
+			Args: []ast.Expr{
+				&ast.BasicLit{Kind: token.STRING, Value: `"first"`},
+				&ast.BasicLit{Kind: token.STRING, Value: `"second"`},
+			},
+		})
+		require.NotNil(t, secondResolved)
+		assert.Equal(t, secondOptionalParam, secondResolved.Param)
+		assert.Equal(t, 2, secondResolved.ParamIndex)
+	})
+}
+
+func TestSourceParamName(t *testing.T) {
+	pkg := gotypes.NewPackage("main", "main")
+	for _, tt := range []struct {
+		name string
+		want string
+	}{
+		{name: "__xgo_optional_opts", want: "opts"},
+		{name: "__gop_optional_opts", want: "opts"},
+		{name: "opts", want: "opts"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			param := gotypes.NewParam(token.NoPos, pkg, tt.name, gotypes.Typ[gotypes.Int])
+			assert.Equal(t, tt.want, SourceParamName(param))
+		})
+	}
+}
+
+func TestResolvedCallExprArgs(t *testing.T) {
+	t.Run("NilCallExpr", func(t *testing.T) {
+		resolved := slices.Collect(ResolvedCallExprArgs(nil, nil))
+		assert.Empty(t, resolved)
 	})
 
 	t.Run("CallExprWithNilFunction", func(t *testing.T) {
-		expr := &ast.CallExpr{
+		resolved := slices.Collect(ResolvedCallExprArgs(newTestTypeInfo(nil, nil), &ast.CallExpr{
 			Fun: &ast.Ident{Name: "unknown"},
-		}
-
-		walkCalled := false
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalled = true
-			return true
-		}
-
-		typeInfo := newTestTypeInfo(nil, nil)
-
-		WalkCallExprArgs(typeInfo, expr, walkFn)
-		assert.False(t, walkCalled)
+		}))
+		assert.Empty(t, resolved)
 	})
 
-	t.Run("CallExprWithSimpleFunction", func(t *testing.T) {
+	t.Run("PositionalArgs", func(t *testing.T) {
 		ident := &ast.Ident{Name: "testFunc"}
 		arg1 := &ast.Ident{Name: "arg1"}
 		arg2 := &ast.Ident{Name: "arg2"}
@@ -296,38 +472,28 @@ func TestWalkCallExprArgs(t *testing.T) {
 		params := gotypes.NewTuple(param1, param2)
 		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
 		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
-		})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, expr))
 
-		var walkCalls []struct {
-			paramIndex int
-			argIndex   int
-			arg        ast.Expr
-		}
-
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalls = append(walkCalls, struct {
-				paramIndex int
-				argIndex   int
-				arg        ast.Expr
-			}{paramIndex, argIndex, arg})
-			return true
-		}
-
-		WalkCallExprArgs(typeInfo, expr, walkFn)
-
-		require.Len(t, walkCalls, 2)
-		assert.Equal(t, 0, walkCalls[0].paramIndex)
-		assert.Equal(t, 0, walkCalls[0].argIndex)
-		assert.Equal(t, arg1, walkCalls[0].arg)
-		assert.Equal(t, 1, walkCalls[1].paramIndex)
-		assert.Equal(t, 1, walkCalls[1].argIndex)
-		assert.Equal(t, arg2, walkCalls[1].arg)
+		require.Len(t, resolved, 2)
+		assert.Equal(t, ResolvedCallExprArgPositional, resolved[0].Kind)
+		assert.Equal(t, fun, resolved[0].Fun)
+		assert.Equal(t, params, resolved[0].Params)
+		assert.Equal(t, param1, resolved[0].Param)
+		assert.Equal(t, 0, resolved[0].ParamIndex)
+		assert.Equal(t, arg1, resolved[0].Arg)
+		assert.Equal(t, 0, resolved[0].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		assert.Equal(t, ResolvedCallExprArgPositional, resolved[1].Kind)
+		assert.Equal(t, param2, resolved[1].Param)
+		assert.Equal(t, 1, resolved[1].ParamIndex)
+		assert.Equal(t, arg2, resolved[1].Arg)
+		assert.Equal(t, 1, resolved[1].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[1].ExpectedType)
 	})
 
-	t.Run("CallExprWithVariadicFunction", func(t *testing.T) {
+	t.Run("VariadicFunction", func(t *testing.T) {
 		ident := &ast.Ident{Name: "testFunc"}
 		arg1 := &ast.Ident{Name: "arg1"}
 		arg2 := &ast.Ident{Name: "arg2"}
@@ -343,184 +509,53 @@ func TestWalkCallExprArgs(t *testing.T) {
 		params := gotypes.NewTuple(param1, variadicParam)
 		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, true)
 		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
-		})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, expr))
 
-		var walkCalls []struct {
-			paramIndex int
-			argIndex   int
-		}
-
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalls = append(walkCalls, struct {
-				paramIndex int
-				argIndex   int
-			}{paramIndex, argIndex})
-			return true
-		}
-
-		WalkCallExprArgs(typeInfo, expr, walkFn)
-
-		require.Len(t, walkCalls, 3)
-		assert.Equal(t, 0, walkCalls[0].paramIndex) // First param
-		assert.Equal(t, 0, walkCalls[0].argIndex)
-		assert.Equal(t, 1, walkCalls[1].paramIndex) // Variadic param
-		assert.Equal(t, 1, walkCalls[1].argIndex)
-		assert.Equal(t, 1, walkCalls[2].paramIndex) // Still variadic param
-		assert.Equal(t, 2, walkCalls[2].argIndex)
+		require.Len(t, resolved, 3)
+		assert.Equal(t, 0, resolved[0].ParamIndex)
+		assert.Equal(t, 0, resolved[0].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		assert.Equal(t, 1, resolved[1].ParamIndex)
+		assert.Equal(t, 1, resolved[1].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[1].ExpectedType)
+		assert.Equal(t, 1, resolved[2].ParamIndex)
+		assert.Equal(t, 2, resolved[2].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[2].ExpectedType)
 	})
 
-	t.Run("CallExprStopsWhenWalkFnReturnsFalse", func(t *testing.T) {
+	t.Run("VariadicFunctionWithEllipsis", func(t *testing.T) {
 		ident := &ast.Ident{Name: "testFunc"}
 		arg1 := &ast.Ident{Name: "arg1"}
 		arg2 := &ast.Ident{Name: "arg2"}
 		expr := &ast.CallExpr{
-			Fun:  ident,
-			Args: []ast.Expr{arg1, arg2},
+			Fun:      ident,
+			Args:     []ast.Expr{arg1, arg2},
+			Ellipsis: token.Pos(1),
 		}
 
 		pkg := gotypes.NewPackage("test", "test")
 		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
-		param2 := gotypes.NewParam(token.NoPos, pkg, "p2", gotypes.Typ[gotypes.String])
-		params := gotypes.NewTuple(param1, param2)
-		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		variadicType := gotypes.NewSlice(gotypes.Typ[gotypes.String])
+		variadicParam := gotypes.NewParam(token.NoPos, pkg, "args", variadicType)
+		params := gotypes.NewTuple(param1, variadicParam)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, true)
 		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
-		})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, expr))
 
-		walkCallCount := 0
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCallCount++
-			return false // Stop after first call.
-		}
-
-		WalkCallExprArgs(typeInfo, expr, walkFn)
-		assert.Equal(t, 1, walkCallCount)
+		require.Len(t, resolved, 2)
+		assert.Equal(t, 0, resolved[0].ParamIndex)
+		assert.Equal(t, 0, resolved[0].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		assert.Equal(t, 1, resolved[1].ParamIndex)
+		assert.Equal(t, 1, resolved[1].ArgIndex)
+		assert.Equal(t, variadicType, resolved[1].ExpectedType)
 	})
 
-	t.Run("CallExprWithXGoPackageXGotMethod", func(t *testing.T) {
-		ident := &ast.Ident{Name: "XGot_Sprite_Move"}
-		arg1 := &ast.Ident{Name: "arg1"}
-		expr := &ast.CallExpr{
-			Fun:  ident,
-			Args: []ast.Expr{arg1},
-		}
-
-		pkg := gotypes.NewPackage("test", "test")
-		markAsXGoPackage(pkg)
-
-		recv := gotypes.NewParam(token.NoPos, pkg, "recv", gotypes.Typ[gotypes.Int])
-		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
-		params := gotypes.NewTuple(recv, param1)
-		sig := gotypes.NewSignatureType(recv, nil, nil, params, nil, false)
-		fun := gotypes.NewFunc(token.NoPos, pkg, "XGot_Sprite_Move", sig)
-
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
-		})
-
-		var walkCalls []struct {
-			paramIndex int
-			argIndex   int
-		}
-
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalls = append(walkCalls, struct {
-				paramIndex int
-				argIndex   int
-			}{paramIndex, argIndex})
-			return true
-		}
-
-		WalkCallExprArgs(typeInfo, expr, walkFn)
-
-		// Should skip the receiver parameter.
-		require.Len(t, walkCalls, 1)
-		assert.Equal(t, 0, walkCalls[0].paramIndex) // First non-receiver param index in new tuple.
-		assert.Equal(t, 0, walkCalls[0].argIndex)   // First arg.
-	})
-
-	t.Run("CallExprWithFuncExFunction", func(t *testing.T) {
-		pkg := gotypes.NewPackage("test", "test")
-		ident := &ast.Ident{Name: "testFunc"}
-		expr := &ast.CallExpr{
-			Fun:  ident,
-			Args: []ast.Expr{&ast.Ident{Name: "arg"}},
-		}
-		fun := gogen.NewOverloadFunc(token.NoPos, pkg, "testFunc",
-			gotypes.NewFunc(token.NoPos, pkg, "foo", gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)),
-		)
-
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
-		})
-
-		walkCalled := false
-		WalkCallExprArgs(typeInfo, expr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalled = true
-			return true
-		})
-		assert.False(t, walkCalled)
-	})
-
-	t.Run("CallExprWithXGoPackageXGoxMethod", func(t *testing.T) {
-		pkg := gotypes.NewPackage("test", "test")
-		markAsXGoPackage(pkg)
-
-		constraint := gotypes.NewInterfaceType(nil, nil)
-		constraint.Complete()
-		typeParam := gotypes.NewTypeParam(gotypes.NewTypeName(token.NoPos, pkg, "T", nil), constraint)
-		recv := gotypes.NewParam(token.NoPos, pkg, "recv", gotypes.Typ[gotypes.Int])
-		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.String])
-		params := gotypes.NewTuple(recv, param1)
-		sig := gotypes.NewSignatureType(nil, nil, []*gotypes.TypeParam{typeParam}, params, nil, false)
-		fun := gotypes.NewFunc(token.NoPos, pkg, "XGot_Sprite_XGox_Move", sig)
-
-		ident := &ast.Ident{Name: "XGot_Sprite_XGox_Move"}
-		expr := &ast.CallExpr{
-			Fun: ident,
-			Args: []ast.Expr{
-				&ast.Ident{Name: "int"},
-				&ast.BasicLit{Kind: token.STRING, Value: `"ok"`},
-			},
-		}
-
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
-		})
-
-		var walkCalls []struct {
-			paramName  string
-			paramIndex int
-			argIndex   int
-		}
-		WalkCallExprArgs(typeInfo, expr, func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalls = append(walkCalls, struct {
-				paramName  string
-				paramIndex int
-				argIndex   int
-			}{
-				paramName:  params.At(paramIndex).Name(),
-				paramIndex: paramIndex,
-				argIndex:   argIndex,
-			})
-			return true
-		})
-
-		require.Len(t, walkCalls, 2)
-		assert.Equal(t, "T", walkCalls[0].paramName)
-		assert.Equal(t, 0, walkCalls[0].paramIndex)
-		assert.Equal(t, 0, walkCalls[0].argIndex)
-		assert.Equal(t, "p1", walkCalls[1].paramName)
-		assert.Equal(t, 1, walkCalls[1].paramIndex)
-		assert.Equal(t, 1, walkCalls[1].argIndex)
-	})
-
-	t.Run("CallExprWithMoreArgsThanParams", func(t *testing.T) {
+	t.Run("VariadicFunctionWithOptionalParamWithoutKwargs", func(t *testing.T) {
 		ident := &ast.Ident{Name: "testFunc"}
 		arg1 := &ast.Ident{Name: "arg1"}
 		arg2 := &ast.Ident{Name: "arg2"}
@@ -531,62 +566,954 @@ func TestWalkCallExprArgs(t *testing.T) {
 		}
 
 		pkg := gotypes.NewPackage("test", "test")
-		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
-		params := gotypes.NewTuple(param1)
-		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		param1 := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_p1", gotypes.Typ[gotypes.Int])
+		variadicParam := gotypes.NewParam(token.NoPos, pkg, "args", gotypes.NewSlice(gotypes.Typ[gotypes.String]))
+		params := gotypes.NewTuple(param1, variadicParam)
+		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, true)
 		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
-		})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, expr))
 
-		var walkCalls []struct {
-			paramIndex int
-			argIndex   int
-		}
-
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalls = append(walkCalls, struct {
-				paramIndex int
-				argIndex   int
-			}{paramIndex, argIndex})
-			return true
-		}
-
-		WalkCallExprArgs(typeInfo, expr, walkFn)
-
-		// Should only process one argument since function is not variadic.
-		require.Len(t, walkCalls, 1)
-		assert.Equal(t, 0, walkCalls[0].paramIndex)
-		assert.Equal(t, 0, walkCalls[0].argIndex)
+		require.Len(t, resolved, 3)
+		assert.Equal(t, param1, resolved[0].Param)
+		assert.Equal(t, 0, resolved[0].ParamIndex)
+		assert.Equal(t, 0, resolved[0].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		assert.Equal(t, variadicParam, resolved[1].Param)
+		assert.Equal(t, 1, resolved[1].ParamIndex)
+		assert.Equal(t, 1, resolved[1].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[1].ExpectedType)
+		assert.Equal(t, variadicParam, resolved[2].Param)
+		assert.Equal(t, 1, resolved[2].ParamIndex)
+		assert.Equal(t, 2, resolved[2].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[2].ExpectedType)
 	})
 
-	t.Run("CallExprWithNoParams", func(t *testing.T) {
+	t.Run("YieldStopsIteration", func(t *testing.T) {
 		ident := &ast.Ident{Name: "testFunc"}
-		arg1 := &ast.Ident{Name: "arg1"}
 		expr := &ast.CallExpr{
-			Fun:  ident,
-			Args: []ast.Expr{arg1},
+			Fun: ident,
+			Args: []ast.Expr{
+				&ast.Ident{Name: "arg1"},
+				&ast.Ident{Name: "arg2"},
+			},
 		}
 
 		pkg := gotypes.NewPackage("test", "test")
-		params := gotypes.NewTuple()
-		sig := gotypes.NewSignatureType(nil, nil, nil, params, nil, false)
+		param1 := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		param2 := gotypes.NewParam(token.NoPos, pkg, "p2", gotypes.Typ[gotypes.String])
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param1, param2), nil, false)
 		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
 
-		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{
-			ident: fun,
+		callCount := 0
+		ResolvedCallExprArgs(typeInfo, expr)(func(ResolvedCallExprArg) bool {
+			callCount++
+			return false
 		})
+		assert.Equal(t, 1, callCount)
+	})
 
-		walkCalled := false
-		walkFn := func(fun *gotypes.Func, params *gotypes.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool {
-			walkCalled = true
-			return true
+	t.Run("XGoPackageXGotMethod", func(t *testing.T) {
+		ident := &ast.Ident{Name: "XGot_Sprite_Move"}
+		arg := &ast.Ident{Name: "arg1"}
+		expr := &ast.CallExpr{
+			Fun:  ident,
+			Args: []ast.Expr{arg},
 		}
 
-		WalkCallExprArgs(typeInfo, expr, walkFn)
+		pkg := gotypes.NewPackage("test", "test")
+		markAsXGoPackage(pkg)
+		recv := gotypes.NewParam(token.NoPos, pkg, "recv", gotypes.Typ[gotypes.Int])
+		param := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		sig := gotypes.NewSignatureType(recv, nil, nil, gotypes.NewTuple(recv, param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "XGot_Sprite_Move", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
 
-		// Should not call walkFn since function has no parameters and more args than params.
-		assert.False(t, walkCalled)
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, expr))
+
+		require.Len(t, resolved, 1)
+		assert.Equal(t, param, resolved[0].Param)
+		assert.Equal(t, 0, resolved[0].ParamIndex)
+		assert.Equal(t, arg, resolved[0].Arg)
+		assert.Equal(t, 0, resolved[0].ArgIndex)
+	})
+
+	t.Run("FuncExFunction", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		ident := &ast.Ident{Name: "testFunc"}
+		fun := gogen.NewOverloadFunc(token.NoPos, pkg, "testFunc",
+			gotypes.NewFunc(token.NoPos, pkg, "foo", gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)),
+		)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:  ident,
+			Args: []ast.Expr{&ast.Ident{Name: "arg"}},
+		}))
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("XGoPackageXGoxMethod", func(t *testing.T) {
+		pkg := gotypes.NewPackage("test", "test")
+		markAsXGoPackage(pkg)
+		constraint := gotypes.NewInterfaceType(nil, nil)
+		constraint.Complete()
+		typeParam := gotypes.NewTypeParam(gotypes.NewTypeName(token.NoPos, pkg, "T", nil), constraint)
+		recv := gotypes.NewParam(token.NoPos, pkg, "recv", gotypes.Typ[gotypes.Int])
+		param := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.String])
+		sig := gotypes.NewSignatureType(nil, nil, []*gotypes.TypeParam{typeParam}, gotypes.NewTuple(recv, param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "XGot_Sprite_XGox_Move", sig)
+
+		ident := &ast.Ident{Name: "XGot_Sprite_XGox_Move"}
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun: ident,
+			Args: []ast.Expr{
+				&ast.Ident{Name: "int"},
+				&ast.BasicLit{Kind: token.STRING, Value: `"ok"`},
+			},
+		}))
+
+		require.Len(t, resolved, 2)
+		assert.Equal(t, "T", resolved[0].Param.Name())
+		assert.Equal(t, 0, resolved[0].ParamIndex)
+		assert.Equal(t, 0, resolved[0].ArgIndex)
+		assert.True(t, resolved[0].IsTypeArg())
+		assert.Equal(t, "p1", resolved[1].Param.Name())
+		assert.Equal(t, 1, resolved[1].ParamIndex)
+		assert.Equal(t, 1, resolved[1].ArgIndex)
+		assert.False(t, resolved[1].IsTypeArg())
+	})
+
+	t.Run("MoreArgsThanParams", func(t *testing.T) {
+		ident := &ast.Ident{Name: "testFunc"}
+		expr := &ast.CallExpr{
+			Fun: ident,
+			Args: []ast.Expr{
+				&ast.Ident{Name: "arg1"},
+				&ast.Ident{Name: "arg2"},
+				&ast.Ident{Name: "arg3"},
+			},
+		}
+
+		pkg := gotypes.NewPackage("test", "test")
+		param := gotypes.NewParam(token.NoPos, pkg, "p1", gotypes.Typ[gotypes.Int])
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, expr))
+
+		require.Len(t, resolved, 1)
+		assert.Equal(t, 0, resolved[0].ParamIndex)
+		assert.Equal(t, 0, resolved[0].ArgIndex)
+	})
+
+	t.Run("NoParams", func(t *testing.T) {
+		ident := &ast.Ident{Name: "testFunc"}
+		pkg := gotypes.NewPackage("test", "test")
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "testFunc", sig)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:  ident,
+			Args: []ast.Expr{&ast.Ident{Name: "arg1"}},
+		}))
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("StructKwargs", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		valueArg := &ast.Ident{Name: "countValue"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: valueArg,
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		countField := gotypes.NewField(token.NoPos, pkg, "Count", gotypes.Typ[gotypes.Int], false)
+		nameField := gotypes.NewField(token.NoPos, pkg, "Name", gotypes.Typ[gotypes.String], false)
+		optsType := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Options", nil),
+			gotypes.NewStruct([]*gotypes.Var{countField, nameField}, nil),
+			nil,
+		)
+		param := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", optsType)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Equal(t, ResolvedCallExprArgKeyword, resolved[0].Kind)
+		assert.Equal(t, kwarg, resolved[0].Kwarg)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		require.NotNil(t, resolved[0].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetStructField, resolved[0].KwargTarget.Kind)
+		assert.Equal(t, "count", resolved[0].KwargTarget.Name)
+		assert.Equal(t, countField, resolved[0].KwargTarget.Field)
+	})
+
+	t.Run("MapKwargsOnVariadicFunction", func(t *testing.T) {
+		ident := &ast.Ident{Name: "process"}
+		firstArg := &ast.Ident{Name: "arg1"}
+		kwargValue := &ast.Ident{Name: "nameValue"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "name"},
+			Value: kwargValue,
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", gotypes.NewMap(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.String]))
+		argsParam := gotypes.NewParam(token.NoPos, pkg, "args", gotypes.NewSlice(gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam, argsParam), nil, true)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "process", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Args:   []ast.Expr{firstArg},
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, ResolvedCallExprArgPositional, resolved[0].Kind)
+		assert.Equal(t, argsParam, resolved[0].Param)
+		assert.Equal(t, 1, resolved[0].ParamIndex)
+		assert.Zero(t, resolved[0].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		assert.Equal(t, ResolvedCallExprArgKeyword, resolved[1].Kind)
+		assert.Equal(t, optsParam, resolved[1].Param)
+		assert.Zero(t, resolved[1].ParamIndex)
+		assert.Equal(t, 1, resolved[1].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[1].ExpectedType)
+		require.NotNil(t, resolved[1].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetMap, resolved[1].KwargTarget.Kind)
+	})
+
+	t.Run("MapKwargsOnVariadicFunctionWithEllipsis", func(t *testing.T) {
+		ident := &ast.Ident{Name: "process"}
+		arg := &ast.Ident{Name: "args"}
+		kwargValue := &ast.Ident{Name: "nameValue"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "name"},
+			Value: kwargValue,
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", gotypes.NewMap(gotypes.Typ[gotypes.String], gotypes.Typ[gotypes.String]))
+		argsType := gotypes.NewSlice(gotypes.Typ[gotypes.Int])
+		argsParam := gotypes.NewParam(token.NoPos, pkg, "args", argsType)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam, argsParam), nil, true)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "process", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:      ident,
+			Args:     []ast.Expr{arg},
+			Ellipsis: token.Pos(1),
+			Kwargs:   []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, ResolvedCallExprArgPositional, resolved[0].Kind)
+		assert.Equal(t, argsParam, resolved[0].Param)
+		assert.Equal(t, 1, resolved[0].ParamIndex)
+		assert.Zero(t, resolved[0].ArgIndex)
+		assert.Equal(t, argsType, resolved[0].ExpectedType)
+		assert.Equal(t, ResolvedCallExprArgKeyword, resolved[1].Kind)
+		assert.Equal(t, optsParam, resolved[1].Param)
+		assert.Zero(t, resolved[1].ParamIndex)
+		assert.Equal(t, 1, resolved[1].ArgIndex)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[1].ExpectedType)
+		require.NotNil(t, resolved[1].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetMap, resolved[1].KwargTarget.Kind)
+	})
+
+	t.Run("MapKwargsWithNamedStringKey", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		keyType := gotypes.NewNamed(gotypes.NewTypeName(token.NoPos, pkg, "Key", nil), gotypes.Typ[gotypes.String], nil)
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", gotypes.NewMap(keyType, gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		require.NotNil(t, resolved[0].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetMap, resolved[0].KwargTarget.Kind)
+	})
+
+	t.Run("MapKwargsWithAnyKey", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		anyIface := gotypes.NewInterfaceType(nil, nil)
+		anyIface.Complete()
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", gotypes.NewMap(anyIface, gotypes.Typ[gotypes.Int]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		require.NotNil(t, resolved[0].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetMap, resolved[0].KwargTarget.Kind)
+	})
+
+	t.Run("MapKwargsWithIntKeyStayUnresolved", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", gotypes.NewMap(gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.String]))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Nil(t, resolved[0].ExpectedType)
+		assert.Nil(t, resolved[0].KwargTarget)
+	})
+
+	t.Run("AnyKwargsFallbackMap", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		anyIface := gotypes.NewInterfaceType(nil, nil)
+		anyIface.Complete()
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", anyIface)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.True(t, gotypes.Identical(anyType(), resolved[0].ExpectedType))
+		require.NotNil(t, resolved[0].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetMap, resolved[0].KwargTarget.Kind)
+		assert.Equal(t, "count", resolved[0].KwargTarget.Name)
+	})
+
+	t.Run("AliasAnyKwargsFallbackMap", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		anyIface := gotypes.NewInterfaceType(nil, nil)
+		anyIface.Complete()
+		anyAlias := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "AnyAlias", nil), anyIface)
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", anyAlias)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.True(t, gotypes.Identical(anyType(), resolved[0].ExpectedType))
+		require.NotNil(t, resolved[0].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetMap, resolved[0].KwargTarget.Kind)
+	})
+
+	t.Run("AliasStructKwargsDoNotUseLocalUnexportedFields", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		countField := gotypes.NewField(token.NoPos, pkg, "count", gotypes.Typ[gotypes.Int], false)
+		optsType := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Options", nil),
+			gotypes.NewStruct([]*gotypes.Var{countField}, nil),
+			nil,
+		)
+		optsAlias := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "OptionsAlias", nil), optsType)
+		param := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", optsAlias)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Nil(t, resolved[0].ExpectedType)
+		assert.Nil(t, resolved[0].KwargTarget)
+	})
+
+	t.Run("AliasPointerStructKwargsUseLocalUnexportedFields", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		countField := gotypes.NewField(token.NoPos, pkg, "count", gotypes.Typ[gotypes.Int], false)
+		optsType := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Options", nil),
+			gotypes.NewStruct([]*gotypes.Var{countField}, nil),
+			nil,
+		)
+		optsAlias := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "OptionsPtrAlias", nil), gotypes.NewPointer(optsType))
+		param := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", optsAlias)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], resolved[0].ExpectedType)
+		require.NotNil(t, resolved[0].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetStructField, resolved[0].KwargTarget.Kind)
+		assert.Equal(t, countField, resolved[0].KwargTarget.Field)
+	})
+
+	t.Run("PointerAliasStructKwargsDoNotUseLocalUnexportedFields", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		countField := gotypes.NewField(token.NoPos, pkg, "count", gotypes.Typ[gotypes.Int], false)
+		optsType := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Options", nil),
+			gotypes.NewStruct([]*gotypes.Var{countField}, nil),
+			nil,
+		)
+		optsAlias := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "OptionsAlias", nil), optsType)
+		param := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", gotypes.NewPointer(optsAlias))
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(param), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun:    ident,
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Nil(t, resolved[0].ExpectedType)
+		assert.Nil(t, resolved[0].KwargTarget)
+	})
+
+	t.Run("NamedEmptyInterfaceKwargsStayUnresolved", func(t *testing.T) {
+		ident := &ast.Ident{Name: "configure"}
+		receiver := &ast.Ident{Name: "client"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "count"},
+			Value: &ast.Ident{Name: "countValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsTypeName := gotypes.NewTypeName(token.NoPos, pkg, "Params", nil)
+		paramsNamed := gotypes.NewNamed(paramsTypeName, nil, nil)
+		emptyIface := gotypes.NewInterfaceType(nil, nil)
+		emptyIface.Complete()
+		paramsNamed.SetUnderlying(emptyIface)
+		optsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", paramsNamed)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(optsParam), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "configure", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   receiver,
+				Sel: ident,
+			},
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 1)
+		assert.Nil(t, resolved[0].ExpectedType)
+		assert.Nil(t, resolved[0].KwargTarget)
+	})
+
+	t.Run("AliasInterfaceKwargsStayUnresolved", func(t *testing.T) {
+		ident := &ast.Ident{Name: "Complete"}
+		receiver := &ast.Ident{Name: "client"}
+		kwarg := &ast.KwargExpr{
+			Name:  &ast.Ident{Name: "maxTokens"},
+			Value: &ast.Ident{Name: "maxTokensValue"},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsTypeName := gotypes.NewTypeName(token.NoPos, pkg, "Params", nil)
+		paramsNamed := gotypes.NewNamed(paramsTypeName, nil, nil)
+		maxTokensMethod := gotypes.NewFunc(token.NoPos, pkg, "MaxTokens", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "n", gotypes.Typ[gotypes.Int64])),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		iface := gotypes.NewInterfaceType([]*gotypes.Func{maxTokensMethod}, nil)
+		iface.Complete()
+		paramsNamed.SetUnderlying(iface)
+		paramsAlias := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "ParamsAlias", nil), paramsNamed)
+
+		promptParam := gotypes.NewParam(token.NoPos, pkg, "prompt", gotypes.Typ[gotypes.String])
+		paramsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsAlias)
+		sig := gotypes.NewSignatureType(nil, nil, nil, gotypes.NewTuple(promptParam, paramsParam), nil, false)
+		fun := gotypes.NewFunc(token.NoPos, pkg, "Complete", sig)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   receiver,
+				Sel: ident,
+			},
+			Args:   []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"hi"`}},
+			Kwargs: []*ast.KwargExpr{kwarg},
+		}))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[0].ExpectedType)
+		assert.Nil(t, resolved[1].ExpectedType)
+		assert.Nil(t, resolved[1].KwargTarget)
+	})
+
+	t.Run("InterfaceKwargs", func(t *testing.T) {
+		ident := &ast.Ident{Name: "Complete"}
+		receiver := &ast.Ident{Name: "client"}
+		call := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   receiver,
+				Sel: ident,
+			},
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"hi"`}},
+			Kwargs: []*ast.KwargExpr{
+				newTestKwarg("maxTokens", "maxTokensValue"),
+			},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsNamed := newTestNamedInterface(pkg, "Params")
+		maxTokensMethod := newTestSelfReturningMethod(pkg, "MaxTokens", paramsNamed, "n", gotypes.Typ[gotypes.Int64], false)
+		setTestNamedInterfaceMethods(paramsNamed, maxTokensMethod)
+		promptParam := gotypes.NewParam(token.NoPos, pkg, "prompt", gotypes.Typ[gotypes.String])
+		paramsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed)
+		fun := newTestFunc(pkg, "Complete", false, promptParam, paramsParam)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		addInterfaceKwargFactory(typeInfo, receiver, "Client", paramsNamed)
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, call))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[0].ExpectedType)
+		assert.Equal(t, gotypes.Typ[gotypes.Int64], resolved[1].ExpectedType)
+		require.NotNil(t, resolved[1].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetInterfaceMethod, resolved[1].KwargTarget.Kind)
+		assert.Equal(t, "maxTokens", resolved[1].KwargTarget.Name)
+		assert.Equal(t, maxTokensMethod, resolved[1].KwargTarget.Method)
+	})
+
+	t.Run("VariadicInterfaceKwargs", func(t *testing.T) {
+		ident := &ast.Ident{Name: "Complete"}
+		receiver := &ast.Ident{Name: "client"}
+		call := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   receiver,
+				Sel: ident,
+			},
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"hi"`}},
+			Kwargs: []*ast.KwargExpr{
+				newTestKwarg("system", "systemValue"),
+			},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsNamed := newTestNamedInterface(pkg, "Params")
+		systemMethod := newTestSelfReturningMethod(pkg, "System", paramsNamed, "prompt", gotypes.NewSlice(gotypes.Typ[gotypes.String]), true)
+		setTestNamedInterfaceMethods(paramsNamed, systemMethod)
+		promptParam := gotypes.NewParam(token.NoPos, pkg, "prompt", gotypes.Typ[gotypes.String])
+		paramsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed)
+		fun := newTestFunc(pkg, "Complete", false, promptParam, paramsParam)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		addInterfaceKwargFactory(typeInfo, receiver, "Client", paramsNamed)
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, call))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[0].ExpectedType)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[1].ExpectedType)
+		require.NotNil(t, resolved[1].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetInterfaceMethod, resolved[1].KwargTarget.Kind)
+		assert.Equal(t, "system", resolved[1].KwargTarget.Name)
+		assert.Equal(t, systemMethod, resolved[1].KwargTarget.Method)
+	})
+
+	t.Run("FreeFunctionInterfaceKwargs", func(t *testing.T) {
+		ident := &ast.Ident{Name: "Complete"}
+		call := &ast.CallExpr{
+			Fun:  ident,
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"hi"`}},
+			Kwargs: []*ast.KwargExpr{
+				newTestKwarg("maxTokens", "maxTokensValue"),
+			},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsNamed := newTestNamedInterface(pkg, "Params")
+		maxTokensMethod := newTestSelfReturningMethod(pkg, "MaxTokens", paramsNamed, "n", gotypes.Typ[gotypes.Int64], false)
+		setTestNamedInterfaceMethods(paramsNamed, maxTokensMethod)
+		promptParam := gotypes.NewParam(token.NoPos, pkg, "prompt", gotypes.Typ[gotypes.String])
+		paramsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed)
+		fun := newTestFunc(pkg, "Complete", false, promptParam, paramsParam)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, call))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[0].ExpectedType)
+		assert.Nil(t, resolved[1].ExpectedType)
+		assert.Nil(t, resolved[1].KwargTarget)
+	})
+
+	t.Run("InterfaceKwargsWithoutFactoryStayUnresolved", func(t *testing.T) {
+		ident := &ast.Ident{Name: "Complete"}
+		receiver := &ast.Ident{Name: "client"}
+		call := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   receiver,
+				Sel: ident,
+			},
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"hi"`}},
+			Kwargs: []*ast.KwargExpr{
+				newTestKwarg("maxTokens", "maxTokensValue"),
+			},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsNamed := newTestNamedInterface(pkg, "Params")
+		maxTokensMethod := newTestSelfReturningMethod(pkg, "MaxTokens", paramsNamed, "n", gotypes.Typ[gotypes.Int64], false)
+		setTestNamedInterfaceMethods(paramsNamed, maxTokensMethod)
+		promptParam := gotypes.NewParam(token.NoPos, pkg, "prompt", gotypes.Typ[gotypes.String])
+		paramsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed)
+		fun := newTestFunc(pkg, "Complete", false, promptParam, paramsParam)
+		clientNamed := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Client", nil),
+			gotypes.NewStruct(nil, nil),
+			nil,
+		)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		typeInfo.Types[receiver] = gotypes.TypeAndValue{Type: clientNamed}
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, call))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[0].ExpectedType)
+		assert.Nil(t, resolved[1].ExpectedType)
+		assert.Nil(t, resolved[1].KwargTarget)
+	})
+
+	t.Run("InterfaceSetKwargs", func(t *testing.T) {
+		ident := &ast.Ident{Name: "Complete"}
+		receiver := &ast.Ident{Name: "client"}
+		call := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   receiver,
+				Sel: ident,
+			},
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"hi"`}},
+			Kwargs: []*ast.KwargExpr{
+				newTestKwarg("custom", "customValue"),
+			},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsNamed := newTestNamedInterface(pkg, "Params")
+		anyIface := newTestEmptyInterface()
+		setMethod := gotypes.NewFunc(token.NoPos, pkg, "Set", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(
+				gotypes.NewParam(token.NoPos, pkg, "name", gotypes.Typ[gotypes.String]),
+				gotypes.NewParam(token.NoPos, pkg, "value", anyIface),
+			),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		setTestNamedInterfaceMethods(paramsNamed, setMethod)
+		promptParam := gotypes.NewParam(token.NoPos, pkg, "prompt", gotypes.Typ[gotypes.String])
+		paramsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed)
+		fun := newTestFunc(pkg, "Complete", false, promptParam, paramsParam)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		addInterfaceKwargFactory(typeInfo, receiver, "Client", paramsNamed)
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, call))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[0].ExpectedType)
+		require.NotNil(t, resolved[1].KwargTarget)
+		assert.Equal(t, ResolvedCallExprKwargTargetInterfaceSet, resolved[1].KwargTarget.Kind)
+		assert.Equal(t, "custom", resolved[1].KwargTarget.Name)
+		assert.True(t, gotypes.Identical(anyType(), resolved[1].ExpectedType))
+	})
+
+	t.Run("InterfaceSetWithAliasParamTypesStaysUnresolved", func(t *testing.T) {
+		ident := &ast.Ident{Name: "Complete"}
+		receiver := &ast.Ident{Name: "client"}
+		call := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   receiver,
+				Sel: ident,
+			},
+			Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"hi"`}},
+			Kwargs: []*ast.KwargExpr{
+				newTestKwarg("custom", "customValue"),
+			},
+		}
+
+		pkg := gotypes.NewPackage("main", "main")
+		paramsNamed := newTestNamedInterface(pkg, "Params")
+		anyIface := newTestEmptyInterface()
+		keyAlias := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "Key", nil), gotypes.Typ[gotypes.String])
+		anyAlias := gotypes.NewAlias(gotypes.NewTypeName(token.NoPos, pkg, "Any", nil), anyIface)
+		setMethod := gotypes.NewFunc(token.NoPos, pkg, "Set", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(
+				gotypes.NewParam(token.NoPos, pkg, "name", keyAlias),
+				gotypes.NewParam(token.NoPos, pkg, "value", anyAlias),
+			),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		setTestNamedInterfaceMethods(paramsNamed, setMethod)
+		promptParam := gotypes.NewParam(token.NoPos, pkg, "prompt", gotypes.Typ[gotypes.String])
+		paramsParam := gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed)
+		fun := newTestFunc(pkg, "Complete", false, promptParam, paramsParam)
+
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+		addInterfaceKwargFactory(typeInfo, receiver, "Client", paramsNamed)
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, call))
+		require.Len(t, resolved, 2)
+		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[0].ExpectedType)
+		assert.Nil(t, resolved[1].ExpectedType)
+		assert.Nil(t, resolved[1].KwargTarget)
+	})
+}
+
+func TestListResolvedCallExprKwargTargets(t *testing.T) {
+	t.Run("StructSkipsLaterLocalFieldName", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		exportedField := gotypes.NewField(token.NoPos, pkg, "Count", gotypes.Typ[gotypes.Int], false)
+		localField := gotypes.NewField(token.NoPos, pkg, "count", gotypes.Typ[gotypes.String], false)
+		optsType := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Options", nil),
+			gotypes.NewStruct([]*gotypes.Var{exportedField, localField}, nil),
+			nil,
+		)
+		kwarg := &ResolvedCallExprKwarg{
+			Param: gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", optsType),
+		}
+
+		targets := ListResolvedCallExprKwargTargets(kwarg)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "count", targets[0].Name)
+		assert.Equal(t, exportedField, targets[0].Field)
+	})
+
+	t.Run("StructSkipsLaterExportedFieldName", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		localField := gotypes.NewField(token.NoPos, pkg, "count", gotypes.Typ[gotypes.String], false)
+		exportedField := gotypes.NewField(token.NoPos, pkg, "Count", gotypes.Typ[gotypes.Int], false)
+		optsType := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Options", nil),
+			gotypes.NewStruct([]*gotypes.Var{localField, exportedField}, nil),
+			nil,
+		)
+		kwarg := &ResolvedCallExprKwarg{
+			Param: gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", optsType),
+		}
+
+		targets := ListResolvedCallExprKwargTargets(kwarg)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "count", targets[0].Name)
+		assert.Equal(t, localField, targets[0].Field)
+	})
+
+	t.Run("StructUsesUnicodeKeywordName", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		field := gotypes.NewField(token.NoPos, pkg, "\u00c4ge", gotypes.Typ[gotypes.Int], false)
+		optsType := gotypes.NewNamed(
+			gotypes.NewTypeName(token.NoPos, pkg, "Options", nil),
+			gotypes.NewStruct([]*gotypes.Var{field}, nil),
+			nil,
+		)
+		kwarg := &ResolvedCallExprKwarg{
+			Param: gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_opts", optsType),
+		}
+
+		targets := ListResolvedCallExprKwargTargets(kwarg)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "\u00e4ge", targets[0].Name)
+		assert.Equal(t, field, targets[0].Field)
+		assert.Equal(t, field, LookupResolvedCallExprKwargTarget(kwarg, "\u00e4ge").Field)
+	})
+
+	t.Run("InterfaceSkipsShadowedLowercaseMethodName", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		paramsTypeName := gotypes.NewTypeName(token.NoPos, pkg, "Params", nil)
+		paramsNamed := gotypes.NewNamed(paramsTypeName, nil, nil)
+		exportedMethod := gotypes.NewFunc(token.NoPos, pkg, "MaxTokens", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "n", gotypes.Typ[gotypes.Int64])),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		localMethod := gotypes.NewFunc(token.NoPos, pkg, "maxTokens", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "n", gotypes.Typ[gotypes.String])),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		iface := gotypes.NewInterfaceType([]*gotypes.Func{exportedMethod, localMethod}, nil)
+		iface.Complete()
+		paramsNamed.SetUnderlying(iface)
+		kwarg := &ResolvedCallExprKwarg{
+			Param:                 gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed),
+			AllowInterfaceTargets: true,
+		}
+
+		targets := ListResolvedCallExprKwargTargets(kwarg)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "maxTokens", targets[0].Name)
+		assert.Equal(t, exportedMethod, targets[0].Method)
+	})
+
+	t.Run("InterfaceListsSetKeywordMethod", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		paramsTypeName := gotypes.NewTypeName(token.NoPos, pkg, "Params", nil)
+		paramsNamed := gotypes.NewNamed(paramsTypeName, nil, nil)
+		setMethod := gotypes.NewFunc(token.NoPos, pkg, "Set", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "enabled", gotypes.Typ[gotypes.Bool])),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		iface := gotypes.NewInterfaceType([]*gotypes.Func{setMethod}, nil)
+		iface.Complete()
+		paramsNamed.SetUnderlying(iface)
+		kwarg := &ResolvedCallExprKwarg{
+			Param:                 gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed),
+			AllowInterfaceTargets: true,
+		}
+
+		targets := ListResolvedCallExprKwargTargets(kwarg)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "set", targets[0].Name)
+		assert.Equal(t, setMethod, targets[0].Method)
+		assert.Equal(t, setMethod, LookupResolvedCallExprKwargTarget(kwarg, "set").Method)
+	})
+
+	t.Run("InterfaceDoesNotListDynamicSetTarget", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		paramsTypeName := gotypes.NewTypeName(token.NoPos, pkg, "Params", nil)
+		paramsNamed := gotypes.NewNamed(paramsTypeName, nil, nil)
+		anyIface := gotypes.NewInterfaceType(nil, nil)
+		anyIface.Complete()
+		setMethod := gotypes.NewFunc(token.NoPos, pkg, "Set", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(
+				gotypes.NewParam(token.NoPos, pkg, "name", gotypes.Typ[gotypes.String]),
+				gotypes.NewParam(token.NoPos, pkg, "value", anyIface),
+			),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		iface := gotypes.NewInterfaceType([]*gotypes.Func{setMethod}, nil)
+		iface.Complete()
+		paramsNamed.SetUnderlying(iface)
+		kwarg := &ResolvedCallExprKwarg{
+			Param:                 gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed),
+			AllowInterfaceTargets: true,
+		}
+
+		assert.Empty(t, ListResolvedCallExprKwargTargets(kwarg))
+		target := LookupResolvedCallExprKwargTarget(kwarg, "custom")
+		require.NotNil(t, target)
+		assert.Equal(t, ResolvedCallExprKwargTargetInterfaceSet, target.Kind)
+	})
+
+	t.Run("InterfaceUsesASCIIKeywordName", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		paramsTypeName := gotypes.NewTypeName(token.NoPos, pkg, "Params", nil)
+		paramsNamed := gotypes.NewNamed(paramsTypeName, nil, nil)
+		method := gotypes.NewFunc(token.NoPos, pkg, "\u00c4ge", gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "n", gotypes.Typ[gotypes.Int])),
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", paramsNamed)),
+			false,
+		))
+		iface := gotypes.NewInterfaceType([]*gotypes.Func{method}, nil)
+		iface.Complete()
+		paramsNamed.SetUnderlying(iface)
+		kwarg := &ResolvedCallExprKwarg{
+			Param:                 gotypes.NewParam(token.NoPos, pkg, "__xgo_optional_params", paramsNamed),
+			AllowInterfaceTargets: true,
+		}
+
+		targets := ListResolvedCallExprKwargTargets(kwarg)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "\u00c4ge", targets[0].Name)
+		assert.Equal(t, method, targets[0].Method)
+		assert.Nil(t, LookupResolvedCallExprKwargTarget(kwarg, "\u00e4ge"))
 	})
 }


### PR DESCRIPTION
Replace the callback-based `WalkCallExprArgs` helper with an iterator that exposes normalized parameters, expected argument types, positional arguments, and keyword argument targets through one call argument model.

This lets analysis and server call sites consume XGo call arguments without duplicating signature mapping logic, and keeps kwargs-aware argument handling centralized for later language service support.