### PR TITLE
refactor(xgoutil): replace traversal walkers with iterators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ features (completion, diagnostics, hover, etc.) for XGo source files.
 
 ## Code conventions
 
+### Iterator conventions
+
+For traversal helpers, prefer `iter.Seq` or `iter.Seq2` with `for range` over walker-style callbacks.
+
 ### Import alias conventions
 
 When a `github.com/goplus/xgo/*` package corresponds to a standard library `go/*` package, prefer the XGo package and

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	gotypes "go/types"
+	"iter"
 	"slices"
 	"strconv"
 	"strings"
@@ -191,9 +192,7 @@ func (s *Server) xgoGetProperties(params XGoGetPropertiesParams) ([]XGoProperty,
 
 	mainPkgDoc, _ := proj.PkgDoc()
 
-	properties := []XGoProperty{}
-	seenNames := make(map[string]bool)
-	collectPropertiesFromNamedType(namedType, mainPkgDoc, make(map[*gotypes.Named]bool), seenNames, &properties)
+	properties := collectPropertiesFromNamedType(namedType, mainPkgDoc)
 
 	slices.SortStableFunc(properties, func(a, b XGoProperty) int {
 		if p1, p2 := xgoPropertyKindPriority[a.Kind], xgoPropertyKindPriority[b.Kind]; p1 != p2 {
@@ -218,73 +217,85 @@ type propertyMember struct {
 	SpxDef SpxDefinition
 }
 
-// walkPropertyMembers recursively walks namedType and its embedded types,
-// calling onMember for each property field or property method in depth-first,
-// outer-scope-first order. Outer (less deeply nested) members shadow embedded
-// ones with the same name. visited prevents infinite recursion for cyclic
-// embeddings; seenNames tracks already-yielded property names.
-func walkPropertyMembers(namedType *gotypes.Named, pkgDocFor func(*gotypes.Package) *pkgdoc.PkgDoc, visited map[*gotypes.Named]bool, seenNames map[string]bool, onMember func(propertyMember)) {
-	if visited[namedType] {
-		return
-	}
-	visited[namedType] = true
-
-	structType, ok := namedType.Underlying().(*gotypes.Struct)
-	if !ok {
-		return
-	}
-
-	selectorTypeName := namedType.Obj().Name()
-
-	// Single pass over fields: yield direct property fields and collect
-	// embedded types for later recursion, so each field is visited only once.
-	var embeddedTypes []*gotypes.Named
-	for field := range structType.Fields() {
-		if field.Embedded() {
-			embeddedType := gotypes.Unalias(xgoutil.DerefType(field.Type()))
-			if embNamed, ok := embeddedType.(*gotypes.Named); ok {
-				embeddedTypes = append(embeddedTypes, embNamed)
+// propertyMembers returns an iterator over property fields and property methods
+// in depth-first, outer-scope-first order. Outer members shadow embedded ones
+// with the same name.
+func propertyMembers(namedType *gotypes.Named, pkgDocFor func(*gotypes.Package) *pkgdoc.PkgDoc) iter.Seq[propertyMember] {
+	return func(yield func(propertyMember) bool) {
+		visited := make(map[*gotypes.Named]bool)
+		seenNames := make(map[string]bool)
+		var walk func(namedType *gotypes.Named) bool
+		walk = func(namedType *gotypes.Named) bool {
+			if visited[namedType] {
+				return true
 			}
-			continue
-		}
-		if !isPropertyField(field) {
-			continue
-		}
-		name := field.Name()
-		if seenNames[name] {
-			continue
-		}
-		seenNames[name] = true
-		onMember(propertyMember{
-			Name:   name,
-			Type:   field.Type(),
-			Kind:   XGoPropertyKindField,
-			SpxDef: GetSpxDefinitionForVar(field, selectorTypeName, false, pkgDocFor(field.Pkg())),
-		})
-	}
+			visited[namedType] = true
 
-	// Collect methods defined directly on this type.
-	for method := range namedType.Methods() {
-		if !isPropertyMethod(method) {
-			continue
-		}
-		name := xgoutil.ToLowerCamelCase(method.Name())
-		if seenNames[name] {
-			continue
-		}
-		seenNames[name] = true
-		sig := method.Signature()
-		onMember(propertyMember{
-			Name:   name,
-			Type:   sig.Results().At(0).Type(),
-			Kind:   XGoPropertyKindMethod,
-			SpxDef: GetSpxDefinitionForFunc(method, selectorTypeName, pkgDocFor(method.Pkg())),
-		})
-	}
+			structType, ok := namedType.Underlying().(*gotypes.Struct)
+			if !ok {
+				return true
+			}
 
-	// Recurse into embedded types collected during the field pass.
-	for _, embNamed := range embeddedTypes {
-		walkPropertyMembers(embNamed, pkgDocFor, visited, seenNames, onMember)
+			selectorTypeName := namedType.Obj().Name()
+			yieldProperty := func(member propertyMember) bool {
+				if seenNames[member.Name] {
+					return true
+				}
+				seenNames[member.Name] = true
+				return yield(member)
+			}
+
+			// Single pass over fields: yield direct property fields and collect
+			// embedded types for later recursion, so each field is visited only once.
+			var embeddedTypes []*gotypes.Named
+			for field := range structType.Fields() {
+				if field.Embedded() {
+					embeddedType := gotypes.Unalias(xgoutil.DerefType(field.Type()))
+					if embNamed, ok := embeddedType.(*gotypes.Named); ok {
+						embeddedTypes = append(embeddedTypes, embNamed)
+					}
+					continue
+				}
+				if !isPropertyField(field) {
+					continue
+				}
+				name := field.Name()
+				if !yieldProperty(propertyMember{
+					Name:   name,
+					Type:   field.Type(),
+					Kind:   XGoPropertyKindField,
+					SpxDef: GetSpxDefinitionForVar(field, selectorTypeName, false, pkgDocFor(field.Pkg())),
+				}) {
+					return false
+				}
+			}
+
+			// Collect methods defined directly on this type.
+			for method := range namedType.Methods() {
+				if !isPropertyMethod(method) {
+					continue
+				}
+				name := xgoutil.ToLowerCamelCase(method.Name())
+				sig := method.Signature()
+				if !yieldProperty(propertyMember{
+					Name:   name,
+					Type:   sig.Results().At(0).Type(),
+					Kind:   XGoPropertyKindMethod,
+					SpxDef: GetSpxDefinitionForFunc(method, selectorTypeName, pkgDocFor(method.Pkg())),
+				}) {
+					return false
+				}
+			}
+
+			// Recurse into embedded types collected during the field pass.
+			for _, embNamed := range embeddedTypes {
+				if !walk(embNamed) {
+					return false
+				}
+			}
+			return true
+		}
+		walk(namedType)
 	}
 }
 
@@ -301,18 +312,19 @@ func makePkgDocFor(mainPkgDoc *pkgdoc.PkgDoc) func(*gotypes.Package) *pkgdoc.Pkg
 	}
 }
 
-// collectPropertiesFromNamedType recursively collects properties from a named
-// type into properties, using walkPropertyMembers for the traversal.
-func collectPropertiesFromNamedType(namedType *gotypes.Named, mainPkgDoc *pkgdoc.PkgDoc, visited map[*gotypes.Named]bool, seenNames map[string]bool, properties *[]XGoProperty) {
-	walkPropertyMembers(namedType, makePkgDocFor(mainPkgDoc), visited, seenNames, func(m propertyMember) {
-		*properties = append(*properties, XGoProperty{
+// collectPropertiesFromNamedType recursively collects properties from a named type.
+func collectPropertiesFromNamedType(namedType *gotypes.Named, mainPkgDoc *pkgdoc.PkgDoc) []XGoProperty {
+	var properties []XGoProperty
+	for m := range propertyMembers(namedType, makePkgDocFor(mainPkgDoc)) {
+		properties = append(properties, XGoProperty{
 			Name:       m.Name,
 			Type:       GetSimplifiedTypeString(m.Type),
 			Kind:       m.Kind,
 			Doc:        m.SpxDef.Detail,
 			Definition: m.SpxDef.ID,
 		})
-	})
+	}
+	return properties
 }
 
 // isPropertyField checks if a field should be included as a property.
@@ -334,13 +346,8 @@ func isPropertyField(field *gotypes.Var) bool {
 	}
 
 	// Allow spx.Value and spx.List
-	if named, ok := fieldType.(*gotypes.Named); ok {
-		if pkg := named.Obj().Pkg(); pkg != nil && pkg.Path() == SpxPkgPath {
-			name := named.Obj().Name()
-			if name == "Value" || name == "List" {
-				return true
-			}
-		}
+	if named, ok := fieldType.(*gotypes.Named); ok && isSpxValueOrListType(named) {
+		return true
 	}
 
 	return false
@@ -373,13 +380,23 @@ func isPropertyMethod(method *gotypes.Func) bool {
 	if _, ok := retType.(*gotypes.Basic); ok {
 		return true
 	}
-	if named, ok := retType.(*gotypes.Named); ok {
-		if pkg := named.Obj().Pkg(); pkg != nil && pkg.Path() == SpxPkgPath {
-			name := named.Obj().Name()
-			if name == "Value" || name == "List" {
-				return true
-			}
-		}
+	if named, ok := retType.(*gotypes.Named); ok && isSpxValueOrListType(named) {
+		return true
+	}
+	return false
+}
+
+// isSpxValueOrListType reports whether named is spx.Value or spx.List.
+func isSpxValueOrListType(named *gotypes.Named) bool {
+	obj := named.Obj()
+	pkg := obj.Pkg()
+	if pkg == nil || pkg.Path() != SpxPkgPath {
+		return false
+	}
+
+	switch obj.Name() {
+	case "Value", "List":
+		return true
 	}
 	return false
 }
@@ -396,12 +413,8 @@ func isPropertyOfEnclosingType(obj gotypes.Object) bool {
 	// Check if the current object is a property (field or method)
 	switch obj := obj.(type) {
 	case *gotypes.Var:
-		if obj.IsField() {
-			// Check if this field is a property
-			return isPropertyField(obj)
-		}
+		return obj.IsField() && isPropertyField(obj)
 	case *gotypes.Func:
-		// Check if this method is a property
 		return isPropertyMethod(obj)
 	}
 
@@ -522,6 +535,11 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 			inputSlots = append(inputSlots, slot)
 		}
 	}
+	addInputSlot := func(slot *SpxInputSlot) {
+		if slot != nil {
+			addInputSlots(*slot)
+		}
+	}
 
 	ast.Inspect(astFile, func(node ast.Node) bool {
 		if node == nil {
@@ -538,26 +556,13 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 			slots := findInputSlotsFromCallExpr(result, node)
 			addInputSlots(slots...)
 		case *ast.BinaryExpr:
-			leftSlot := checkValueInputSlot(result, node.X, nil)
-			if leftSlot != nil {
-				addInputSlots(*leftSlot)
-			}
-
-			rightSlot := checkValueInputSlot(result, node.Y, nil)
-			if rightSlot != nil {
-				addInputSlots(*rightSlot)
-			}
+			addInputSlot(checkValueInputSlot(result, node.X, nil))
+			addInputSlot(checkValueInputSlot(result, node.Y, nil))
 		case *ast.UnaryExpr:
-			slot := checkValueInputSlot(result, node.X, nil)
-			if slot != nil {
-				addInputSlots(*slot)
-			}
+			addInputSlot(checkValueInputSlot(result, node.X, nil))
 		case *ast.AssignStmt:
 			for _, lhs := range node.Lhs {
-				slot := checkAddressInputSlot(result, lhs)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkAddressInputSlot(result, lhs))
 			}
 
 			for i, rhs := range node.Rhs {
@@ -566,34 +571,22 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 					declaredType = typeInfo.TypeOf(node.Lhs[i])
 				}
 
-				slot := checkValueInputSlot(result, rhs, declaredType)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkValueInputSlot(result, rhs, declaredType))
 			}
 		case *ast.ForStmt:
 			if node.Init != nil {
 				if expr, ok := node.Init.(*ast.ExprStmt); ok {
-					slot := checkValueInputSlot(result, expr.X, nil)
-					if slot != nil {
-						addInputSlots(*slot)
-					}
+					addInputSlot(checkValueInputSlot(result, expr.X, nil))
 				}
 			}
 
 			if node.Cond != nil {
-				slot := checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool])
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool]))
 			}
 
 			if node.Post != nil {
 				if expr, ok := node.Post.(*ast.ExprStmt); ok {
-					slot := checkValueInputSlot(result, expr.X, nil)
-					if slot != nil {
-						addInputSlots(*slot)
-					}
+					addInputSlot(checkValueInputSlot(result, expr.X, nil))
 				}
 			}
 		case *ast.ValueSpec:
@@ -609,61 +602,34 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 					}
 				}
 
-				slot := checkValueInputSlot(result, value, declaredType)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkValueInputSlot(result, value, declaredType))
 			}
 		case *ast.ReturnStmt:
 			for _, res := range node.Results {
-				slot := checkValueInputSlot(result, res, nil)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkValueInputSlot(result, res, nil))
 			}
 		case *ast.IfStmt:
-			slot := checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool])
-			if slot != nil {
-				addInputSlots(*slot)
-			}
+			addInputSlot(checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool]))
 		case *ast.SwitchStmt:
 			if node.Tag != nil {
-				slot := checkValueInputSlot(result, node.Tag, nil)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkValueInputSlot(result, node.Tag, nil))
 			}
 		case *ast.CaseClause:
 			for _, expr := range node.List {
-				slot := checkValueInputSlot(result, expr, nil)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkValueInputSlot(result, expr, nil))
 			}
 		case *ast.RangeStmt:
 			if node.Key != nil && !isBlank(node.Key) {
-				slot := checkAddressInputSlot(result, node.Key)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkAddressInputSlot(result, node.Key))
 			}
 
 			if node.Value != nil && !isBlank(node.Value) {
-				slot := checkAddressInputSlot(result, node.Value)
-				if slot != nil {
-					addInputSlots(*slot)
-				}
+				addInputSlot(checkAddressInputSlot(result, node.Value))
 			}
 
-			slot := checkValueInputSlot(result, node.X, nil)
-			if slot != nil {
-				addInputSlots(*slot)
-			}
+			addInputSlot(checkValueInputSlot(result, node.X, nil))
 		case *ast.IncDecStmt:
-			slot := checkAddressInputSlot(result, node.X)
-			if slot != nil {
-				addInputSlots(*slot)
-			}
+			addInputSlot(checkAddressInputSlot(result, node.X))
 		}
 		return true
 	})
@@ -770,8 +736,8 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 					continue
 				}
 
-				xgoutil.WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-					switch member := member.(type) {
+				for structMember := range xgoutil.StructMembers(named) {
+					switch member := structMember.Member.(type) {
 					case *gotypes.Var:
 						if !member.Origin().Embedded() {
 							addNameOf(member)
@@ -784,8 +750,7 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 							addNameOf(member)
 						}
 					}
-					return true
-				})
+				}
 			}
 		}
 	}
@@ -1232,29 +1197,29 @@ func inferSpxSpriteResourceEnclosingNode(result *compileResult, node ast.Node) *
 	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, node)
 
 	var spxSpriteResource *SpxSpriteResource
-	xgoutil.WalkPathEnclosingInterval(astFile, node.Pos(), node.End(), false, func(node ast.Node) bool {
-		if node == nil {
-			return true
+	for pathNode := range xgoutil.PathEnclosingIntervalNodes(astFile, node.Pos(), node.End(), false) {
+		if pathNode == nil {
+			continue
 		}
 
-		callExpr, ok := node.(*ast.CallExpr)
+		callExpr, ok := pathNode.(*ast.CallExpr)
 		if !ok {
-			return true
+			continue
 		}
 
 		var spxSpriteName string
 		if sel, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
 			ident, ok := sel.X.(*ast.Ident)
 			if !ok {
-				return false
+				break
 			}
 			obj := typeInfo.ObjectOf(ident)
 			if obj == nil {
-				return false
+				break
 			}
 			named, ok := xgoutil.DerefType(obj.Type()).(*gotypes.Named)
 			if !ok {
-				return false
+				break
 			}
 
 			if named == GetSpxSpriteType() {
@@ -1266,8 +1231,8 @@ func inferSpxSpriteResourceEnclosingNode(result *compileResult, node ast.Node) *
 			spxSpriteName = strings.TrimSuffix(spxFile, ".spx")
 		}
 		spxSpriteResource = result.spxResourceSet.sprites[spxSpriteName]
-		return false
-	})
+		break
+	}
 	return spxSpriteResource
 }
 

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -776,13 +776,12 @@ onStart => {
 			require.True(t, pos.IsValid())
 
 			var expr ast.Expr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 				if node, ok := node.(ast.Expr); ok && tt.exprFilter(node) {
 					expr = node
-					return false
+					break
 				}
-				return true
-			})
+			}
 			require.NotNil(t, expr)
 
 			got := checkValueInputSlot(result, expr, nil)
@@ -855,13 +854,12 @@ onStart => {
 			require.True(t, pos.IsValid())
 
 			var expr ast.Expr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 				if node, ok := node.(ast.Expr); ok && tt.exprFilter(node) {
 					expr = node
-					return false
+					break
 				}
-				return true
-			})
+			}
 			require.NotNil(t, expr)
 
 			got := checkAddressInputSlot(result, expr)
@@ -974,13 +972,12 @@ onStart => {
 			require.True(t, pos.IsValid())
 
 			var lit *ast.BasicLit
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 				if node, ok := node.(*ast.BasicLit); ok {
 					lit = node
-					return false
+					break
 				}
-				return true
-			})
+			}
 			require.NotNil(t, lit)
 
 			got := createValueInputSlotFromBasicLit(result, lit, tt.declaredType)
@@ -1138,13 +1135,12 @@ onStart => {
 			require.True(t, pos.IsValid())
 
 			var ident *ast.Ident
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 				if node, ok := node.(*ast.Ident); ok {
 					ident = node
-					return false
+					break
 				}
-				return true
-			})
+			}
 			require.NotNil(t, ident)
 
 			got := createValueInputSlotFromIdent(result, ident, nil)
@@ -1182,13 +1178,12 @@ onStart => {
 		require.True(t, pos.IsValid())
 
 		var ident *ast.Ident
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+		for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 			if node, ok := node.(*ast.Ident); ok && node.Name == "mySound" {
 				ident = node
-				return false
+				break
 			}
-			return true
-		})
+		}
 		require.NotNil(t, ident)
 
 		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
@@ -1293,13 +1288,12 @@ onStart => {
 			require.True(t, pos.IsValid())
 
 			var unaryExpr *ast.UnaryExpr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 				if expr, ok := node.(*ast.UnaryExpr); ok {
 					unaryExpr = expr
-					return false
+					break
 				}
-				return true
-			})
+			}
 			require.NotNil(t, unaryExpr)
 
 			got := createValueInputSlotFromUnaryExpr(result, unaryExpr, nil)
@@ -1368,13 +1362,12 @@ onStart => {
 			require.True(t, pos.IsValid())
 
 			var callExpr *ast.CallExpr
-			xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+			for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 				if node, ok := node.(*ast.CallExpr); ok {
 					callExpr = node
-					return false
+					break
 				}
-				return true
-			})
+			}
 			require.NotNil(t, callExpr)
 
 			got := createValueInputSlotFromColorFuncCall(result, callExpr, nil)
@@ -1597,13 +1590,12 @@ onStart => {
 		require.True(t, pos.IsValid())
 
 		var callExpr *ast.CallExpr
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+		for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 			if node, ok := node.(*ast.CallExpr); ok {
 				callExpr = node
-				return false
+				break
 			}
-			return true
-		})
+		}
 		require.NotNil(t, callExpr)
 
 		spxSpriteResource := inferSpxSpriteResourceEnclosingNode(result, callExpr)
@@ -1622,13 +1614,12 @@ onStart => {
 		require.True(t, pos.IsValid())
 
 		var callExpr *ast.CallExpr
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+		for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 			if node, ok := node.(*ast.CallExpr); ok {
 				callExpr = node
-				return false
+				break
 			}
-			return true
-		})
+		}
 		require.NotNil(t, callExpr)
 
 		spxSpriteResource := inferSpxSpriteResourceEnclosingNode(result, callExpr)
@@ -1647,13 +1638,12 @@ onStart => {
 		require.True(t, pos.IsValid())
 
 		var callExpr *ast.CallExpr
-		xgoutil.WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+		for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 			if node, ok := node.(*ast.CallExpr); ok {
 				callExpr = node
-				return false
+				break
 			}
-			return true
-		})
+		}
 		require.NotNil(t, callExpr)
 
 		spxSpriteResource := inferSpxSpriteResourceEnclosingNode(result, callExpr)

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -143,10 +143,9 @@ func (r *compileResult) spxDefinitionsForIdent(ident *ast.Ident) []SpxDefinition
 // struct type.
 func (r *compileResult) spxDefinitionsForNamedStruct(named *gotypes.Named) []SpxDefinition {
 	var defs []SpxDefinition
-	xgoutil.WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-		defs = append(defs, r.spxDefinitionsFor(member, selector.Obj().Name())...)
-		return true
-	})
+	for structMember := range xgoutil.StructMembers(named) {
+		defs = append(defs, r.spxDefinitionsFor(structMember.Member, structMember.Selector.Obj().Name())...)
+	}
 	return defs
 }
 
@@ -210,22 +209,24 @@ func (r *compileResult) isInSpxEventHandler(pos token.Pos) bool {
 	}
 
 	var isIn bool
-	xgoutil.WalkPathEnclosingInterval(astFile, pos-1, pos, false, func(node ast.Node) bool {
+	for node := range xgoutil.PathEnclosingIntervalNodes(astFile, pos-1, pos, false) {
 		callExpr, ok := node.(*ast.CallExpr)
 		if !ok || len(callExpr.Args) == 0 {
-			return true
+			continue
 		}
 		funcIdent, ok := callExpr.Fun.(*ast.Ident)
 		if !ok {
-			return true
+			continue
 		}
 		funcObj := typeInfo.ObjectOf(funcIdent)
 		if !IsInSpxPkg(funcObj) {
-			return true
+			continue
 		}
 		isIn = IsSpxEventHandlerFuncName(funcIdent.Name)
-		return !isIn // Stop walking if we found a match.
-	})
+		if isIn {
+			break
+		}
+	}
 	return isIn
 }
 
@@ -571,9 +572,9 @@ func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
 					return nil
 				}
 				var names []string
-				walkPropertyMembers(named, makePkgDocFor(pkgDoc), make(map[*gotypes.Named]bool), make(map[string]bool), func(m propertyMember) {
+				for m := range propertyMembers(named, makePkgDocFor(pkgDoc)) {
 					names = append(names, m.Name)
-				})
+				}
 				propertyNamesCache[call] = names
 				return names
 			},
@@ -705,20 +706,19 @@ func (s *Server) inspectForAutoBindingSpxResources(result *compileResult) {
 	if !ok || !xgoutil.IsNamedStructType(gameType) {
 		return
 	}
-	xgoutil.WalkStruct(gameType, func(member gotypes.Object, selector *gotypes.Named) bool {
-		field, ok := member.(*gotypes.Var)
+	for structMember := range xgoutil.StructMembers(gameType) {
+		field, ok := structMember.Member.(*gotypes.Var)
 		if !ok {
-			return true
+			continue
 		}
 		fieldType, ok := xgoutil.DerefType(field.Type()).(*gotypes.Named)
 		if !ok {
-			return true
+			continue
 		}
 		if fieldType == GetSpxSpriteType() || result.hasSpxSpriteType(fieldType) {
-			result.spxSpriteResourceAutoBindings[member] = struct{}{}
+			result.spxSpriteResourceAutoBindings[structMember.Member] = struct{}{}
 		}
-		return true
-	})
+	}
 	for ident, obj := range typeInfo.Uses {
 		if result.hasSpxSpriteResourceAutoBinding(obj) && !ident.Implicit() {
 			result.addSpxResourceRef(SpxResourceRef{
@@ -740,21 +740,21 @@ func (s *Server) resolveIdentifierToAssignedExpr(result *compileResult, ident *a
 	}
 
 	var resolvedExpr ast.Expr = ident
-	xgoutil.WalkPathEnclosingInterval(astFile, ident.Pos(), ident.End(), false, func(node ast.Node) bool {
+	for node := range xgoutil.PathEnclosingIntervalNodes(astFile, ident.Pos(), ident.End(), false) {
 		assignStmt, ok := node.(*ast.AssignStmt)
 		if !ok {
-			return true
+			continue
 		}
 
 		idx := slices.IndexFunc(assignStmt.Lhs, func(lhs ast.Expr) bool {
 			return lhs == ident
 		})
 		if idx < 0 || idx >= len(assignStmt.Rhs) {
-			return true
+			continue
 		}
 		resolvedExpr = assignStmt.Rhs[idx]
-		return false
-	})
+		break
+	}
 	return resolvedExpr
 }
 

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -1567,13 +1567,13 @@ func (ctx *completionContext) collectPropertyNames(target string) {
 	}
 
 	mainPkgDoc, _ := ctx.proj.PkgDoc()
-	ctx.collectPropertyNamesFromNamedType(namedType, mainPkgDoc, make(map[*gotypes.Named]bool), make(map[string]bool))
+	ctx.collectPropertyNamesFromNamedType(namedType, mainPkgDoc)
 }
 
 // collectPropertyNamesFromNamedType collects property name completion items
-// from the given named type (including embedded types) using walkPropertyMembers.
-func (ctx *completionContext) collectPropertyNamesFromNamedType(namedType *gotypes.Named, mainPkgDoc *pkgdoc.PkgDoc, visited map[*gotypes.Named]bool, seenNames map[string]bool) {
-	walkPropertyMembers(namedType, makePkgDocFor(mainPkgDoc), visited, seenNames, func(m propertyMember) {
+// from the given named type, including embedded types.
+func (ctx *completionContext) collectPropertyNamesFromNamedType(namedType *gotypes.Named, mainPkgDoc *pkgdoc.PkgDoc) {
+	for m := range propertyMembers(namedType, makePkgDocFor(mainPkgDoc)) {
 		insertText := m.Name
 		if !ctx.inStringLit {
 			insertText = strconv.Quote(m.Name)
@@ -1589,7 +1589,7 @@ func (ctx *completionContext) collectPropertyNamesFromNamedType(namedType *gotyp
 		def.CompletionItemInsertText = insertText
 		def.CompletionItemInsertTextFormat = PlainTextTextFormat
 		ctx.itemSet.addSpxDefs(def)
-	})
+	}
 }
 
 // collectStructLit collects struct literal completions.

--- a/internal/server/format.go
+++ b/internal/server/format.go
@@ -635,17 +635,16 @@ func getFuncAndOverloadsType(proj *xgo.Project, funIdent *ast.Ident) (fun *gotyp
 		return
 	}
 	var underlineFunType *gotypes.Func
-	xgoutil.WalkStruct(recvNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
-		method, ok := member.(*gotypes.Func)
+	for structMember := range xgoutil.StructMembers(recvNamed) {
+		method, ok := structMember.Member.(*gotypes.Func)
 		if !ok {
-			return true
+			continue
 		}
 		if pn, overloadID := xgoutil.ParseXGoFuncName(method.Name()); pn == funIdent.Name && overloadID == nil {
 			underlineFunType = method
-			return false
+			break
 		}
-		return true
-	})
+	}
 	if underlineFunType == nil {
 		return
 	}

--- a/internal/server/reference.go
+++ b/internal/server/reference.go
@@ -110,15 +110,15 @@ func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *g
 		}
 		seenIfaces[current] = true
 
-		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+		for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 			typeSpec := spec.(*ast.TypeSpec)
 			typeName := typeInfo.ObjectOf(typeSpec.Name)
 			if typeName == nil {
-				return
+				continue
 			}
 			embedIface, ok := typeName.Type().Underlying().(*gotypes.Interface)
 			if !ok {
-				return
+				continue
 			}
 
 			for typ := range embedIface.EmbeddedTypes() {
@@ -133,7 +133,7 @@ func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *g
 					find(embedIface)
 				}
 			}
-		})
+		}
 	}
 	find(iface)
 	return locations
@@ -148,27 +148,27 @@ func (s *Server) findImplementingMethodReferences(result *compileResult, iface *
 	}
 	var locations []Location
 	astPkg, _ := result.proj.ASTPackage()
-	xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+	for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 		typeSpec := spec.(*ast.TypeSpec)
 		typeName := typeInfo.ObjectOf(typeSpec.Name)
 		if typeName == nil {
-			return
+			continue
 		}
 		named, ok := typeName.Type().(*gotypes.Named)
 		if !ok || !gotypes.Implements(named, iface) {
-			return
+			continue
 		}
 
 		selection, ok := gotypes.LookupSelection(named, false, named.Obj().Pkg(), methodName)
 		if !ok {
-			return
+			continue
 		}
 		method, ok := selection.Obj().(*gotypes.Func)
 		if !ok {
-			return
+			continue
 		}
 		locations = append(locations, s.findReferenceLocations(result, method)...)
-	})
+	}
 	return locations
 }
 
@@ -184,29 +184,29 @@ func (s *Server) findInterfaceMethodReferences(result *compileResult, fn *gotype
 	seenIfaces := make(map[*gotypes.Interface]bool)
 	astPkg, _ := result.proj.ASTPackage()
 
-	xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+	for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 		typeSpec := spec.(*ast.TypeSpec)
 		typeName := typeInfo.ObjectOf(typeSpec.Name)
 		if typeName == nil {
-			return
+			continue
 		}
 		ifaceType, ok := typeName.Type().Underlying().(*gotypes.Interface)
 		if !ok || !gotypes.Implements(recvType, ifaceType) || seenIfaces[ifaceType] {
-			return
+			continue
 		}
 		seenIfaces[ifaceType] = true
 
 		selection, ok := gotypes.LookupSelection(ifaceType, false, typeName.Pkg(), fn.Name())
 		if !ok {
-			return
+			continue
 		}
 		method, ok := selection.Obj().(*gotypes.Func)
 		if !ok {
-			return
+			continue
 		}
 		locations = append(locations, s.findReferenceLocations(result, method)...)
 		locations = append(locations, s.findEmbeddedInterfaceReferences(result, ifaceType, fn.Name())...)
-	})
+	}
 	return locations
 }
 
@@ -225,19 +225,19 @@ func (s *Server) handleEmbeddedFieldReferences(result *compileResult, obj gotype
 
 		seenTypes := make(map[gotypes.Type]bool)
 		astPkg, _ := result.proj.ASTPackage()
-		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+		for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 			typeSpec := spec.(*ast.TypeSpec)
 			typeName := typeInfo.ObjectOf(typeSpec.Name)
 			if typeName == nil {
-				return
+				continue
 			}
 			named, ok := typeName.Type().(*gotypes.Named)
 			if !ok {
-				return
+				continue
 			}
 
 			locations = append(locations, s.findEmbeddedMethodReferences(result, fn, named, recv.Type(), seenTypes)...)
-		})
+		}
 	}
 	return locations
 }
@@ -286,19 +286,19 @@ func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *gotypes
 			return nil
 		}
 		astPkg, _ := result.proj.ASTPackage()
-		xgoutil.RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
+		for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 			typeSpec := spec.(*ast.TypeSpec)
 			typeName := typeInfo.ObjectOf(typeSpec.Name)
 			if typeName == nil {
-				return
+				continue
 			}
 			named, ok := typeName.Type().(*gotypes.Named)
 			if !ok {
-				return
+				continue
 			}
 
 			locations = append(locations, s.findEmbeddedMethodReferences(result, fn, named, named, seenTypes)...)
-		})
+		}
 	}
 	return locations
 }

--- a/xgo/xgoutil/call_expr_test.go
+++ b/xgo/xgoutil/call_expr_test.go
@@ -608,10 +608,10 @@ func TestResolvedCallExprArgs(t *testing.T) {
 		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
 
 		callCount := 0
-		ResolvedCallExprArgs(typeInfo, expr)(func(ResolvedCallExprArg) bool {
+		for range ResolvedCallExprArgs(typeInfo, expr) {
 			callCount++
-			return false
-		})
+			break
+		}
 		assert.Equal(t, 1, callCount)
 	})
 

--- a/xgo/xgoutil/scope.go
+++ b/xgo/xgoutil/scope.go
@@ -37,7 +37,7 @@ func InnermostScopeAt(fset *token.FileSet, typeInfo *types.Info, astPkg *ast.Pac
 	}
 
 	var scope *gotypes.Scope
-	WalkPathEnclosingInterval(astFile, pos, pos, false, func(node ast.Node) bool {
+	for node := range PathEnclosingIntervalNodes(astFile, pos, pos, false) {
 		scope = typeInfo.Scopes[node]
 		if scope == nil {
 			// NOTE: For function declarations and literals without
@@ -55,7 +55,9 @@ func InnermostScopeAt(fset *token.FileSet, typeInfo *types.Info, astPkg *ast.Pac
 				}
 			}
 		}
-		return scope == nil // Stop at the first non-nil scope.
-	})
+		if scope != nil {
+			break
+		}
+	}
 	return scope
 }

--- a/xgo/xgoutil/struct.go
+++ b/xgo/xgoutil/struct.go
@@ -16,7 +16,19 @@
 
 package xgoutil
 
-import gotypes "go/types"
+import (
+	gotypes "go/types"
+	"iter"
+)
+
+// StructMember describes a resolved struct member and the selector type used
+// to refer to it.
+type StructMember struct {
+	// Member is the field or method object yielded from the traversal.
+	Member gotypes.Object
+	// Selector is the named type used to select Member.
+	Selector *gotypes.Named
+}
 
 // IsNamedStructType reports whether the given named type is a struct type.
 func IsNamedStructType(named *gotypes.Named) bool {
@@ -52,72 +64,73 @@ func IsXGoClassStructType(named *gotypes.Named) bool {
 	return false
 }
 
-// WalkStruct walks a struct and calls the given onMember for each field and
-// method. If onMember returns false, the walk is stopped.
-func WalkStruct(named *gotypes.Named, onMember func(member gotypes.Object, selector *gotypes.Named) bool) {
-	if named == nil {
-		return
-	}
-	walked := make(map[*gotypes.Named]struct{})
-	seenMembers := make(map[string]struct{})
-	var walk func(named *gotypes.Named, namedPath []*gotypes.Named) bool
-	walk = func(named *gotypes.Named, namedPath []*gotypes.Named) bool {
-		if _, ok := walked[named]; ok {
+// StructMembers returns an iterator over exported or main-package struct fields
+// and methods. It includes embedded struct members in depth-first order and
+// skips shadowed member names.
+func StructMembers(named *gotypes.Named) iter.Seq[StructMember] {
+	return func(yield func(StructMember) bool) {
+		if named == nil {
+			return
+		}
+		walked := make(map[*gotypes.Named]struct{})
+		seenMembers := make(map[string]struct{})
+		var walk func(named *gotypes.Named, namedPath []*gotypes.Named) bool
+		walk = func(named *gotypes.Named, namedPath []*gotypes.Named) bool {
+			if _, ok := walked[named]; ok {
+				return true
+			}
+			walked[named] = struct{}{}
+
+			st, ok := named.Underlying().(*gotypes.Struct)
+			if !ok {
+				return true
+			}
+
+			selector := named
+			for _, selectorNamed := range namedPath {
+				if !IsExportedOrInMainPkg(selectorNamed.Obj()) {
+					break
+				}
+				selector = selectorNamed
+				if IsXGoClassStructType(selector) {
+					break
+				}
+			}
+			yieldMember := func(member gotypes.Object) bool {
+				if _, ok := seenMembers[member.Name()]; ok || !IsExportedOrInMainPkg(member) {
+					return true
+				}
+				seenMembers[member.Name()] = struct{}{}
+
+				return yield(StructMember{Member: member, Selector: selector})
+			}
+
+			for field := range st.Fields() {
+				if !yieldMember(field) {
+					return false
+				}
+			}
+			for method := range named.Methods() {
+				if !yieldMember(method) {
+					return false
+				}
+			}
+			for field := range st.Fields() {
+				if !field.Embedded() {
+					continue
+				}
+				fieldType := DerefType(field.Type())
+				namedField, ok := fieldType.(*gotypes.Named)
+				if !ok || !IsNamedStructType(namedField) {
+					continue
+				}
+
+				if !walk(namedField, append(namedPath, namedField)) {
+					return false
+				}
+			}
 			return true
 		}
-		walked[named] = struct{}{}
-
-		st, ok := named.Underlying().(*gotypes.Struct)
-		if !ok {
-			return true
-		}
-
-		selector := named
-		for _, named := range namedPath {
-			if !IsExportedOrInMainPkg(named.Obj()) {
-				break
-			}
-			selector = named
-			if IsXGoClassStructType(selector) {
-				break
-			}
-		}
-
-		for field := range st.Fields() {
-			if _, ok := seenMembers[field.Name()]; ok || !IsExportedOrInMainPkg(field) {
-				continue
-			}
-			seenMembers[field.Name()] = struct{}{}
-
-			if !onMember(field, selector) {
-				return false
-			}
-		}
-		for method := range named.Methods() {
-			if _, ok := seenMembers[method.Name()]; ok || !IsExportedOrInMainPkg(method) {
-				continue
-			}
-			seenMembers[method.Name()] = struct{}{}
-
-			if !onMember(method, selector) {
-				return false
-			}
-		}
-		for field := range st.Fields() {
-			if !field.Embedded() {
-				continue
-			}
-			fieldType := DerefType(field.Type())
-			namedField, ok := fieldType.(*gotypes.Named)
-			if !ok || !IsNamedStructType(namedField) {
-				continue
-			}
-
-			if !walk(namedField, append(namedPath, namedField)) {
-				return false
-			}
-		}
-		return true
+		walk(named, []*gotypes.Named{named})
 	}
-	walk(named, []*gotypes.Named{named})
 }

--- a/xgo/xgoutil/struct_test.go
+++ b/xgo/xgoutil/struct_test.go
@@ -171,16 +171,15 @@ func TestIsXGoClassStructType(t *testing.T) {
 	})
 }
 
-func TestWalkStruct(t *testing.T) {
+func TestStructMembers(t *testing.T) {
 	t.Run("NilNamedType", func(t *testing.T) {
 		var (
 			named  *gotypes.Named
 			called bool
 		)
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
+		for range StructMembers(named) {
 			called = true
-			return true
-		})
+		}
 		assert.False(t, called)
 	})
 
@@ -190,10 +189,9 @@ func TestWalkStruct(t *testing.T) {
 		named := gotypes.NewNamed(typeName, gotypes.Typ[gotypes.Int], nil)
 
 		var called bool
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
+		for range StructMembers(named) {
 			called = true
-			return true
-		})
+		}
 		assert.False(t, called)
 	})
 
@@ -204,10 +202,9 @@ func TestWalkStruct(t *testing.T) {
 		named := gotypes.NewNamed(typeName, structType, nil)
 
 		var called bool
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
+		for range StructMembers(named) {
 			called = true
-			return true
-		})
+		}
 		assert.False(t, called)
 	})
 
@@ -223,11 +220,10 @@ func TestWalkStruct(t *testing.T) {
 			members   []gotypes.Object
 			selectors []*gotypes.Named
 		)
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			selectors = append(selectors, selector)
-			return true
-		})
+		for structMember := range StructMembers(named) {
+			members = append(members, structMember.Member)
+			selectors = append(selectors, structMember.Selector)
+		}
 		require.Len(t, members, 2)
 		assert.Equal(t, "Field1", members[0].Name())
 		assert.Equal(t, "Field2", members[1].Name())
@@ -250,10 +246,9 @@ func TestWalkStruct(t *testing.T) {
 		named.AddMethod(method)
 
 		var members []gotypes.Object
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(named) {
+			members = append(members, structMember.Member)
+		}
 		require.Len(t, members, 1)
 		assert.Equal(t, "Method1", members[0].Name())
 	})
@@ -269,10 +264,10 @@ func TestWalkStruct(t *testing.T) {
 		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "Method2", signature))
 
 		var members []gotypes.Object
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return false
-		})
+		for structMember := range StructMembers(named) {
+			members = append(members, structMember.Member)
+			break
+		}
 
 		require.Len(t, members, 1)
 		assert.Equal(t, "Method1", members[0].Name())
@@ -289,10 +284,9 @@ func TestWalkStruct(t *testing.T) {
 		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "unexportedMethod", signature))
 
 		var members []gotypes.Object
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(named) {
+			members = append(members, structMember.Member)
+		}
 
 		require.Len(t, members, 1)
 		assert.Equal(t, "ExportedMethod", members[0].Name())
@@ -314,10 +308,9 @@ func TestWalkStruct(t *testing.T) {
 		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
 		var members []gotypes.Object
-		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(mainNamed) {
+			members = append(members, structMember.Member)
+		}
 		require.Len(t, members, 3)
 		memberNames := make([]string, len(members))
 		for i, member := range members {
@@ -337,10 +330,10 @@ func TestWalkStruct(t *testing.T) {
 		named := gotypes.NewNamed(typeName, structType, nil)
 
 		var members []gotypes.Object
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return len(members) < 1 // Stop after first member.
-		})
+		for structMember := range StructMembers(named) {
+			members = append(members, structMember.Member)
+			break
+		}
 		require.Len(t, members, 1)
 		assert.Equal(t, "Field1", members[0].Name())
 	})
@@ -369,10 +362,9 @@ func TestWalkStruct(t *testing.T) {
 		namedB.SetUnderlying(structBTypeWithA)
 
 		var callCount int
-		WalkStruct(namedA, func(member gotypes.Object, selector *gotypes.Named) bool {
+		for range StructMembers(namedA) {
 			callCount++
-			return true
-		})
+		}
 		assert.GreaterOrEqual(t, callCount, 0) // Should not cause infinite recursion.
 	})
 
@@ -385,10 +377,9 @@ func TestWalkStruct(t *testing.T) {
 		named := gotypes.NewNamed(typeName, structType, nil)
 
 		var members []gotypes.Object
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(named) {
+			members = append(members, structMember.Member)
+		}
 
 		// Only exported field should be included.
 		require.Len(t, members, 1)
@@ -411,10 +402,9 @@ func TestWalkStruct(t *testing.T) {
 		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
 		var members []gotypes.Object
-		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(mainNamed) {
+			members = append(members, structMember.Member)
+		}
 
 		// Should see SameName (first occurrence) and EmbeddedStruct, but not the duplicate SameName.
 		require.Len(t, members, 2)
@@ -449,10 +439,9 @@ func TestWalkStruct(t *testing.T) {
 		named.AddMethod(gotypes.NewFunc(token.NoPos, pkg, "SameName", signature))
 
 		var members []gotypes.Object
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(named) {
+			members = append(members, structMember.Member)
+		}
 
 		require.Len(t, members, 1)
 		assert.Equal(t, "SameName", members[0].Name())
@@ -472,10 +461,9 @@ func TestWalkStruct(t *testing.T) {
 		named := gotypes.NewNamed(typeName, structType, nil)
 
 		var selectors []*gotypes.Named
-		WalkStruct(named, func(member gotypes.Object, selector *gotypes.Named) bool {
-			selectors = append(selectors, selector)
-			return true
-		})
+		for structMember := range StructMembers(named) {
+			selectors = append(selectors, structMember.Selector)
+		}
 		require.Len(t, selectors, 1)
 		assert.Equal(t, named, selectors[0])
 	})
@@ -497,10 +485,9 @@ func TestWalkStruct(t *testing.T) {
 		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
 		var members []gotypes.Object
-		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(mainNamed) {
+			members = append(members, structMember.Member)
+		}
 		require.Len(t, members, 3)
 		memberNames := make([]string, len(members))
 		for i, member := range members {
@@ -524,16 +511,14 @@ func TestWalkStruct(t *testing.T) {
 		mainTypeName := gotypes.NewTypeName(token.NoPos, pkg, "MainStruct", mainStructType)
 		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
-		var selectorForInnerField *gotypes.Named
-		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
-			if member.Name() == "ExportedField" {
-				selectorForInnerField = selector
-			}
-			return true
-		})
+		var members []StructMember
+		for structMember := range StructMembers(mainNamed) {
+			members = append(members, structMember)
+		}
 
-		require.NotNil(t, selectorForInnerField)
-		assert.Equal(t, mainNamed, selectorForInnerField)
+		require.Len(t, members, 1)
+		assert.Equal(t, "ExportedField", members[0].Member.Name())
+		assert.Equal(t, mainNamed, members[0].Selector)
 	})
 
 	t.Run("EmbeddedNamedNonStructIsIgnored", func(t *testing.T) {
@@ -550,16 +535,15 @@ func TestWalkStruct(t *testing.T) {
 		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
 		var members []gotypes.Object
-		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member)
-			return true
-		})
+		for structMember := range StructMembers(mainNamed) {
+			members = append(members, structMember.Member)
+		}
 
 		require.Len(t, members, 1)
 		assert.Equal(t, "EmbeddedInt", members[0].Name())
 	})
 
-	t.Run("EmbeddedWalkEarlyTermination", func(t *testing.T) {
+	t.Run("EmbeddedEarlyTermination", func(t *testing.T) {
 		pkg := gotypes.NewPackage("test", "test")
 
 		embeddedField := gotypes.NewField(token.NoPos, pkg, "EmbeddedField", gotypes.Typ[gotypes.String], false)
@@ -574,10 +558,12 @@ func TestWalkStruct(t *testing.T) {
 		mainNamed := gotypes.NewNamed(mainTypeName, mainStructType, nil)
 
 		var members []string
-		WalkStruct(mainNamed, func(member gotypes.Object, selector *gotypes.Named) bool {
-			members = append(members, member.Name())
-			return member.Name() != "EmbeddedField"
-		})
+		for structMember := range StructMembers(mainNamed) {
+			members = append(members, structMember.Member.Name())
+			if structMember.Member.Name() == "EmbeddedField" {
+				break
+			}
+		}
 
 		assert.Equal(t, []string{"MainField", "EmbeddedStruct", "EmbeddedField"}, members)
 	})

--- a/xgo/xgoutil/xgoutil.go
+++ b/xgo/xgoutil/xgoutil.go
@@ -28,16 +28,20 @@ import (
 	"github.com/goplus/xgolsw/xgo/types"
 )
 
-// RangeASTSpecs iterates all XGo AST specs.
-func RangeASTSpecs(astPkg *ast.Package, tok token.Token, f func(spec ast.Spec)) {
-	if astPkg == nil {
-		return
-	}
-	for _, file := range astPkg.Files {
-		for _, decl := range file.Decls {
-			if decl, ok := decl.(*ast.GenDecl); ok && decl.Tok == tok {
-				for _, spec := range decl.Specs {
-					f(spec)
+// ASTSpecs returns an iterator over all XGo AST specs matching tok.
+func ASTSpecs(astPkg *ast.Package, tok token.Token) iter.Seq[ast.Spec] {
+	return func(yield func(ast.Spec) bool) {
+		if astPkg == nil {
+			return
+		}
+		for _, file := range astPkg.Files {
+			for _, decl := range file.Decls {
+				if decl, ok := decl.(*ast.GenDecl); ok && decl.Tok == tok {
+					for _, spec := range decl.Specs {
+						if !yield(spec) {
+							return
+						}
+					}
 				}
 			}
 		}
@@ -65,20 +69,22 @@ func IsDefinedInClassFieldsDecl(fset *token.FileSet, typeInfo *types.Info, astPk
 	return defIdent.Pos() >= decl.Pos() && defIdent.End() <= decl.End()
 }
 
-// WalkPathEnclosingInterval calls walkFn for each node in the AST path
-// enclosing the given [start, end) interval, starting from the innermost node
-// and walking outward. The walk stops if walkFn returns false.
-func WalkPathEnclosingInterval(root *ast.File, start, end token.Pos, backward bool, walkFn func(node ast.Node) bool) {
-	path, _ := PathEnclosingInterval(root, start, end)
-	var seq iter.Seq2[int, ast.Node]
-	if backward {
-		seq = slices.Backward(path)
-	} else {
-		seq = slices.All(path)
-	}
-	for _, node := range seq {
-		if !walkFn(node) {
-			break
+// PathEnclosingIntervalNodes returns an iterator over nodes in the AST path
+// enclosing the given [start, end) interval. It starts from the innermost node
+// and walks outward unless backward is true.
+func PathEnclosingIntervalNodes(root *ast.File, start, end token.Pos, backward bool) iter.Seq[ast.Node] {
+	return func(yield func(ast.Node) bool) {
+		path, _ := PathEnclosingInterval(root, start, end)
+		var seq iter.Seq2[int, ast.Node]
+		if backward {
+			seq = slices.Backward(path)
+		} else {
+			seq = slices.All(path)
+		}
+		for _, node := range seq {
+			if !yield(node) {
+				return
+			}
 		}
 	}
 }

--- a/xgo/xgoutil/xgoutil_test.go
+++ b/xgo/xgoutil/xgoutil_test.go
@@ -163,16 +163,13 @@ func markAsXGoPackage(pkg *gotypes.Package) {
 	pkg.Scope().Insert(cnst)
 }
 
-func TestRangeASTSpecs(t *testing.T) {
+func TestASTSpecs(t *testing.T) {
 	t.Run("SingleTypeSpec", func(t *testing.T) {
 		_, astFile, err := newTestFile("main.xgo", "type A = int")
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.TYPE))
 
 		require.Len(t, specs, 1)
 		ts := requireTypeSpec(t, specs[0])
@@ -193,10 +190,7 @@ type (
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.TYPE))
 
 		require.Len(t, specs, 3)
 		names := make([]string, len(specs))
@@ -219,10 +213,7 @@ var (
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.VAR, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.VAR))
 
 		require.Len(t, specs, 2)
 		names := make([]string, len(specs))
@@ -244,10 +235,7 @@ const (
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.CONST, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.CONST))
 
 		require.Len(t, specs, 2)
 		names := make([]string, len(specs))
@@ -270,10 +258,7 @@ const (
 			"other.xgo": otherFile,
 		})
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.TYPE))
 
 		require.Len(t, specs, 2)
 		names := make([]string, len(specs))
@@ -290,10 +275,7 @@ const (
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.TYPE))
 
 		assert.Empty(t, specs)
 	})
@@ -301,10 +283,7 @@ const (
 	t.Run("EmptyPackage", func(t *testing.T) {
 		astPkg := newTestPackage(nil)
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.TYPE))
 
 		assert.Empty(t, specs)
 	})
@@ -318,20 +297,11 @@ func myFunc() {}`)
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		var typeSpecs []ast.Spec
-		RangeASTSpecs(astPkg, token.TYPE, func(spec ast.Spec) {
-			typeSpecs = append(typeSpecs, spec)
-		})
+		typeSpecs := slices.Collect(ASTSpecs(astPkg, token.TYPE))
 
-		var varSpecs []ast.Spec
-		RangeASTSpecs(astPkg, token.VAR, func(spec ast.Spec) {
-			varSpecs = append(varSpecs, spec)
-		})
+		varSpecs := slices.Collect(ASTSpecs(astPkg, token.VAR))
 
-		var constSpecs []ast.Spec
-		RangeASTSpecs(astPkg, token.CONST, func(spec ast.Spec) {
-			constSpecs = append(constSpecs, spec)
-		})
+		constSpecs := slices.Collect(ASTSpecs(astPkg, token.CONST))
 
 		require.Len(t, typeSpecs, 1)
 		require.Len(t, varSpecs, 1)
@@ -352,10 +322,7 @@ import (
 		require.NoError(t, err)
 		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
-		var specs []ast.Spec
-		RangeASTSpecs(astPkg, token.IMPORT, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(astPkg, token.IMPORT))
 
 		require.Len(t, specs, 2)
 		paths := make([]string, len(specs))
@@ -368,10 +335,7 @@ import (
 	})
 
 	t.Run("NilPackage", func(t *testing.T) {
-		var specs []ast.Spec
-		RangeASTSpecs(nil, token.TYPE, func(spec ast.Spec) {
-			specs = append(specs, spec)
-		})
+		specs := slices.Collect(ASTSpecs(nil, token.TYPE))
 
 		assert.Empty(t, specs)
 	})
@@ -476,8 +440,8 @@ func test() {
 	})
 }
 
-func TestWalkPathEnclosingInterval(t *testing.T) {
-	t.Run("WalkFunction", func(t *testing.T) {
+func TestPathEnclosingIntervalNodes(t *testing.T) {
+	t.Run("Function", func(t *testing.T) {
 		_, astFile, err := newTestFile("main.xgo", "func test() { println(1) }")
 		require.NoError(t, err)
 		var funcDecl *ast.FuncDecl
@@ -491,16 +455,15 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 		require.NotNil(t, funcDecl)
 
 		var nodes []ast.Node
-		WalkPathEnclosingInterval(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), false, func(node ast.Node) bool {
+		for node := range PathEnclosingIntervalNodes(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), false) {
 			nodes = append(nodes, node)
-			return true
-		})
+		}
 		require.NotEmpty(t, nodes)
 		assert.IsType(t, &ast.BlockStmt{}, nodes[0])
 		assert.IsType(t, &ast.File{}, nodes[len(nodes)-1])
 	})
 
-	t.Run("WalkSinglePosition", func(t *testing.T) {
+	t.Run("SinglePosition", func(t *testing.T) {
 		_, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
@@ -510,10 +473,9 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 		require.NotEqual(t, token.NoPos, identPos)
 
 		var nodes []ast.Node
-		WalkPathEnclosingInterval(astFile, identPos, identPos+1, false, func(node ast.Node) bool {
+		for node := range PathEnclosingIntervalNodes(astFile, identPos, identPos+1, false) {
 			nodes = append(nodes, node)
-			return true
-		})
+		}
 		require.NotEmpty(t, nodes)
 		assert.True(t, slices.ContainsFunc(nodes, func(node ast.Node) bool {
 			if ident, ok := node.(*ast.Ident); ok && ident.Name == "x" {
@@ -538,10 +500,10 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 		require.NotNil(t, funcDecl)
 
 		var nodes []ast.Node
-		WalkPathEnclosingInterval(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), false, func(node ast.Node) bool {
+		for node := range PathEnclosingIntervalNodes(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), false) {
 			nodes = append(nodes, node)
-			return false // Stop after first node.
-		})
+			break
+		}
 		require.Len(t, nodes, 1)
 	})
 
@@ -550,14 +512,13 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 		require.NoError(t, err)
 
 		var nodes []ast.Node
-		WalkPathEnclosingInterval(astFile, token.NoPos, token.NoPos, false, func(node ast.Node) bool {
+		for node := range PathEnclosingIntervalNodes(astFile, token.NoPos, token.NoPos, false) {
 			nodes = append(nodes, node)
-			return true
-		})
+		}
 		require.Len(t, nodes, 1) // Should still return at least the file node.
 	})
 
-	t.Run("WalkBackward", func(t *testing.T) {
+	t.Run("Backward", func(t *testing.T) {
 		_, astFile, err := newTestFile("main.xgo", "func test() { x := 1; y := 2 }")
 		require.NoError(t, err)
 
@@ -572,16 +533,14 @@ func TestWalkPathEnclosingInterval(t *testing.T) {
 		require.NotNil(t, funcDecl)
 
 		var forwardNodes []ast.Node
-		WalkPathEnclosingInterval(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), false, func(node ast.Node) bool {
+		for node := range PathEnclosingIntervalNodes(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), false) {
 			forwardNodes = append(forwardNodes, node)
-			return true
-		})
+		}
 
 		var backwardNodes []ast.Node
-		WalkPathEnclosingInterval(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), true, func(node ast.Node) bool {
+		for node := range PathEnclosingIntervalNodes(astFile, funcDecl.Body.Pos(), funcDecl.Body.End(), true) {
 			backwardNodes = append(backwardNodes, node)
-			return true
-		})
+		}
 
 		require.NotEmpty(t, forwardNodes)
 		require.NotEmpty(t, backwardNodes)


### PR DESCRIPTION
Expose traversal helpers as `iter.Seq` values so callers can use `for range` control flow instead of callback-based walkers.

Update server call sites and tests to consume the iterator APIs, and document the iterator preference for traversal helpers in `AGENTS.md`.