### PR TITLE
feat(server): implement LSP initialize capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ For detailed API references, please check the [index.d.ts](index.d.ts) file.
 | **Other** |||
 || [`workspace/executeCommand`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_executeCommand) | Executes [predefined commands](#predefined-commands) for workspace-specific operations. |
 
+*Note: This table lists implemented message handlers. Clients should use the `initialize` response to determine which
+capabilities are advertised for their client capabilities.*
+
 ## Predefined commands
 
 ### XGo resource renaming

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,11 @@ export interface Message {
 }
 
 /**
+ * A JSON-RPC message identifier.
+ */
+export type MessageID = number | string
+
+/**
  * A request message to describe a request between the client and the server. Every processed request must send a
  * response back to the sender of the request.
  *
@@ -58,7 +63,7 @@ export interface RequestMessage extends Message {
   /**
    * The request id.
    */
-  id: number
+  id: MessageID
 
   /**
    * The method to be invoked.
@@ -82,7 +87,7 @@ export interface ResponseMessage extends Message {
   /**
    * The request id.
    */
-  id: number
+  id: MessageID
 
   /**
    * The result of a request. This member is REQUIRED on success.

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -48,8 +48,13 @@ func (s *Server) textDocumentCompletion(params *CompletionParams) (any, error) {
 	if innermostScope == nil {
 		return nil, nil
 	}
+	clientCapabilities, hasClientCapabilities := s.completionClientCapabilities()
+	documentationKind := Markdown
+	if hasClientCapabilities {
+		documentationKind = preferredMarkupKind(clientCapabilities.CompletionItem.DocumentationFormat)
+	}
 	ctx := &completionContext{
-		itemSet:        newCompletionItemSet(),
+		itemSet:        newCompletionItemSet(documentationKind),
 		proj:           result.proj,
 		typeInfo:       typeInfo,
 		result:         result,
@@ -65,6 +70,9 @@ func (s *Server) textDocumentCompletion(params *CompletionParams) (any, error) {
 		return nil, fmt.Errorf("failed to collect completion items: %w", err)
 	}
 	items := ctx.sortedItems()
+	if hasClientCapabilities {
+		adaptCompletionItemsForClient(clientCapabilities, items)
+	}
 	if ctx.isIncomplete {
 		return CompletionList{
 			IsIncomplete: true,
@@ -1700,7 +1708,7 @@ func (ctx *completionContext) collectTypeSpecific(typ gotypes.Type) error {
 		ctx.itemSet.add(CompletionItem{
 			Label:            name,
 			Kind:             TextCompletion,
-			Documentation:    &Or_CompletionItem_documentation{Value: MarkupContent{Kind: Markdown, Value: spxResourceID.URI().HTML()}},
+			Documentation:    completionDocumentation(resourceMarkupContent(spxResourceID.URI(), ctx.itemSet.documentationKind)),
 			InsertText:       name,
 			InsertTextFormat: ToPtr(PlainTextTextFormat),
 		})
@@ -1729,10 +1737,11 @@ func (ctx *completionContext) collectXGoUnitCompletions(expectedTypes []gotypes.
 				Kind:       UnitCompletion,
 				Detail:     GetSimplifiedTypeString(spec.SourceType),
 				FilterText: filterPrefix + spec.Name,
-				Documentation: &Or_CompletionItem_documentation{Value: MarkupContent{
-					Kind:  Markdown,
-					Value: "Multiplier: `" + spec.Factor + "`",
-				}},
+				Documentation: completionDocumentation(markupContent(
+					ctx.itemSet.documentationKind,
+					"Multiplier: `"+spec.Factor+"`",
+					"Multiplier: "+spec.Factor,
+				)),
 				InsertTextFormat: ToPtr(PlainTextTextFormat),
 				TextEdit: &Or_CompletionItem_textEdit{Value: TextEdit{
 					Range:   completionRange,
@@ -2023,10 +2032,58 @@ func (ctx *completionContext) sortedItems() []CompletionItem {
 	return ctx.itemSet.items
 }
 
+// adaptCompletionItemsForClient removes completion features unsupported by the
+// client. It adapts items in place.
+func adaptCompletionItemsForClient(capabilities CompletionClientCapabilities, items []CompletionItem) {
+	for i := range items {
+		item := &items[i]
+		if item.InsertTextFormat != nil && *item.InsertTextFormat == SnippetTextFormat &&
+			!capabilities.CompletionItem.SnippetSupport {
+			item.InsertText = item.Label
+			item.TextEdit = plainTextCompletionTextEdit(item.Label, item.TextEdit)
+			item.InsertTextFormat = ToPtr(PlainTextTextFormat)
+		}
+		if !completionItemKindSupportedByClient(capabilities, item.Kind) {
+			item.Kind = TextCompletion
+		}
+	}
+}
+
+// plainTextCompletionTextEdit returns a text edit with snippet text replaced by label.
+func plainTextCompletionTextEdit(label string, textEdit *Or_CompletionItem_textEdit) *Or_CompletionItem_textEdit {
+	if textEdit == nil {
+		return nil
+	}
+	result := *textEdit
+	switch edit := result.Value.(type) {
+	case TextEdit:
+		edit.NewText = label
+		result.Value = edit
+	case InsertReplaceEdit:
+		edit.NewText = label
+		result.Value = edit
+	default:
+		return textEdit
+	}
+	return &result
+}
+
+// completionItemKindSupportedByClient reports whether kind is safe to send.
+func completionItemKindSupportedByClient(capabilities CompletionClientCapabilities, kind CompletionItemKind) bool {
+	if kind == 0 {
+		return true
+	}
+	if capabilities.CompletionItemKind != nil && capabilities.CompletionItemKind.ValueSet != nil {
+		return true
+	}
+	return kind <= ReferenceCompletion
+}
+
 // completionItemSet is a set of completion items.
 type completionItemSet struct {
 	items                         []CompletionItem
 	seenSpxDefs                   map[string]struct{}
+	documentationKind             MarkupKind
 	supportedKinds                map[CompletionItemKind]struct{}
 	isCompatibleWithExpectedTypes func(typ gotypes.Type) bool
 	disallowVoidFuncs             bool
@@ -2035,10 +2092,11 @@ type completionItemSet struct {
 }
 
 // newCompletionItemSet creates a new [completionItemSet].
-func newCompletionItemSet() *completionItemSet {
+func newCompletionItemSet(documentationKind MarkupKind) *completionItemSet {
 	return &completionItemSet{
-		items:       []CompletionItem{},
-		seenSpxDefs: make(map[string]struct{}),
+		items:             []CompletionItem{},
+		seenSpxDefs:       make(map[string]struct{}),
+		documentationKind: documentationKind,
 	}
 }
 
@@ -2196,6 +2254,6 @@ func (s *completionItemSet) addSpxDefs(spxDefs ...SpxDefinition) {
 		}
 		s.seenSpxDefs[spxDefIDKey] = struct{}{}
 
-		s.add(spxDef.CompletionItem())
+		s.add(spxDef.completionItem(s.documentationKind))
 	}
 }

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgo/x/typesutil"
+	"github.com/goplus/xgolsw/protocol"
 	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -5269,6 +5270,125 @@ func TestCompletionContextResolvePropertyLikeFuncResultType(t *testing.T) {
 		got := ctx.resolvePropertyLikeFuncResultType(ident)
 		assert.Nil(t, got)
 	})
+}
+
+func TestAdaptCompletionItemsForClient(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		capabilities CompletionClientCapabilities
+		items        []CompletionItem
+		want         []CompletionItem
+	}{
+		{
+			name: "DowngradesUnsupportedSnippetAndKind",
+			items: []CompletionItem{{
+				Label:            "count",
+				Kind:             ConstantCompletion,
+				InsertText:       "count = ${1:}",
+				InsertTextFormat: ToPtr(SnippetTextFormat),
+				TextEdit: &Or_CompletionItem_textEdit{Value: TextEdit{
+					Range: Range{
+						Start: Position{Line: 1, Character: 2},
+						End:   Position{Line: 1, Character: 4},
+					},
+					NewText: "count = ${1:}",
+				}},
+			}},
+			want: []CompletionItem{{
+				Label:            "count",
+				Kind:             TextCompletion,
+				InsertText:       "count",
+				InsertTextFormat: ToPtr(PlainTextTextFormat),
+				TextEdit: &Or_CompletionItem_textEdit{Value: TextEdit{
+					Range: Range{
+						Start: Position{Line: 1, Character: 2},
+						End:   Position{Line: 1, Character: 4},
+					},
+					NewText: "count",
+				}},
+			}},
+		},
+		{
+			name: "KeepsSnippetAndKindWithValueSet",
+			capabilities: CompletionClientCapabilities{
+				CompletionItem: protocol.ClientCompletionItemOptions{
+					SnippetSupport: true,
+				},
+				CompletionItemKind: &protocol.ClientCompletionItemOptionsKind{
+					ValueSet: []CompletionItemKind{TextCompletion},
+				},
+			},
+			items: []CompletionItem{{
+				Label:            "count",
+				Kind:             ConstantCompletion,
+				InsertText:       "count = ${1:}",
+				InsertTextFormat: ToPtr(SnippetTextFormat),
+			}},
+			want: []CompletionItem{{
+				Label:            "count",
+				Kind:             ConstantCompletion,
+				InsertText:       "count = ${1:}",
+				InsertTextFormat: ToPtr(SnippetTextFormat),
+			}},
+		},
+		{
+			name: "DowngradesUnsupportedSnippetInsertReplaceEdit",
+			items: []CompletionItem{{
+				Label:            "move",
+				Kind:             FunctionCompletion,
+				InsertTextFormat: ToPtr(SnippetTextFormat),
+				TextEdit: &Or_CompletionItem_textEdit{Value: InsertReplaceEdit{
+					NewText: "move ${1:steps}",
+					Insert:  Range{Start: Position{Line: 1, Character: 2}, End: Position{Line: 1, Character: 4}},
+					Replace: Range{
+						Start: Position{Line: 1, Character: 2},
+						End:   Position{Line: 1, Character: 6},
+					},
+				}},
+			}},
+			want: []CompletionItem{{
+				Label:            "move",
+				Kind:             FunctionCompletion,
+				InsertText:       "move",
+				InsertTextFormat: ToPtr(PlainTextTextFormat),
+				TextEdit: &Or_CompletionItem_textEdit{Value: InsertReplaceEdit{
+					NewText: "move",
+					Insert:  Range{Start: Position{Line: 1, Character: 2}, End: Position{Line: 1, Character: 4}},
+					Replace: Range{
+						Start: Position{Line: 1, Character: 2},
+						End:   Position{Line: 1, Character: 6},
+					},
+				}},
+			}},
+		},
+		{
+			name: "KeepsInitialProtocolKindWithoutValueSet",
+			items: []CompletionItem{{
+				Label: "ref",
+				Kind:  ReferenceCompletion,
+			}},
+			want: []CompletionItem{{
+				Label: "ref",
+				Kind:  ReferenceCompletion,
+			}},
+		},
+		{
+			name: "DowngradesEnumMemberForInitialProtocolClient",
+			items: []CompletionItem{
+				{Label: "Color", Kind: EnumCompletion},
+				{Label: "Red", Kind: EnumMemberCompletion},
+			},
+			want: []CompletionItem{
+				{Label: "Color", Kind: EnumCompletion},
+				{Label: "Red", Kind: TextCompletion},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			adaptCompletionItemsForClient(tt.capabilities, tt.items)
+			assert.Equal(t, tt.want, tt.items)
+		})
+	}
 }
 
 func newPropertyLikeTestCompletionContext(pkg *gotypes.Package, innermostScope *gotypes.Scope, uses map[*ast.Ident]gotypes.Object) *completionContext {

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -11,6 +11,11 @@ import (
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification#textDocument_hover
 func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
+	markupKind := Markdown
+	if capabilities, ok := s.hoverClientCapabilities(); ok {
+		markupKind = preferredMarkupKind(capabilities.ContentFormat)
+	}
+
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
 	if err != nil {
 		return nil, err
@@ -25,11 +30,8 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 
 	if spxResourceRef := result.spxResourceRefAtPosition(position); spxResourceRef != nil {
 		return &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: spxResourceRef.ID.URI().HTML(),
-			},
-			Range: RangeForNode(result.proj, spxResourceRef.Node),
+			Contents: resourceMarkupContent(spxResourceRef.ID.URI(), markupKind),
+			Range:    RangeForNode(result.proj, spxResourceRef.Node),
 		}, nil
 	}
 
@@ -37,22 +39,24 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 	if typeInfo == nil {
 		return nil, nil
 	}
-	if hover := hoverForXGoUnit(result.proj, typeInfo, astFile, position); hover != nil {
+	if hover := hoverForXGoUnit(result.proj, typeInfo, astFile, position, markupKind); hover != nil {
 		return hover, nil
 	}
 	if tokenFile := xgoutil.NodeTokenFile(result.proj.Fset, astFile); tokenFile != nil {
 		pos := tokenFile.Pos(position.Offset)
 		if member := result.enumInfo.declarationMemberAt(pos); member != nil {
 			def := result.spxDefinitionForEnumMembers(member)
-			return hoverForSpxDefs(result.proj, []SpxDefinition{def}, member.ident), nil
+			return hoverForSpxDefs(result.proj, []SpxDefinition{def}, member.ident, markupKind), nil
 		}
 		if ident, obj := result.enumInfo.regularConstDeclarationAt(pos); ident != nil {
-			return hoverForSpxDefs(result.proj, result.spxDefinitionsFor(obj, ""), ident), nil
+			return hoverForSpxDefs(result.proj, result.spxDefinitionsFor(obj, ""), ident, markupKind), nil
 		}
 	}
 	ident, obj, kwargTarget := objectAtPosition(result.proj, typeInfo, astFile, position)
 	if kwargTarget != nil {
-		return hoverForSpxDefs(result.proj, result.spxDefinitionsFor(obj, getTypeFromObject(typeInfo, obj)), kwargTarget.ident), nil
+		return hoverForSpxDefs(
+			result.proj, result.spxDefinitionsFor(obj, getTypeFromObject(typeInfo, obj)), kwargTarget.ident, markupKind,
+		), nil
 	}
 	if ident == nil {
 		// Check if the position is within an import declaration.
@@ -61,7 +65,7 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 		if rpkg != nil {
 			return &Hover{
 				Contents: MarkupContent{
-					Kind:  Markdown,
+					Kind:  markupKind,
 					Value: godoc.Synopsis(rpkg.Pkg.Doc),
 				},
 				Range: RangeForNode(result.proj, rpkg.Node),
@@ -75,22 +79,29 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 			return nil, nil
 		}
 	}
-	return hoverForSpxDefs(result.proj, result.spxDefinitionsForIdent(ident), ident), nil
+	return hoverForSpxDefs(result.proj, result.spxDefinitionsForIdent(ident), ident, markupKind), nil
 }
 
 // hoverForSpxDefs renders spx definitions into a hover at node.
-func hoverForSpxDefs(proj *xgo.Project, spxDefs []SpxDefinition, node ast.Node) *Hover {
+func hoverForSpxDefs(proj *xgo.Project, spxDefs []SpxDefinition, node ast.Node, markupKind MarkupKind) *Hover {
 	if len(spxDefs) == 0 {
 		return nil
 	}
 
+	separator := ""
+	if markupKind == PlainText {
+		separator = "\n\n"
+	}
 	var hoverContent strings.Builder
-	for _, spxDef := range spxDefs {
-		hoverContent.WriteString(spxDef.HTML())
+	for i, spxDef := range spxDefs {
+		if i > 0 {
+			hoverContent.WriteString(separator)
+		}
+		hoverContent.WriteString(spxDef.markupContent(markupKind).Value)
 	}
 	return &Hover{
 		Contents: MarkupContent{
-			Kind:  Markdown,
+			Kind:  markupKind,
 			Value: hoverContent.String(),
 		},
 		Range: RangeForNode(proj, node),

--- a/internal/server/initialize.go
+++ b/internal/server/initialize.go
@@ -1,24 +1,25 @@
 package server
 
 import (
+	"net/url"
+	"slices"
+	"strings"
+
 	"golang.org/x/text/language"
 
 	"github.com/goplus/xgolsw/i18n"
+	"github.com/goplus/xgolsw/protocol"
 )
 
-// initialize handles the initialize request and sets up the server language preference
+// initialize handles the initialize request and sets up the server capabilities
+// and client-derived configuration.
 func (s *Server) initialize(params *InitializeParams) (*InitializeResult, error) {
-	// Set language based on client locale
+	s.setClientCapabilities(params.Capabilities)
 	s.setLanguageFromLocale(params.Locale)
-
-	// Create server capabilities
-	capabilities := ServerCapabilities{
-		// TODO(wyvern): Configure server capabilities based on client capabilities
-		// For now, return empty capabilities as placeholder
-	}
+	s.setWorkspaceRootURI(params)
 
 	return &InitializeResult{
-		Capabilities: capabilities,
+		Capabilities: serverCapabilities(params),
 		ServerInfo: &ServerInfo{
 			Name:    "XGo Language Server",
 			Version: "0.1.0",
@@ -26,19 +27,164 @@ func (s *Server) initialize(params *InitializeParams) (*InitializeResult, error)
 	}, nil
 }
 
-// setLanguageFromLocale sets the server language based on the client locale
+// serverCapabilities returns the LSP capabilities this server can safely
+// advertise for the given initialize params.
+func serverCapabilities(params *InitializeParams) ServerCapabilities {
+	textDocument := params.Capabilities.TextDocument
+	capabilities := ServerCapabilities{
+		PositionEncoding: ToPtr(protocol.UTF16),
+		TextDocumentSync: protocol.TextDocumentSyncOptions{
+			OpenClose: true,
+			Change:    protocol.Incremental,
+			Save:      &protocol.SaveOptions{},
+		},
+		CompletionProvider: &protocol.CompletionOptions{
+			TriggerCharacters: []string{"."},
+		},
+		HoverProvider: &protocol.Or_ServerCapabilities_hoverProvider{Value: true},
+		SignatureHelpProvider: &protocol.SignatureHelpOptions{
+			TriggerCharacters: []string{"(", ","},
+		},
+		DeclarationProvider:       &protocol.Or_ServerCapabilities_declarationProvider{Value: true},
+		DefinitionProvider:        &protocol.Or_ServerCapabilities_definitionProvider{Value: true},
+		TypeDefinitionProvider:    &protocol.Or_ServerCapabilities_typeDefinitionProvider{Value: true},
+		ImplementationProvider:    &protocol.Or_ServerCapabilities_implementationProvider{Value: true},
+		ReferencesProvider:        &protocol.Or_ServerCapabilities_referencesProvider{Value: true},
+		DocumentHighlightProvider: &protocol.Or_ServerCapabilities_documentHighlightProvider{Value: true},
+		DocumentLinkProvider:      &protocol.DocumentLinkOptions{},
+		DiagnosticProvider: &protocol.Or_ServerCapabilities_diagnosticProvider{
+			Value: protocol.DiagnosticOptions{InterFileDependencies: true},
+		},
+		DocumentFormattingProvider: &protocol.Or_ServerCapabilities_documentFormattingProvider{Value: true},
+		RenameProvider:             true,
+		ExecuteCommandProvider: &protocol.ExecuteCommandOptions{
+			Commands: []string{
+				CommandXGoRenameResources,
+				CommandSpxRenameResources,
+				CommandXGoGetInputSlots,
+				CommandSpxGetInputSlots,
+				CommandXGoGetProperties,
+			},
+		},
+		InlayHintProvider: protocol.InlayHintOptions{},
+	}
+	if textDocument.Rename != nil && textDocument.Rename.PrepareSupport {
+		capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: true}
+	}
+	if textDocument.SignatureHelp != nil && textDocument.SignatureHelp.ContextSupport {
+		capabilities.SignatureHelpProvider.RetriggerCharacters = []string{","}
+	}
+	if provider, ok := semanticTokensServerCapabilities(textDocument.SemanticTokens); ok {
+		capabilities.SemanticTokensProvider = provider
+	}
+	return capabilities
+}
+
+// semanticTokensServerCapabilities returns semantic token options supported by
+// both client and server.
+func semanticTokensServerCapabilities(client protocol.SemanticTokensClientCapabilities) (protocol.SemanticTokensOptions, bool) {
+	if !semanticTokensFullSupported(client) ||
+		!slices.Contains(client.Formats, protocol.Relative) ||
+		!client.OverlappingTokenSupport {
+		return protocol.SemanticTokensOptions{}, false
+	}
+
+	tokenTypes := semanticTokenLegendStrings(semanticTokenTypesLegend)
+	if !semanticTokenLegendSupported(client.TokenTypes, tokenTypes) {
+		return protocol.SemanticTokensOptions{}, false
+	}
+	tokenModifiers := semanticTokenLegendStrings(semanticTokenModifiersLegend)
+	if !semanticTokenLegendSupported(client.TokenModifiers, tokenModifiers) {
+		return protocol.SemanticTokensOptions{}, false
+	}
+	return protocol.SemanticTokensOptions{
+		Legend: protocol.SemanticTokensLegend{
+			TokenTypes:     tokenTypes,
+			TokenModifiers: tokenModifiers,
+		},
+		Full: &protocol.Or_SemanticTokensOptions_full{Value: true},
+	}, true
+}
+
+// semanticTokensFullSupported reports whether the client can send full semantic
+// token requests when the server advertises them.
+func semanticTokensFullSupported(client protocol.SemanticTokensClientCapabilities) bool {
+	if client.Requests.Full == nil {
+		return false
+	}
+	switch full := client.Requests.Full.Value.(type) {
+	case bool:
+		return full
+	case protocol.ClientSemanticTokensRequestFullDelta:
+		return true
+	default:
+		return false
+	}
+}
+
+// semanticTokenLegendSupported reports whether supported contains every legend value.
+func semanticTokenLegendSupported(supported []string, legend []string) bool {
+	for _, value := range legend {
+		if !slices.Contains(supported, value) {
+			return false
+		}
+	}
+	return true
+}
+
+// setWorkspaceRootURI sets the server workspace root from initialize params.
+func (s *Server) setWorkspaceRootURI(params *InitializeParams) {
+	if rootURI := workspaceRootURI(params); rootURI != "" {
+		s.workspaceRootURI = DocumentURI(ensureTrailingSlash(rootURI))
+	}
+}
+
+// workspaceRootURI returns the root URI selected from initialize params.
+func workspaceRootURI(params *InitializeParams) string {
+	if len(params.WorkspaceFolders) > 0 && params.WorkspaceFolders[0].URI != "" {
+		return string(params.WorkspaceFolders[0].URI)
+	}
+	if params.RootURI != "" {
+		return string(params.RootURI)
+	}
+	if params.RootPath != "" {
+		return fileURIFromPath(params.RootPath)
+	}
+	return ""
+}
+
+// fileURIFromPath returns a file URI for a filesystem path.
+func fileURIFromPath(path string) string {
+	path = strings.ReplaceAll(path, "\\", "/")
+	if strings.HasPrefix(path, "//") {
+		host, rest, ok := strings.Cut(strings.TrimPrefix(path, "//"), "/")
+		if ok && host != "" {
+			return (&url.URL{Scheme: "file", Host: host, Path: "/" + rest}).String()
+		}
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return (&url.URL{Scheme: "file", Path: path}).String()
+}
+
+// ensureTrailingSlash returns uri with a trailing slash.
+func ensureTrailingSlash(uri string) string {
+	if strings.HasSuffix(uri, "/") {
+		return uri
+	}
+	return uri + "/"
+}
+
+// setLanguageFromLocale sets the server language based on the client locale.
 func (s *Server) setLanguageFromLocale(locale string) {
-	// Default to English
 	s.language = i18n.LanguageEN
 
-	// Parse the locale using golang.org/x/text/language
 	tag, err := language.Parse(locale)
 	if err != nil {
-		// If parsing fails, keep the default language
 		return
 	}
 
-	// Check if the base language is Chinese
 	base, _ := tag.Base()
 	chineseBase, _ := language.Chinese.Base()
 	if base == chineseBase {
@@ -46,7 +192,7 @@ func (s *Server) setLanguageFromLocale(locale string) {
 	}
 }
 
-// translate translates a diagnostic message based on the server's current language
+// translate translates a diagnostic message based on the server's current language.
 func (s *Server) translate(message string) string {
 	return i18n.Translate(message, s.language)
 }

--- a/internal/server/initialize_test.go
+++ b/internal/server/initialize_test.go
@@ -1,0 +1,321 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/goplus/xgolsw/jsonrpc2"
+	"github.com/goplus/xgolsw/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requireCapabilityMap(t *testing.T, capabilities ServerCapabilities) map[string]any {
+	t.Helper()
+
+	data, err := json.Marshal(capabilities)
+	require.NoError(t, err)
+	var capabilityMap map[string]any
+	require.NoError(t, json.Unmarshal(data, &capabilityMap))
+	return capabilityMap
+}
+
+func semanticTokensClientCapabilitiesForTest() protocol.SemanticTokensClientCapabilities {
+	return protocol.SemanticTokensClientCapabilities{
+		Requests: protocol.ClientSemanticTokensRequestOptions{
+			Full: &protocol.Or_ClientSemanticTokensRequestOptions_full{Value: true},
+		},
+		TokenTypes:              semanticTokenLegendStrings(semanticTokenTypesLegend),
+		TokenModifiers:          semanticTokenLegendStrings(semanticTokenModifiersLegend),
+		Formats:                 []protocol.TokenFormat{protocol.Relative},
+		OverlappingTokenSupport: true,
+		MultilineTokenSupport:   true,
+	}
+}
+
+func stringsAsAny(values []string) []any {
+	result := make([]any, len(values))
+	for i, value := range values {
+		result[i] = value
+	}
+	return result
+}
+
+func TestServerInitialize(t *testing.T) {
+	t.Run("Capabilities", func(t *testing.T) {
+		replier := newMockReplier()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{
+			XInitializeParams: protocol.XInitializeParams{
+				RootURI: "file:///workspace",
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: protocol.TextDocumentClientCapabilities{
+						Completion: protocol.CompletionClientCapabilities{
+							CompletionItem: protocol.ClientCompletionItemOptions{
+								SnippetSupport:      true,
+								DocumentationFormat: []protocol.MarkupKind{protocol.Markdown},
+							},
+						},
+						Hover: &protocol.HoverClientCapabilities{
+							ContentFormat: []protocol.MarkupKind{protocol.Markdown},
+						},
+						Rename: &protocol.RenameClientCapabilities{
+							PrepareSupport: true,
+						},
+						SignatureHelp: &protocol.SignatureHelpClientCapabilities{
+							ContextSupport: true,
+						},
+						SemanticTokens: semanticTokensClientCapabilitiesForTest(),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(call))
+
+		messages := replier.waitForMessages(2, 5*time.Second)
+		response := requireResponseForID(t, messages, call.ID())
+		require.NoError(t, response.Err())
+
+		var result InitializeResult
+		require.NoError(t, json.Unmarshal(response.Result(), &result))
+		require.NotNil(t, result.ServerInfo)
+		assert.Equal(t, "XGo Language Server", result.ServerInfo.Name)
+		assert.Equal(t, "0.1.0", result.ServerInfo.Version)
+		assert.Equal(t, DocumentURI("file:///workspace/"), server.workspaceRootURI)
+		completionClientCapabilities, ok := server.completionClientCapabilities()
+		require.True(t, ok)
+		assert.True(t, completionClientCapabilities.CompletionItem.SnippetSupport)
+		assert.Equal(t, []MarkupKind{Markdown}, completionClientCapabilities.CompletionItem.DocumentationFormat)
+		hoverClientCapabilities, ok := server.hoverClientCapabilities()
+		require.True(t, ok)
+		assert.Equal(t, []MarkupKind{Markdown}, hoverClientCapabilities.ContentFormat)
+
+		capabilities := requireCapabilityMap(t, result.Capabilities)
+		assert.Equal(t, "utf-16", capabilities["positionEncoding"])
+		assert.Contains(t, capabilities, "textDocumentSync")
+		textDocumentSync := requireValueAs[map[string]any](t, capabilities["textDocumentSync"])
+		assert.Equal(t, true, textDocumentSync["openClose"])
+		assert.Equal(t, float64(protocol.Incremental), textDocumentSync["change"])
+		assert.Contains(t, textDocumentSync, "save")
+
+		completionProvider := requireValueAs[map[string]any](t, capabilities["completionProvider"])
+		assert.Equal(t, []any{"."}, completionProvider["triggerCharacters"])
+		assert.NotContains(t, completionProvider, "resolveProvider")
+		assert.Equal(t, true, capabilities["hoverProvider"])
+
+		signatureHelpProvider := requireValueAs[map[string]any](t, capabilities["signatureHelpProvider"])
+		assert.Equal(t, []any{"(", ","}, signatureHelpProvider["triggerCharacters"])
+		assert.Equal(t, []any{","}, signatureHelpProvider["retriggerCharacters"])
+		assert.Equal(t, true, capabilities["declarationProvider"])
+		assert.Equal(t, true, capabilities["definitionProvider"])
+		assert.Equal(t, true, capabilities["typeDefinitionProvider"])
+		assert.Equal(t, true, capabilities["implementationProvider"])
+		assert.Equal(t, true, capabilities["referencesProvider"])
+		assert.Equal(t, true, capabilities["documentHighlightProvider"])
+		assert.Equal(t, map[string]any{}, capabilities["documentLinkProvider"])
+
+		diagnosticProvider := requireValueAs[map[string]any](t, capabilities["diagnosticProvider"])
+		assert.Equal(t, true, diagnosticProvider["interFileDependencies"])
+		assert.Equal(t, false, diagnosticProvider["workspaceDiagnostics"])
+		assert.Equal(t, true, capabilities["documentFormattingProvider"])
+
+		renameProvider := requireValueAs[map[string]any](t, capabilities["renameProvider"])
+		assert.Equal(t, true, renameProvider["prepareProvider"])
+
+		executeCommandProvider := requireValueAs[map[string]any](t, capabilities["executeCommandProvider"])
+		assert.ElementsMatch(t, []any{
+			CommandXGoRenameResources,
+			CommandSpxRenameResources,
+			CommandXGoGetInputSlots,
+			CommandSpxGetInputSlots,
+			CommandXGoGetProperties,
+		}, executeCommandProvider["commands"])
+
+		assert.Equal(t, map[string]any{}, capabilities["inlayHintProvider"])
+
+		semanticTokensProvider := requireValueAs[map[string]any](t, capabilities["semanticTokensProvider"])
+		legend := requireValueAs[map[string]any](t, semanticTokensProvider["legend"])
+		assert.Equal(t, stringsAsAny(semanticTokenLegendStrings(semanticTokenTypesLegend)), legend["tokenTypes"])
+		assert.Equal(t, stringsAsAny(semanticTokenLegendStrings(semanticTokenModifiersLegend)), legend["tokenModifiers"])
+		assert.Equal(t, true, semanticTokensProvider["full"])
+		assert.NotContains(t, semanticTokensProvider, "range")
+
+		assert.NotContains(t, capabilities, "documentSymbolProvider")
+		assert.NotContains(t, capabilities, "workspaceSymbolProvider")
+		assert.NotContains(t, capabilities, "codeActionProvider")
+		assert.NotContains(t, capabilities, "codeLensProvider")
+		assert.NotContains(t, capabilities, "documentRangeFormattingProvider")
+		assert.NotContains(t, capabilities, "documentOnTypeFormattingProvider")
+		assert.NotContains(t, capabilities, "foldingRangeProvider")
+		assert.NotContains(t, capabilities, "selectionRangeProvider")
+	})
+
+	t.Run("RenameWithoutPrepareSupport", func(t *testing.T) {
+		capabilities := serverCapabilities(&InitializeParams{})
+		capabilityMap := requireCapabilityMap(t, capabilities)
+		assert.Equal(t, true, capabilityMap["renameProvider"])
+	})
+
+	t.Run("SignatureHelpWithoutContextSupport", func(t *testing.T) {
+		capabilities := serverCapabilities(&InitializeParams{})
+		capabilityMap := requireCapabilityMap(t, capabilities)
+		signatureHelpProvider := requireValueAs[map[string]any](t, capabilityMap["signatureHelpProvider"])
+		assert.Equal(t, []any{"(", ","}, signatureHelpProvider["triggerCharacters"])
+		assert.NotContains(t, signatureHelpProvider, "retriggerCharacters")
+	})
+
+	t.Run("SemanticTokensCapabilityNegotiation", func(t *testing.T) {
+		for _, tt := range []struct {
+			name   string
+			mutate func(*protocol.SemanticTokensClientCapabilities)
+			want   bool
+		}{
+			{
+				name: "Supported",
+				want: true,
+			},
+			{
+				name: "FullMissing",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.Requests.Full = nil
+				},
+			},
+			{
+				name: "FullFalse",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.Requests.Full.Value = false
+				},
+			},
+			{
+				name: "RelativeFormatMissing",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.Formats = nil
+				},
+			},
+			{
+				name: "TokenTypeMissing",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.TokenTypes = capabilities.TokenTypes[:len(capabilities.TokenTypes)-1]
+				},
+			},
+			{
+				name: "TokenModifierMissing",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.TokenModifiers = capabilities.TokenModifiers[:len(capabilities.TokenModifiers)-1]
+				},
+			},
+			{
+				name: "OverlappingTokenUnsupported",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.OverlappingTokenSupport = false
+				},
+			},
+			{
+				name: "MultilineTokenSupportNotRequired",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.MultilineTokenSupport = false
+				},
+				want: true,
+			},
+			{
+				name: "FullDeltaRequestSupported",
+				mutate: func(capabilities *protocol.SemanticTokensClientCapabilities) {
+					capabilities.Requests.Full.Value = protocol.ClientSemanticTokensRequestFullDelta{Delta: true}
+				},
+				want: true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				semanticTokens := semanticTokensClientCapabilitiesForTest()
+				if tt.mutate != nil {
+					tt.mutate(&semanticTokens)
+				}
+				capabilities := serverCapabilities(&InitializeParams{
+					XInitializeParams: protocol.XInitializeParams{
+						Capabilities: protocol.ClientCapabilities{
+							TextDocument: protocol.TextDocumentClientCapabilities{
+								SemanticTokens: semanticTokens,
+							},
+						},
+					},
+				})
+				capabilityMap := requireCapabilityMap(t, capabilities)
+				if tt.want {
+					assert.Contains(t, capabilityMap, "semanticTokensProvider")
+				} else {
+					assert.NotContains(t, capabilityMap, "semanticTokensProvider")
+				}
+			})
+		}
+	})
+
+	t.Run("WorkspaceFolderRoot", func(t *testing.T) {
+		replier := newMockReplier()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{
+			XInitializeParams: protocol.XInitializeParams{
+				RootURI: "file:///root-uri",
+			},
+			WorkspaceFoldersInitializeParams: protocol.WorkspaceFoldersInitializeParams{
+				WorkspaceFolders: []protocol.WorkspaceFolder{{
+					URI:  "file:///workspace-folder",
+					Name: "workspace-folder",
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(call))
+		messages := replier.waitForMessages(2, 5*time.Second)
+		require.NoError(t, requireResponseForID(t, messages, call.ID()).Err())
+		assert.Equal(t, DocumentURI("file:///workspace-folder/"), server.workspaceRootURI)
+	})
+
+	t.Run("RootPathFallback", func(t *testing.T) {
+		for _, tt := range []struct {
+			name        string
+			rootPath    string
+			wantRootURI DocumentURI
+			documentURI DocumentURI
+		}{
+			{
+				name:        "UnixPath",
+				rootPath:    "/legacy-root",
+				wantRootURI: "file:///legacy-root/",
+				documentURI: "file:///legacy-root/main.spx",
+			},
+			{
+				name:        "WindowsDrivePath",
+				rootPath:    `C:\Users\me\proj`,
+				wantRootURI: "file:///C:/Users/me/proj/",
+				documentURI: "file:///C:/Users/me/proj/main.spx",
+			},
+			{
+				name:        "WindowsUNCPath",
+				rootPath:    `\\server\share\proj`,
+				wantRootURI: "file://server/share/proj/",
+				documentURI: "file://server/share/proj/main.spx",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				replier := newMockReplier()
+				server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+				call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{
+					XInitializeParams: protocol.XInitializeParams{
+						RootPath: tt.rootPath,
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, server.HandleMessage(call))
+				messages := replier.waitForMessages(2, 5*time.Second)
+				require.NoError(t, requireResponseForID(t, messages, call.ID()).Err())
+				assert.Equal(t, tt.wantRootURI, server.workspaceRootURI)
+
+				path, err := server.fromDocumentURI(tt.documentURI)
+				require.NoError(t, err)
+				assert.Equal(t, "main.spx", path)
+			})
+		}
+	})
+}

--- a/internal/server/markup.go
+++ b/internal/server/markup.go
@@ -1,0 +1,36 @@
+package server
+
+// preferredMarkupKind returns the client's most preferred supported markup
+// kind. Plain text is the protocol-compatible default.
+func preferredMarkupKind(formats []MarkupKind) MarkupKind {
+	for _, format := range formats {
+		switch format {
+		case Markdown, PlainText:
+			return format
+		}
+	}
+	return PlainText
+}
+
+// markupContent constructs markup content from equivalent Markdown and plain
+// text representations.
+func markupContent(kind MarkupKind, markdownValue, plainTextValue string) MarkupContent {
+	if kind == Markdown {
+		return MarkupContent{Kind: Markdown, Value: markdownValue}
+	}
+	return MarkupContent{Kind: PlainText, Value: plainTextValue}
+}
+
+// completionDocumentation converts markup content to the completion
+// documentation representation compatible with older plain-text clients.
+func completionDocumentation(content MarkupContent) *Or_CompletionItem_documentation {
+	if content.Kind == PlainText {
+		return &Or_CompletionItem_documentation{Value: content.Value}
+	}
+	return &Or_CompletionItem_documentation{Value: content}
+}
+
+// resourceMarkupContent constructs markup content for an XGo resource.
+func resourceMarkupContent(uri XGoResourceURI, kind MarkupKind) MarkupContent {
+	return markupContent(kind, uri.HTML(), string(uri))
+}

--- a/internal/server/markup_test.go
+++ b/internal/server/markup_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/goplus/xgolsw/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreferredMarkupKind(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		formats []MarkupKind
+		want    MarkupKind
+	}{
+		{
+			name: "DefaultsToPlainText",
+			want: PlainText,
+		},
+		{
+			name:    "UsesMarkdown",
+			formats: []MarkupKind{Markdown},
+			want:    Markdown,
+		},
+		{
+			name:    "HonorsClientPreference",
+			formats: []MarkupKind{PlainText, Markdown},
+			want:    PlainText,
+		},
+		{
+			name:    "SkipsUnknownKinds",
+			formats: []MarkupKind{"custom", Markdown},
+			want:    Markdown,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, preferredMarkupKind(tt.formats))
+		})
+	}
+}
+
+func TestResourceMarkupContent(t *testing.T) {
+	uri := XGoResourceURI("spx://resources/sounds/MySound")
+	assert.Equal(t, MarkupContent{
+		Kind:  Markdown,
+		Value: "<resource-preview resource=\"spx://resources/sounds/MySound\" />\n",
+	}, resourceMarkupContent(uri, Markdown))
+	assert.Equal(t, MarkupContent{
+		Kind:  PlainText,
+		Value: "spx://resources/sounds/MySound",
+	}, resourceMarkupContent(uri, PlainText))
+}
+
+func TestSpxDefinitionMarkupContent(t *testing.T) {
+	def := SpxDefinition{
+		ID:       SpxDefinitionIdentifier{Name: ToPtr("count")},
+		Overview: "var count int",
+		Detail:   "count is a variable.\n",
+	}
+	assert.Equal(t, MarkupContent{
+		Kind:  Markdown,
+		Value: "<pre is=\"definition-item\" def-id=\"xgo:?count\" overview=\"var count int\">\ncount is a variable.\n</pre>\n",
+	}, def.markupContent(Markdown))
+	assert.Equal(t, MarkupContent{
+		Kind:  PlainText,
+		Value: "var count int\n\ncount is a variable.",
+	}, def.markupContent(PlainText))
+}
+
+func TestCompletionDocumentation(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		content MarkupContent
+		want    *Or_CompletionItem_documentation
+	}{
+		{
+			name:    "Markdown",
+			content: MarkupContent{Kind: Markdown, Value: "**count**"},
+			want: &Or_CompletionItem_documentation{
+				Value: MarkupContent{Kind: Markdown, Value: "**count**"},
+			},
+		},
+		{
+			name:    "PlainText",
+			content: MarkupContent{Kind: PlainText, Value: "count"},
+			want:    &Or_CompletionItem_documentation{Value: "count"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, completionDocumentation(tt.content))
+		})
+	}
+}
+
+func TestServerTextDocumentHoverPlainTextEnum(t *testing.T) {
+	files := map[string][]byte{
+		"main.spx": []byte(`type Color const (
+	// Red documentation.
+	Red = iota
+)
+`),
+	}
+	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+	_, err := server.initialize(&InitializeParams{
+		XInitializeParams: protocol.XInitializeParams{
+			Capabilities: protocol.ClientCapabilities{
+				TextDocument: protocol.TextDocumentClientCapabilities{
+					Hover: &protocol.HoverClientCapabilities{
+						ContentFormat: []protocol.MarkupKind{protocol.PlainText},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	server.finishInitialize(nil)
+
+	hover, err := server.textDocumentHover(&HoverParams{
+		TextDocumentPositionParams: TextDocumentPositionParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			Position:     Position{Line: 2, Character: 1},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hover)
+	assert.Equal(t, PlainText, hover.Contents.Kind)
+	assert.Contains(t, hover.Contents.Value, "Red documentation.")
+	assert.NotContains(t, hover.Contents.Value, "<pre")
+}

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -17,8 +17,9 @@ type (
 	Range       = protocol.Range
 	Location    = protocol.Location
 
-	TextEdit      = protocol.TextEdit
-	WorkspaceEdit = protocol.WorkspaceEdit
+	TextEdit          = protocol.TextEdit
+	WorkspaceEdit     = protocol.WorkspaceEdit
+	InsertReplaceEdit = protocol.InsertReplaceEdit
 
 	TextDocumentPositionParams = protocol.TextDocumentPositionParams
 	TextDocumentIdentifier     = protocol.TextDocumentIdentifier
@@ -26,6 +27,7 @@ type (
 	InsertTextFormat = protocol.InsertTextFormat
 
 	MarkupContent = protocol.MarkupContent
+	MarkupKind    = protocol.MarkupKind
 
 	DocumentHighlightParams = protocol.DocumentHighlightParams
 	DocumentHighlight       = protocol.DocumentHighlight
@@ -49,6 +51,7 @@ type (
 
 	CompletionItem                  = protocol.CompletionItem
 	CompletionItemKind              = protocol.CompletionItemKind
+	CompletionClientCapabilities    = protocol.CompletionClientCapabilities
 	CompletionList                  = protocol.CompletionList
 	CompletionParams                = protocol.CompletionParams
 	Or_CompletionItem_documentation = protocol.Or_CompletionItem_documentation
@@ -64,8 +67,9 @@ type (
 	ReferenceParams  = protocol.ReferenceParams
 	ReferenceContext = protocol.ReferenceContext
 
-	HoverParams = protocol.HoverParams
-	Hover       = protocol.Hover
+	HoverParams             = protocol.HoverParams
+	Hover                   = protocol.Hover
+	HoverClientCapabilities = protocol.HoverClientCapabilities
 
 	ImplementationParams = protocol.ImplementationParams
 
@@ -83,6 +87,7 @@ type (
 	InitializeResult     = protocol.InitializeResult
 	ServerCapabilities   = protocol.ServerCapabilities
 	ServerInfo           = protocol.ServerInfo
+	ClientCapabilities   = protocol.ClientCapabilities
 	InitializedParams    = protocol.InitializedParams
 	ExecuteCommandParams = protocol.ExecuteCommandParams
 	CancelParams         = protocol.CancelParams
@@ -116,11 +121,13 @@ const (
 	FunctionCompletion   = protocol.FunctionCompletion
 	ModuleCompletion     = protocol.ModuleCompletion
 	EnumMemberCompletion = protocol.EnumMemberCompletion
+	ReferenceCompletion  = protocol.ReferenceCompletion
 
 	DiagnosticFull = protocol.DiagnosticFull
 
-	Markdown = protocol.Markdown
-	Text     = protocol.Text
+	Markdown  = protocol.Markdown
+	PlainText = protocol.PlainText
+	Text      = protocol.Text
 
 	Write = protocol.Write
 	Read  = protocol.Read
@@ -156,7 +163,8 @@ const (
 	Type      = protocol.Type
 	Parameter = protocol.Parameter
 
-	RequestCancelled = protocol.RequestCancelled
+	ServerNotInitialized = protocol.ServerNotInitialized
+	RequestCancelled     = protocol.RequestCancelled
 )
 
 // UnmarshalJSON unmarshals msg into the variable pointed to by params.

--- a/internal/server/semantic_token.go
+++ b/internal/server/semantic_token.go
@@ -73,6 +73,15 @@ type semanticTokenInfo struct {
 	tokenModifiers []SemanticTokenModifiers
 }
 
+// semanticTokenLegendStrings converts a semantic token legend to protocol strings.
+func semanticTokenLegendStrings[T ~string](legend []T) []string {
+	values := make([]string, len(legend))
+	for i, value := range legend {
+		values[i] = string(value)
+	}
+	return values
+}
+
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_semanticTokens
 func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*SemanticTokens, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)

--- a/internal/server/semantic_token_test.go
+++ b/internal/server/semantic_token_test.go
@@ -164,6 +164,34 @@ onStart => {
 		})
 	})
 
+	t.Run("UTF16Encoding", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`var café = "😀"
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      0,
+			character: 4,
+			length:    4,
+			tokenType: VariableType,
+		})
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      0,
+			character: 11,
+			length:    4,
+			tokenType: StringType,
+		})
+	})
+
 	t.Run("MultilineInterpolatedString", func(t *testing.T) {
 		s := newXGoUnitTestServer(`
 onStart => {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	gotypes "go/types"
 	"maps"
@@ -45,14 +44,18 @@ type Scheduler interface {
 
 // Server is the core language server implementation that handles LSP messages.
 type Server struct {
-	workspaceRootURI DocumentURI
-	workspaceRootFS  *xgo.Project
-	replier          MessageReplier
-	analyzers        []*analysis.Analyzer
-	fileMapGetter    FileMapGetter // TODO(wyvern): Remove this field.
-	cancelCauseFuncs sync.Map      // Map of request IDs to cancel functions (with cause).
-	scheduler        Scheduler
-	language         i18n.Language // Current language for error message translation
+	workspaceRootURI   DocumentURI
+	workspaceRootFS    *xgo.Project
+	replier            MessageReplier
+	analyzers          []*analysis.Analyzer
+	fileMapGetter      FileMapGetter // TODO(wyvern): Remove this field.
+	cancelCauseFuncs   sync.Map      // Map of request IDs to cancel functions (with cause).
+	scheduler          Scheduler
+	language           i18n.Language // Current language for error message translation
+	initMu             sync.Mutex
+	clientCapabilities ClientCapabilities
+	initializeCalled   bool
+	initialized        bool
 }
 
 func (s *Server) getProj() *xgo.Project {
@@ -75,7 +78,6 @@ func New(proj *xgo.Project, replier MessageReplier, fileMapGetter FileMapGetter,
 	proj.Mod = mod
 	proj.Importer = internal.Importer
 	return &Server{
-		// TODO(spxls): Initialize request should set workspaceRootURI value
 		workspaceRootURI: "file:///",
 		workspaceRootFS:  proj,
 		replier:          replier,
@@ -114,9 +116,20 @@ func (s *Server) handleCall(c *jsonrpc2.Call) error {
 		if err := UnmarshalJSON(c.Params(), &params); err != nil {
 			return s.replyParseError(c.ID(), err)
 		}
-		s.runForCall(c, func() (any, error) {
+		if err := s.beginInitialize(); err != nil {
+			return s.replyError(c.ID(), err)
+		}
+		s.runForCallWithReplyHook(c, func() (any, error) {
 			return s.initialize(&params)
-		})
+		}, s.finishInitialize)
+		return nil
+	}
+
+	if !s.isInitialized() {
+		return s.replyError(c.ID(), serverNotInitialized)
+	}
+
+	switch c.Method() {
 	case "shutdown":
 		s.runForCall(c, func() (any, error) {
 			return nil, nil // Protocol conformance only.
@@ -274,16 +287,14 @@ func (s *Server) handleCall(c *jsonrpc2.Call) error {
 // handleNotification handles a notification message.
 func (s *Server) handleNotification(n *jsonrpc2.Notification) error {
 	switch n.Method() {
-	case "initialized":
-		var params InitializedParams
-		if err := UnmarshalJSON(n.Params(), &params); err != nil {
-			return fmt.Errorf("failed to parse initialized params: %w", err)
-		}
-		s.runForNotification(n, func() error {
-			return errors.New("TODO")
-		})
 	case "exit":
-		// Protocol conformance only.
+		return nil
+	}
+	if !s.isInitialized() {
+		return nil
+	}
+
+	switch n.Method() {
 	case "$/cancelRequest":
 		var params CancelParams
 		if err := UnmarshalJSON(n.Params(), &params); err != nil {
@@ -291,6 +302,14 @@ func (s *Server) handleNotification(n *jsonrpc2.Notification) error {
 		}
 		s.runForNotification(n, func() error {
 			return s.cancelRequest(&params)
+		})
+	case "initialized":
+		var params InitializedParams
+		if err := UnmarshalJSON(n.Params(), &params); err != nil {
+			return fmt.Errorf("failed to parse initialized params: %w", err)
+		}
+		s.runForNotification(n, func() error {
+			return nil
 		})
 	case "textDocument/didOpen":
 		var params DidOpenTextDocumentParams
@@ -326,6 +345,71 @@ func (s *Server) handleNotification(n *jsonrpc2.Notification) error {
 		})
 	}
 	return nil
+}
+
+// beginInitialize marks the initialize request as started.
+func (s *Server) beginInitialize() error {
+	s.initMu.Lock()
+	defer s.initMu.Unlock()
+	if s.initializeCalled {
+		return fmt.Errorf("%w: initialize request may only be sent once", jsonrpc2.ErrInvalidRequest)
+	}
+	s.initializeCalled = true
+	return nil
+}
+
+// setClientCapabilities records the client capabilities from initialize params.
+func (s *Server) setClientCapabilities(capabilities ClientCapabilities) {
+	s.initMu.Lock()
+	defer s.initMu.Unlock()
+	s.clientCapabilities = capabilities
+}
+
+// finishInitialize records successful completion of the initialize request.
+func (s *Server) finishInitialize(err error) {
+	s.initMu.Lock()
+	defer s.initMu.Unlock()
+	if err == nil {
+		s.initialized = true
+	}
+}
+
+// isInitialized reports whether the initialize request completed successfully.
+func (s *Server) isInitialized() bool {
+	s.initMu.Lock()
+	defer s.initMu.Unlock()
+	return s.initialized
+}
+
+// clientCapabilitiesAfterInitialize returns the client capabilities after initialize completes.
+func (s *Server) clientCapabilitiesAfterInitialize() (ClientCapabilities, bool) {
+	s.initMu.Lock()
+	defer s.initMu.Unlock()
+	if !s.initialized {
+		return ClientCapabilities{}, false
+	}
+	return s.clientCapabilities, true
+}
+
+// completionClientCapabilities returns the completion capabilities after initialize.
+func (s *Server) completionClientCapabilities() (CompletionClientCapabilities, bool) {
+	capabilities, ok := s.clientCapabilitiesAfterInitialize()
+	if !ok {
+		return CompletionClientCapabilities{}, false
+	}
+	return capabilities.TextDocument.Completion, true
+}
+
+// hoverClientCapabilities returns the hover capabilities after initialize.
+func (s *Server) hoverClientCapabilities() (HoverClientCapabilities, bool) {
+	capabilities, ok := s.clientCapabilitiesAfterInitialize()
+	if !ok {
+		return HoverClientCapabilities{}, false
+	}
+	if capabilities.TextDocument.Hover == nil {
+		return HoverClientCapabilities{}, true
+	}
+	return *capabilities.TextDocument.Hover, true
 }
 
 // notifyPropertyRenamed sends a notification to the client when a property is renamed.
@@ -422,13 +506,29 @@ func (s *Server) wrapWithMetrics(msg jsonrpc2.Message, fn func() (any, error)) f
 
 // runForCall runs a function for a call message and replies with the result or error.
 func (s *Server) runForCall(call *jsonrpc2.Call, fn func() (any, error)) {
+	s.runForCallWithReplyHook(call, fn, nil)
+}
+
+// runForCallWithReplyHook runs a function for a call message and replies with
+// the result or error. If beforeReply is not nil, it runs once after the
+// response outcome is known and before the response is sent to the client.
+func (s *Server) runForCallWithReplyHook(call *jsonrpc2.Call, fn func() (any, error), beforeReply func(error)) {
 	ctx, cancelCauseFunc := context.WithCancelCause(context.TODO())
 	s.cancelCauseFuncs.Store(call.ID(), cancelCauseFunc)
 	wrap := s.wrapWithMetrics(call, fn)
 	go func() (err error) {
+		runBeforeReply := func(replyErr error) {
+			if beforeReply == nil {
+				return
+			}
+			hook := beforeReply
+			beforeReply = nil
+			hook(replyErr)
+		}
 		defer func() {
 			s.cancelCauseFuncs.Delete(call.ID())
 			if err != nil {
+				runBeforeReply(err)
 				s.replyError(call.ID(), err)
 			}
 		}()
@@ -439,24 +539,29 @@ func (s *Server) runForCall(call *jsonrpc2.Call, fn func() (any, error)) {
 			return err
 		}
 
-		result, err := wrap()
-		resp, err := jsonrpc2.NewResponse(call.ID(), result, err)
+		result, callErr := wrap()
+		resp, err := jsonrpc2.NewResponse(call.ID(), result, callErr)
 		if err != nil {
 			return err
 		}
+		runBeforeReply(callErr)
 		return s.replier.ReplyMessage(resp)
 	}()
 }
 
 // runForNotification runs a function for a notification message without expecting a response.
 func (s *Server) runForNotification(notify *jsonrpc2.Notification, fn func() error) {
-	wrap := s.wrapWithMetrics(notify, func() (any, error) {
+	s.wrapWithMetrics(notify, func() (any, error) {
 		return nil, fn()
-	})
-	go wrap()
+	})()
 }
 
-var requestCancelled = jsonrpc2.NewError(int64(RequestCancelled), "Request cancelled")
+var (
+	// serverNotInitialized is returned for requests received before initialize completes.
+	serverNotInitialized = jsonrpc2.NewError(int64(ServerNotInitialized), "Server not initialized")
+	// requestCancelled is returned when a request is cancelled before execution.
+	requestCancelled = jsonrpc2.NewError(int64(RequestCancelled), "Request cancelled")
+)
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#cancelRequest
 func (s *Server) cancelRequest(params *CancelParams) error {
@@ -468,10 +573,7 @@ func (s *Server) cancelRequest(params *CancelParams) error {
 		return fmt.Errorf("cancelRequest: %w", err)
 	}
 	if cancelCauseFunc, ok := s.cancelCauseFuncs.Load(id); ok {
-		if cancelWithCause, ok := cancelCauseFunc.(context.CancelCauseFunc); ok {
-			cancelWithCause(requestCancelled)
-			return nil
-		}
+		cancelCauseFunc.(context.CancelCauseFunc)(requestCancelled)
 	}
 	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -34,6 +34,45 @@ func (m *mockReplier) ReplyMessage(msg jsonrpc2.Message) error {
 	return nil
 }
 
+type reentrantResponseReplier struct {
+	*mockReplier
+	id         jsonrpc2.ID
+	onResponse func() error
+	once       sync.Once
+	errMu      sync.Mutex
+	err        error
+}
+
+func newReentrantResponseReplier(id jsonrpc2.ID, onResponse func() error) *reentrantResponseReplier {
+	return &reentrantResponseReplier{
+		mockReplier: newMockReplier(),
+		id:          id,
+		onResponse:  onResponse,
+	}
+}
+
+func (m *reentrantResponseReplier) ReplyMessage(msg jsonrpc2.Message) error {
+	response, ok := msg.(*jsonrpc2.Response)
+	if ok && response.ID() == m.id {
+		m.once.Do(func() {
+			m.setErr(m.onResponse())
+		})
+	}
+	return m.mockReplier.ReplyMessage(msg)
+}
+
+func (m *reentrantResponseReplier) Err() error {
+	m.errMu.Lock()
+	defer m.errMu.Unlock()
+	return m.err
+}
+
+func (m *reentrantResponseReplier) setErr(err error) {
+	m.errMu.Lock()
+	m.err = err
+	m.errMu.Unlock()
+}
+
 func (m *mockReplier) getMessages() []jsonrpc2.Message {
 	m.mu.Lock()
 	result := make([]jsonrpc2.Message, len(m.messages))
@@ -42,15 +81,17 @@ func (m *mockReplier) getMessages() []jsonrpc2.Message {
 	return result
 }
 
+func (m *mockReplier) clearMessages() {
+	m.mu.Lock()
+	m.messages = nil
+	m.mu.Unlock()
+}
+
 func (m *mockReplier) waitForMessages(count int, timeout time.Duration) []jsonrpc2.Message {
 	// For count=0, wait a short time to ensure no unexpected messages arrive
 	if count == 0 {
 		time.Sleep(10 * time.Millisecond)
-		m.mu.Lock()
-		result := make([]jsonrpc2.Message, len(m.messages))
-		copy(result, m.messages)
-		m.mu.Unlock()
-		return result
+		return m.getMessages()
 	}
 
 	m.mu.Lock()
@@ -74,12 +115,41 @@ func (m *mockReplier) waitForMessages(count int, timeout time.Duration) []jsonrp
 	return result
 }
 
+func (m *mockReplier) waitForResponse(id jsonrpc2.ID, timeout time.Duration) *jsonrpc2.Response {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	timedOut := false
+	timer := time.AfterFunc(timeout, func() {
+		m.mu.Lock()
+		timedOut = true
+		m.cond.Broadcast()
+		m.mu.Unlock()
+	})
+	defer timer.Stop()
+
+	for !timedOut {
+		for _, message := range m.messages {
+			response, ok := message.(*jsonrpc2.Response)
+			if ok && response.ID() == id {
+				return response
+			}
+		}
+		m.cond.Wait()
+	}
+	return nil
+}
+
 func newProjectWithoutModTime(files map[string][]byte) *xgo.Project {
+	return xgo.NewProject(nil, newFileMap(files), xgo.FeatAll)
+}
+
+func newFileMap(files map[string][]byte) map[string]*xgo.File {
 	fileMap := make(map[string]*xgo.File)
 	for k, v := range files {
 		fileMap[k] = &xgo.File{Content: v}
 	}
-	return xgo.NewProject(nil, fileMap, xgo.FeatAll)
+	return fileMap
 }
 
 func requireValueAs[T any](t *testing.T, value any) T {
@@ -92,11 +162,7 @@ func requireValueAs[T any](t *testing.T, value any) T {
 
 func fileMapGetter(files map[string][]byte) func() map[string]*xgo.File {
 	return func() map[string]*xgo.File {
-		fileMap := make(map[string]*xgo.File)
-		for k, v := range files {
-			fileMap[k] = &xgo.File{Content: v}
-		}
-		return fileMap
+		return newFileMap(files)
 	}
 }
 
@@ -105,6 +171,203 @@ type MockScheduler struct{}
 
 func (s *MockScheduler) Sched() {
 	time.Sleep(1 * time.Millisecond)
+}
+
+type blockingScheduler struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingScheduler() *blockingScheduler {
+	return &blockingScheduler{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *blockingScheduler) Sched() {
+	s.once.Do(func() {
+		close(s.started)
+	})
+	<-s.release
+}
+
+func initializeServerForTest(t *testing.T, server *Server, replier *mockReplier) {
+	t.Helper()
+
+	call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{
+		XInitializeParams: protocol.XInitializeParams{
+			RootURI: "file:///",
+			Capabilities: protocol.ClientCapabilities{
+				TextDocument: protocol.TextDocumentClientCapabilities{
+					Completion: protocol.CompletionClientCapabilities{
+						CompletionItem: protocol.ClientCompletionItemOptions{
+							SnippetSupport:      true,
+							DocumentationFormat: []protocol.MarkupKind{protocol.Markdown},
+						},
+						CompletionItemKind: &protocol.ClientCompletionItemOptionsKind{
+							ValueSet: []protocol.CompletionItemKind{
+								protocol.TextCompletion,
+								protocol.MethodCompletion,
+								protocol.FunctionCompletion,
+								protocol.FieldCompletion,
+								protocol.VariableCompletion,
+								protocol.ClassCompletion,
+								protocol.InterfaceCompletion,
+								protocol.ModuleCompletion,
+								protocol.PropertyCompletion,
+								protocol.UnitCompletion,
+								protocol.KeywordCompletion,
+								protocol.ReferenceCompletion,
+								protocol.ConstantCompletion,
+								protocol.StructCompletion,
+							},
+						},
+					},
+					Hover: &protocol.HoverClientCapabilities{
+						ContentFormat: []protocol.MarkupKind{protocol.Markdown},
+					},
+					Rename: &protocol.RenameClientCapabilities{
+						PrepareSupport: true,
+					},
+					SignatureHelp: &protocol.SignatureHelpClientCapabilities{
+						ContextSupport: true,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, server.HandleMessage(call))
+	messages := replier.waitForMessages(2, 5*time.Second)
+	require.Len(t, messages, 2)
+	require.NoError(t, requireResponseForID(t, messages, call.ID()).Err())
+	replier.clearMessages()
+}
+
+func requireResponseForID(t *testing.T, messages []jsonrpc2.Message, id jsonrpc2.ID) *jsonrpc2.Response {
+	t.Helper()
+
+	for _, message := range messages {
+		response, ok := message.(*jsonrpc2.Response)
+		if ok && response.ID() == id {
+			return response
+		}
+	}
+	require.Failf(t, "missing response", "missing response for id %q", id)
+	return nil
+}
+
+func TestHandleMessageInitialization(t *testing.T) {
+	t.Run("RequestBeforeInitialize", func(t *testing.T) {
+		replier := newMockReplier()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("hover"), "textDocument/hover", HoverParams{})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(call))
+
+		messages := replier.waitForMessages(1, 5*time.Second)
+		response := requireResponseForID(t, messages, call.ID())
+		require.Error(t, response.Err())
+		var wireErr *jsonrpc2.WireError
+		require.True(t, errors.As(response.Err(), &wireErr))
+		assert.Equal(t, int64(ServerNotInitialized), wireErr.Code)
+	})
+
+	t.Run("NotificationBeforeInitialize", func(t *testing.T) {
+		replier := newMockReplier()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		notification, err := jsonrpc2.NewNotification("textDocument/didOpen", DidOpenTextDocumentParams{})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(notification))
+		assert.Empty(t, replier.waitForMessages(0, time.Second))
+	})
+
+	t.Run("CancelRequestBeforeInitialize", func(t *testing.T) {
+		replier := newMockReplier()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		notification, err := jsonrpc2.NewNotification("$/cancelRequest", CancelParams{ID: "initialize"})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(notification))
+		assert.Empty(t, replier.waitForMessages(0, time.Second))
+	})
+
+	t.Run("CancelNotificationDuringInitialize", func(t *testing.T) {
+		replier := newMockReplier()
+		scheduler := newBlockingScheduler()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), scheduler)
+		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(call))
+
+		select {
+		case <-scheduler.started:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "initialize did not start")
+		}
+
+		notification, err := jsonrpc2.NewNotification("$/cancelRequest", CancelParams{ID: "initialize"})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(notification))
+		close(scheduler.release)
+
+		response := replier.waitForResponse(call.ID(), 5*time.Second)
+		require.NotNil(t, response)
+		require.NoError(t, response.Err())
+		assert.True(t, server.isInitialized())
+	})
+
+	t.Run("ExitBeforeInitialize", func(t *testing.T) {
+		replier := newMockReplier()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		notification, err := jsonrpc2.NewNotification("exit", nil)
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(notification))
+		assert.Empty(t, replier.waitForMessages(0, time.Second))
+	})
+
+	t.Run("InitializeOnlyOnce", func(t *testing.T) {
+		replier := newMockReplier()
+		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		initializeServerForTest(t, server, replier)
+
+		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize-again"), "initialize", InitializeParams{})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(call))
+		messages := replier.waitForMessages(1, 5*time.Second)
+		response := requireResponseForID(t, messages, call.ID())
+		require.Error(t, response.Err())
+		var wireErr *jsonrpc2.WireError
+		require.True(t, errors.As(response.Err(), &wireErr))
+		assert.Equal(t, int64(protocol.InvalidRequest), wireErr.Code)
+	})
+
+	t.Run("InitializeAcceptsReentrantRequestDuringReply", func(t *testing.T) {
+		initializeID := jsonrpc2.NewStringID("initialize")
+		shutdownID := jsonrpc2.NewStringID("shutdown")
+		var server *Server
+		replier := newReentrantResponseReplier(initializeID, func() error {
+			shutdownCall, err := jsonrpc2.NewCall(shutdownID, "shutdown", nil)
+			if err != nil {
+				return err
+			}
+			return server.HandleMessage(shutdownCall)
+		})
+		server = New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		initializeCall, err := jsonrpc2.NewCall(initializeID, "initialize", InitializeParams{})
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(initializeCall))
+
+		initializeResponse := replier.waitForResponse(initializeCall.ID(), 5*time.Second)
+		require.NotNil(t, initializeResponse)
+		require.NoError(t, initializeResponse.Err())
+		shutdownResponse := replier.waitForResponse(shutdownID, 5*time.Second)
+		require.NotNil(t, shutdownResponse)
+		require.NoError(t, shutdownResponse.Err())
+		require.NoError(t, replier.Err())
+		assert.True(t, server.isInitialized())
+	})
 }
 
 func TestServerCancellation(t *testing.T) {
@@ -121,14 +384,14 @@ echo x
 		call1, _ := jsonrpc2.NewCall(jsonrpc2.NewStringID("test-request-1"), "$/cancelRequest", &CancelParams{ID: "test-request-1"})
 		call2, _ := jsonrpc2.NewCall(jsonrpc2.NewStringID("test-request-2"), "$/cancelRequest", &CancelParams{ID: "test-request-2"})
 
-		var request1Runned bool
-		var request2Runned bool
+		var request1Ran bool
+		var request2Ran bool
 		s.runForCall(call1, func() (any, error) {
-			request1Runned = true
+			request1Ran = true
 			return "should not reach here", nil
 		})
 		s.runForCall(call2, func() (any, error) {
-			request2Runned = true
+			request2Ran = true
 			return "should not reach here either", nil
 		})
 
@@ -139,21 +402,12 @@ echo x
 
 		messages := replier.waitForMessages(2, 5*time.Second)
 
-		assert.False(t, request1Runned, "Function should not have been executed for cancelled request")
-		assert.False(t, request2Runned, "Function should not have been executed for cancelled request")
+		assert.False(t, request1Ran, "Function should not have been executed for cancelled request")
+		assert.False(t, request2Ran, "Function should not have been executed for cancelled request")
 		require.Len(t, messages, 2)
 
-		var response1, response2 *jsonrpc2.Response
-		require.Len(t, messages, 2, "Should receive two Response messages")
-		for _, v := range messages {
-			response, ok := v.(*jsonrpc2.Response)
-			require.True(t, ok, "Should receive a Response message")
-			if response.ID() == call1.ID() {
-				response1 = response
-			} else if response.ID() == call2.ID() {
-				response2 = response
-			}
-		}
+		response1 := requireResponseForID(t, messages, call1.ID())
+		response2 := requireResponseForID(t, messages, call2.ID())
 
 		assert.Equal(t, call1.ID(), response1.ID())
 		assert.NotNil(t, response1.Err())
@@ -192,6 +446,53 @@ echo x
 			})
 		}
 	})
+}
+
+func TestHandleMessageNotificationOrdering(t *testing.T) {
+	files := map[string][]byte{"main.spx": []byte("echo \"a\"\n")}
+	project := newProjectWithoutModTime(files)
+	project.PutFile("main.spx", &xgo.File{Content: files["main.spx"], Version: 1})
+	replier := newMockReplier()
+	server := New(project, replier, fileMapGetter(files), &MockScheduler{})
+	initializeServerForTest(t, server, replier)
+
+	for _, params := range []DidChangeTextDocumentParams{
+		{
+			TextDocument: protocol.VersionedTextDocumentIdentifier{
+				TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Version:                2,
+			},
+			ContentChanges: []protocol.TextDocumentContentChangeEvent{{
+				Range: &protocol.Range{
+					Start: protocol.Position{Line: 0, Character: 7},
+					End:   protocol.Position{Line: 0, Character: 7},
+				},
+				Text: "b",
+			}},
+		},
+		{
+			TextDocument: protocol.VersionedTextDocumentIdentifier{
+				TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Version:                3,
+			},
+			ContentChanges: []protocol.TextDocumentContentChangeEvent{{
+				Range: &protocol.Range{
+					Start: protocol.Position{Line: 0, Character: 8},
+					End:   protocol.Position{Line: 0, Character: 8},
+				},
+				Text: "c",
+			}},
+		},
+	} {
+		notification, err := jsonrpc2.NewNotification("textDocument/didChange", params)
+		require.NoError(t, err)
+		require.NoError(t, server.HandleMessage(notification))
+	}
+
+	file, ok := project.File("main.spx")
+	require.True(t, ok)
+	assert.Equal(t, "echo \"abc\"\n", string(file.Content))
+	assert.Equal(t, 3, file.Version)
 }
 
 func TestHandleMessageCall(t *testing.T) {
@@ -490,6 +791,7 @@ fmt.Println("Hello, World!")
 		t.Run(tc.name, func(t *testing.T) {
 			replier := newMockReplier()
 			server := New(newProjectWithoutModTime(tc.files), replier, fileMapGetter(tc.files), &MockScheduler{})
+			initializeServerForTest(t, server, replier)
 
 			var params json.RawMessage
 			if tc.params != nil {
@@ -531,7 +833,7 @@ func TestHandleMessageNotification(t *testing.T) {
 			name:   "Exit",
 			method: "exit",
 			params: nil,
-			msgNum: 0, // exit 不发送任何消息
+			msgNum: 0, // exit does not send any messages
 		},
 		{
 			name:   "CancelRequest",
@@ -618,6 +920,7 @@ func TestHandleMessageNotification(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			replier := newMockReplier()
 			server := New(newProjectWithoutModTime(tc.files), replier, fileMapGetter(tc.files), &MockScheduler{})
+			initializeServerForTest(t, server, replier)
 
 			var params json.RawMessage
 			if tc.params != nil {

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -37,10 +37,27 @@ func (def SpxDefinition) HTML() string {
 
 // CompletionItem constructs a [CompletionItem] from the definition.
 func (def SpxDefinition) CompletionItem() CompletionItem {
+	return def.completionItem(Markdown)
+}
+
+// markupContent constructs markup content from the definition.
+func (def SpxDefinition) markupContent(kind MarkupKind) MarkupContent {
+	plainText := def.Overview
+	if detail := strings.TrimSpace(def.Detail); detail != "" {
+		if plainText != "" {
+			plainText += "\n\n"
+		}
+		plainText += detail
+	}
+	return markupContent(kind, def.HTML(), plainText)
+}
+
+// completionItem constructs a [CompletionItem] from the definition.
+func (def SpxDefinition) completionItem(documentationKind MarkupKind) CompletionItem {
 	return CompletionItem{
 		Label:            def.CompletionItemLabel,
 		Kind:             def.CompletionItemKind,
-		Documentation:    &Or_CompletionItem_documentation{Value: MarkupContent{Kind: Markdown, Value: def.HTML()}},
+		Documentation:    completionDocumentation(def.markupContent(documentationKind)),
 		InsertText:       def.CompletionItemInsertText,
 		InsertTextFormat: &def.CompletionItemInsertTextFormat,
 		Data: &CompletionItemData{

--- a/internal/server/text_synchronization.go
+++ b/internal/server/text_synchronization.go
@@ -33,8 +33,6 @@ func (s *Server) didOpen(params *DidOpenTextDocumentParams) error {
 
 // didChange handles the textDocument/didChange notification from the LSP client.
 // It applies document changes to the project and publishes updated diagnostics.
-// For simplicity, this implementation only uses the latest content change
-// rather than applying incremental changes.
 func (s *Server) didChange(params *DidChangeTextDocumentParams) error {
 	path, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {

--- a/internal/server/unit.go
+++ b/internal/server/unit.go
@@ -272,7 +272,9 @@ func xgoUnitExpectedTypeForResolvedArg(resolvedArg xgoutil.ResolvedCallExprArg) 
 }
 
 // hoverForXGoUnit returns hover content for the unit suffix at position.
-func hoverForXGoUnit(proj *xgo.Project, typeInfo *types.Info, astFile *ast.File, position token.Position) *Hover {
+func hoverForXGoUnit(
+	proj *xgo.Project, typeInfo *types.Info, astFile *ast.File, position token.Position, markupKind MarkupKind,
+) *Hover {
 	tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile)
 	pos := tokenFile.Pos(position.Offset)
 	path, _ := xgoutil.PathEnclosingInterval(astFile, pos, pos)
@@ -290,16 +292,19 @@ func hoverForXGoUnit(proj *xgo.Project, typeInfo *types.Info, astFile *ast.File,
 		if !ok {
 			continue
 		}
+		unitType := GetSimplifiedTypeString(spec.SourceType)
+		markdownValue := fmt.Sprintf(
+			"unit `%s` for `%s`\n\nMultiplier: `%s`",
+			spec.Name,
+			unitType,
+			spec.Factor,
+		)
 		return &Hover{
-			Contents: MarkupContent{
-				Kind: Markdown,
-				Value: fmt.Sprintf(
-					"unit `%s` for `%s`\n\nMultiplier: `%s`",
-					spec.Name,
-					GetSimplifiedTypeString(spec.SourceType),
-					spec.Factor,
-				),
-			},
+			Contents: markupContent(
+				markupKind,
+				markdownValue,
+				fmt.Sprintf("unit %s for %s\n\nMultiplier: %s", spec.Name, unitType, spec.Factor),
+			),
 			Range: RangeForPosEnd(proj, unitStart, lit.End()),
 		}
 	}

--- a/jsonrpc2/wire.go
+++ b/jsonrpc2/wire.go
@@ -91,8 +91,9 @@ type wireVersionTag struct{}
 
 // ID is a Request identifier.
 type ID struct {
-	name   string
-	number int64
+	name     string
+	number   int64
+	isString bool
 }
 
 func NewError(code int64, message string) error {
@@ -145,7 +146,7 @@ func MakeID(v any) (ID, error) {
 func NewIntID(v int64) ID { return ID{number: v} }
 
 // NewStringID returns a new string request ID.
-func NewStringID(v string) ID { return ID{name: v} }
+func NewStringID(v string) ID { return ID{name: v, isString: true} }
 
 // Format writes the ID to the formatter.
 // If the rune is q the representation is non ambiguous,
@@ -155,25 +156,30 @@ func (id ID) Format(f fmt.State, r rune) {
 	if r == 'q' {
 		numF, strF = `#%d`, `%q`
 	}
-	switch {
-	case id.name != "":
+	if id.isString {
 		fmt.Fprintf(f, strF, id.name)
-	default:
-		fmt.Fprintf(f, numF, id.number)
+		return
 	}
+	fmt.Fprintf(f, numF, id.number)
 }
 
 func (id *ID) MarshalJSON() ([]byte, error) {
-	if id.name != "" {
+	if id.isString {
 		return json.Marshal(id.name)
 	}
 	return json.Marshal(id.number)
 }
 
 func (id *ID) UnmarshalJSON(data []byte) error {
-	*id = ID{}
-	if err := json.Unmarshal(data, &id.number); err == nil {
+	var number int64
+	if err := json.Unmarshal(data, &number); err == nil {
+		*id = NewIntID(number)
 		return nil
 	}
-	return json.Unmarshal(data, &id.name)
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+	*id = NewStringID(name)
+	return nil
 }

--- a/jsonrpc2/wire_test.go
+++ b/jsonrpc2/wire_test.go
@@ -1,0 +1,40 @@
+package jsonrpc2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIDJSONRoundTrip(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		json string
+		want ID
+	}{
+		{name: "Number", json: `42`, want: NewIntID(42)},
+		{name: "Zero", json: `0`, want: NewIntID(0)},
+		{name: "String", json: `"request"`, want: NewStringID("request")},
+		{name: "EmptyString", json: `""`, want: NewStringID("")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ID
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &got))
+			assert.Equal(t, tt.want, got)
+
+			encoded, err := json.Marshal(&got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.json, string(encoded))
+		})
+	}
+}
+
+func TestIDKindsAreDistinct(t *testing.T) {
+	ids := map[ID]struct{}{
+		NewIntID(0):     {},
+		NewStringID(""): {},
+	}
+	assert.Len(t, ids, 2)
+}


### PR DESCRIPTION
Declare server capabilities that match the supported LSP handlers and initialize workspace and locale state from client parameters.

Negotiate semantic tokens, completion behavior, and markup formats against client capabilities while preserving readable plain-text output.

Enforce the one-shot initialize lifecycle and gate ordinary requests and notifications until initialization completes.

Serialize document notifications to preserve incremental synchronization ordering, preserve numeric and string JSON-RPC request IDs, and advertise only document diagnostics.

Add regression coverage for capability negotiation, workspace roots, initialization ordering, document synchronization, and message IDs.
