### PR TITLE
feat(spx): support sprite instance input slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,10 @@ type XGoInputSlotAccept =
       /**
        * The input type accepted by the slot.
        */
-      type: XGoInputType.SpxResourceName
+      type: XGoInputType.SpxResourceName | XGoInputType.SpxSpriteInstance
 
       /**
-       * The resource context for the resource name input type.
+       * The resource context for the resource-backed input type.
        */
       resourceContext: XGoResourceContextUri
     }
@@ -329,6 +329,11 @@ enum XGoInputType {
    * Resource name (`SpriteName`, `SoundName`, etc.) in spx.
    */
   SpxResourceName = 'spx-resource-name',
+
+  /**
+   * Sprite instance resource references in spx.
+   */
+  SpxSpriteInstance = 'spx-sprite-instance',
 
   /**
    * Direction values in spx.
@@ -395,6 +400,7 @@ type XGoInputTypedValue =
   | { type: XGoInputType.Boolean; value: boolean }
   | { type: XGoInputType.Unknown; value: void }
   | { type: XGoInputType.SpxResourceName; value: XGoResourceUri }
+  | { type: XGoInputType.SpxSpriteInstance; value: XGoResourceUri }
   | { type: XGoInputType.SpxDirection; value: number }
   | { type: XGoInputType.SpxLayerAction; value: string }
   | { type: XGoInputType.SpxDirAction; value: string }

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -913,7 +913,7 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 
 	input := SpxInput{
 		Kind: SpxInputKindPredefined,
-		Type: inferSpxInputTypeFromType(typ),
+		Type: inferSpxInputTypeFromTypeInProject(result, typ),
 		Name: ident.Name,
 	}
 	switch input.Type {
@@ -950,9 +950,10 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 
 	accept := SpxInputSlotAccept{Type: input.Type}
 	if declaredType != nil {
-		accept.Type = inferSpxInputTypeFromType(declaredType)
+		accept.Type = inferSpxInputTypeFromTypeInProject(result, declaredType)
 	}
-	if accept.Type == SpxInputTypeResourceName {
+	switch accept.Type {
+	case SpxInputTypeResourceName:
 		switch canonicalSpxResourceNameType(declaredType) {
 		case GetSpxBackdropNameType():
 			accept.ResourceContext = ToPtr(SpxBackdropResourceContextURI)
@@ -977,6 +978,13 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 		default:
 			return nil
 		}
+	case SpxInputTypeSpriteInstance:
+		accept.ResourceContext = ToPtr(SpxSpriteResourceContextURI)
+		if spxSpriteResource := spxSpriteResourceForObject(result, typeInfo.ObjectOf(ident)); spxSpriteResource != nil {
+			input.Kind = SpxInputKindInPlace
+			input.Value = spxSpriteResource.ID.URI()
+			input.Name = ""
+		}
 	}
 
 	return &SpxInputSlot{
@@ -986,6 +994,41 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 		PredefinedNames: collectPredefinedNames(result, ident, declaredType),
 		Range:           RangeForNode(result.proj, ident),
 	}
+}
+
+// inferSpxInputTypeFromTypeInProject attempts to infer the input type from typ
+// using project sprite type metadata.
+func inferSpxInputTypeFromTypeInProject(result *compileResult, typ gotypes.Type) SpxInputType {
+	if isSpxSpriteInstanceType(result, typ) {
+		return SpxInputTypeSpriteInstance
+	}
+	return inferSpxInputTypeFromType(typ)
+}
+
+// isSpxSpriteInstanceType reports whether the given type represents an spx
+// sprite instance.
+func isSpxSpriteInstanceType(result *compileResult, typ gotypes.Type) bool {
+	if typ == nil {
+		return false
+	}
+	typ = xgoutil.DerefType(typ)
+	if typ == GetSpxSpriteType() {
+		return true
+	}
+	if result != nil && result.hasSpxSpriteType(typ) {
+		return true
+	}
+	return gotypes.AssignableTo(typ, GetSpxSpriteType())
+}
+
+// spxSpriteResourceForObject returns the spx sprite resource for obj if it is an
+// auto-bound sprite. It returns nil if obj is nil, obj has no auto-binding, or
+// the corresponding sprite resource is not found in the resource set.
+func spxSpriteResourceForObject(result *compileResult, obj gotypes.Object) *SpxSpriteResource {
+	if obj == nil || !result.hasSpxSpriteResourceAutoBinding(obj) {
+		return nil
+	}
+	return result.spxResourceSet.Sprite(obj.Name())
 }
 
 // createValueInputSlotFromUnaryExpr creates a value input slot from a unary expression.

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -38,6 +38,7 @@ onStart => {
 
 	// Spx resource name.
 	MySprite.stepTo "OtherSprite"
+	MySprite.stepTo OtherSprite
 }
 `),
 			"MySprite.spx":                          []byte(``),
@@ -142,6 +143,14 @@ onStart => {
 					shouldExist: true,
 				},
 				{
+					name:        "SpxSpriteInstance",
+					value:       SpxResourceURI("spx://resources/sprites/OtherSprite"),
+					acceptType:  SpxInputTypeSpriteInstance,
+					inputType:   SpxInputTypeSpriteInstance,
+					inputKind:   SpxInputKindInPlace,
+					shouldExist: true,
+				},
+				{
 					name:        "NonExistentValue",
 					value:       int64(999),
 					acceptType:  SpxInputTypeInteger,
@@ -166,6 +175,19 @@ onStart => {
 					}
 				})
 			}
+		})
+
+		t.Run("SpxSpriteInstanceContext", func(t *testing.T) {
+			slot := findInputSlot(
+				inputSlots,
+				SpxResourceURI("spx://resources/sprites/OtherSprite"),
+				"",
+				SpxInputTypeSpriteInstance,
+				SpxInputKindInPlace,
+			)
+			require.NotNil(t, slot)
+			assert.Equal(t, ToPtr(SpxSpriteResourceContextURI), slot.Accept.ResourceContext)
+			assert.Contains(t, slot.PredefinedNames, "OtherSprite")
 		})
 
 		t.Run("PredefinedValues", func(t *testing.T) {
@@ -279,6 +301,41 @@ var (
 		assert.ErrorContains(t, err, "only supports one document")
 	})
 
+	t.Run("SpxSpriteInstanceVariable", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+var target Sprite
+
+onStart => {
+	target = OtherSprite
+	MySprite.stepTo target
+}
+`),
+			"MySprite.spx":                          []byte(``),
+			"OtherSprite.spx":                       []byte(``),
+			"assets/index.json":                     []byte(`{}`),
+			"assets/sprites/MySprite/index.json":    []byte(`{}`),
+			"assets/sprites/OtherSprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		inputSlots, err := s.spxGetInputSlots([]SpxGetInputSlotsParams{
+			{TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"}},
+		})
+		require.NoError(t, err)
+
+		slot := findInputSlot(inputSlots, nil, "target", SpxInputTypeSpriteInstance, SpxInputKindPredefined)
+		require.NotNil(t, slot)
+		assert.Equal(t, SpxInputTypeSpriteInstance, slot.Accept.Type)
+		assert.Equal(t, ToPtr(SpxSpriteResourceContextURI), slot.Accept.ResourceContext)
+		assert.Contains(t, slot.PredefinedNames, "target")
+		assert.Contains(t, slot.PredefinedNames, "OtherSprite")
+		assert.Equal(t, Range{
+			Start: Position{Line: 5, Character: 17},
+			End:   Position{Line: 5, Character: 23},
+		}, slot.Range)
+	})
+
 	t.Run("EmptyParams", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`var a = 1`),
@@ -376,6 +433,7 @@ onStart => {
 
 	// Spx resource name
 	MySprite.stepTo "OtherSprite"
+	MySprite.stepTo OtherSprite
 
 	// Other commands
 	MySprite.turn MySprite.heading
@@ -456,6 +514,12 @@ onStart => {
 				wantInputType:  SpxInputTypeResourceName,
 			},
 			{
+				name:           "SpxSpriteInstance",
+				value:          SpxResourceURI("spx://resources/sprites/OtherSprite"),
+				wantAcceptType: SpxInputTypeSpriteInstance,
+				wantInputType:  SpxInputTypeSpriteInstance,
+			},
+			{
 				name:           "BinaryExprResult",
 				value:          int64(10),
 				wantAcceptType: SpxInputTypeInteger,
@@ -489,6 +553,19 @@ onStart => {
 				assert.NotEmpty(t, slot.Range)
 			})
 		}
+	})
+
+	t.Run("SpxSpriteInstanceContext", func(t *testing.T) {
+		slot := findInputSlot(
+			inputSlots,
+			SpxResourceURI("spx://resources/sprites/OtherSprite"),
+			"",
+			SpxInputTypeSpriteInstance,
+			SpxInputKindInPlace,
+		)
+		require.NotNil(t, slot)
+		assert.Equal(t, ToPtr(SpxSpriteResourceContextURI), slot.Accept.ResourceContext)
+		assert.Contains(t, slot.PredefinedNames, "OtherSprite")
 	})
 
 	t.Run("AddressSlots", func(t *testing.T) {

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -309,8 +309,9 @@ type XGoInputSlotAccept struct {
 	// Type of input accepted by the slot.
 	Type XGoInputType `json:"type"`
 
-	// Resource context for XGoInputTypeSpxResourceName.
-	// Only valid when Type is XGoInputTypeSpxResourceName.
+	// Resource context for resource-backed input types.
+	// Only valid when Type is [XGoInputTypeSpxResourceName] or
+	// [XGoInputTypeSpxSpriteInstance].
 	ResourceContext *XGoResourceContextURI `json:"resourceContext,omitempty"`
 }
 
@@ -319,21 +320,22 @@ type XGoInputType string
 
 // XGoInputType constants.
 const (
-	XGoInputTypeString           XGoInputType = "string"
-	XGoInputTypeInteger          XGoInputType = "integer"
-	XGoInputTypeDecimal          XGoInputType = "decimal"
-	XGoInputTypeBoolean          XGoInputType = "boolean"
-	XGoInputTypeUnknown          XGoInputType = "unknown"
-	XGoInputTypeSpxResourceName  XGoInputType = "spx-resource-name"
-	XGoInputTypeSpxDirection     XGoInputType = "spx-direction"
-	XGoInputTypeSpxLayerAction   XGoInputType = "spx-layer-action"
-	XGoInputTypeSpxDirAction     XGoInputType = "spx-dir-action"
-	XGoInputTypeSpxColor         XGoInputType = "spx-color"
-	XGoInputTypeSpxEffectKind    XGoInputType = "spx-effect-kind"
-	XGoInputTypeSpxKey           XGoInputType = "spx-key"
-	XGoInputTypeSpxSpecialObj    XGoInputType = "spx-special-obj"
-	XGoInputTypeSpxRotationStyle XGoInputType = "spx-rotation-style"
-	XGoInputTypeSpxPropertyName  XGoInputType = "spx-property-name"
+	XGoInputTypeString            XGoInputType = "string"
+	XGoInputTypeInteger           XGoInputType = "integer"
+	XGoInputTypeDecimal           XGoInputType = "decimal"
+	XGoInputTypeBoolean           XGoInputType = "boolean"
+	XGoInputTypeUnknown           XGoInputType = "unknown"
+	XGoInputTypeSpxResourceName   XGoInputType = "spx-resource-name"
+	XGoInputTypeSpxSpriteInstance XGoInputType = "spx-sprite-instance"
+	XGoInputTypeSpxDirection      XGoInputType = "spx-direction"
+	XGoInputTypeSpxLayerAction    XGoInputType = "spx-layer-action"
+	XGoInputTypeSpxDirAction      XGoInputType = "spx-dir-action"
+	XGoInputTypeSpxColor          XGoInputType = "spx-color"
+	XGoInputTypeSpxEffectKind     XGoInputType = "spx-effect-kind"
+	XGoInputTypeSpxKey            XGoInputType = "spx-key"
+	XGoInputTypeSpxSpecialObj     XGoInputType = "spx-special-obj"
+	XGoInputTypeSpxRotationStyle  XGoInputType = "spx-rotation-style"
+	XGoInputTypeSpxPropertyName   XGoInputType = "spx-property-name"
 )
 
 // XGoInputTypeSpxColorConstructor represents the name for color constructors.
@@ -421,21 +423,22 @@ type SpxInputType = XGoInputType
 
 // Deprecated: use XGoInputType*.
 const (
-	SpxInputTypeString        SpxInputType = XGoInputTypeString
-	SpxInputTypeInteger       SpxInputType = XGoInputTypeInteger
-	SpxInputTypeDecimal       SpxInputType = XGoInputTypeDecimal
-	SpxInputTypeBoolean       SpxInputType = XGoInputTypeBoolean
-	SpxInputTypeUnknown       SpxInputType = XGoInputTypeUnknown
-	SpxInputTypeResourceName  SpxInputType = XGoInputTypeSpxResourceName
-	SpxInputTypeDirection     SpxInputType = XGoInputTypeSpxDirection
-	SpxInputTypeLayerAction   SpxInputType = XGoInputTypeSpxLayerAction
-	SpxInputTypeDirAction     SpxInputType = XGoInputTypeSpxDirAction
-	SpxInputTypeColor         SpxInputType = XGoInputTypeSpxColor
-	SpxInputTypeEffectKind    SpxInputType = XGoInputTypeSpxEffectKind
-	SpxInputTypeKey           SpxInputType = XGoInputTypeSpxKey
-	SpxInputTypeSpecialObj    SpxInputType = XGoInputTypeSpxSpecialObj
-	SpxInputTypeRotationStyle SpxInputType = XGoInputTypeSpxRotationStyle
-	SpxInputTypePropertyName  SpxInputType = XGoInputTypeSpxPropertyName
+	SpxInputTypeString         SpxInputType = XGoInputTypeString
+	SpxInputTypeInteger        SpxInputType = XGoInputTypeInteger
+	SpxInputTypeDecimal        SpxInputType = XGoInputTypeDecimal
+	SpxInputTypeBoolean        SpxInputType = XGoInputTypeBoolean
+	SpxInputTypeUnknown        SpxInputType = XGoInputTypeUnknown
+	SpxInputTypeResourceName   SpxInputType = XGoInputTypeSpxResourceName
+	SpxInputTypeSpriteInstance SpxInputType = XGoInputTypeSpxSpriteInstance
+	SpxInputTypeDirection      SpxInputType = XGoInputTypeSpxDirection
+	SpxInputTypeLayerAction    SpxInputType = XGoInputTypeSpxLayerAction
+	SpxInputTypeDirAction      SpxInputType = XGoInputTypeSpxDirAction
+	SpxInputTypeColor          SpxInputType = XGoInputTypeSpxColor
+	SpxInputTypeEffectKind     SpxInputType = XGoInputTypeSpxEffectKind
+	SpxInputTypeKey            SpxInputType = XGoInputTypeSpxKey
+	SpxInputTypeSpecialObj     SpxInputType = XGoInputTypeSpxSpecialObj
+	SpxInputTypeRotationStyle  SpxInputType = XGoInputTypeSpxRotationStyle
+	SpxInputTypePropertyName   SpxInputType = XGoInputTypeSpxPropertyName
 )
 
 // Deprecated: use XGoInputTypeSpxColorConstructor.


### PR DESCRIPTION
Return sprite resource URIs for auto-bound sprite references in input slots while keeping ordinary Sprite variables as predefined inputs.

Updates goplus/builder#3110