### PR TITLE
fix(server): encode semantic token ranges as UTF-16

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,12 @@ node. `github.com/goplus/xgo/token.Token` is a distinct XGo token type.
 Do not use aliases such as `xgoast`, `xgotoken`, or `xgotypes`. Apply the same convention in both production code and
 unit tests.
 
+## LSP position encoding
+
+LSP `Position`, `Range`, and semantic token coordinates must use UTF-16 code unit offsets unless the server explicitly
+negotiates another `PositionEncodingKind`. Do not expose Go byte offsets, `token.Position.Column`, or `len(string)` as
+LSP character counts. Use the existing UTF-16 conversion helpers in `internal/server/util.go`.
+
 # Generated data
 
 After changing dependencies in `go.mod`, regenerate `internal/pkgdata/pkgdata.zip` by running:

--- a/internal/server/semantic_token.go
+++ b/internal/server/semantic_token.go
@@ -1,9 +1,10 @@
 package server
 
 import (
+	"bytes"
+	"cmp"
 	gotypes "go/types"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/goplus/xgo/ast"
@@ -104,6 +105,34 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 			tokenModifiers: tokenModifiers,
 		})
 	}
+	addStringToken := func(node *ast.BasicLit) {
+		endPos := node.End()
+		if node.Extra == nil || len(node.Extra.Parts) == 0 {
+			addToken(node.Pos(), endPos, StringType, nil)
+			return
+		}
+
+		partPos := node.ValuePos + 1
+		stringStart := node.ValuePos
+		for _, part := range node.Extra.Parts {
+			switch v := part.(type) {
+			case string:
+				partPos = ast.NextPartPos(partPos, v)
+			case ast.Expr:
+				if stringStart < v.Pos() {
+					addToken(stringStart, v.Pos(), StringType, nil)
+				}
+				if v.End() < endPos {
+					addToken(v.End(), v.End()+1, StringType, nil)
+				}
+				partPos = v.End() + 1
+				stringStart = partPos
+			}
+		}
+		if stringStart < endPos {
+			addToken(stringStart, endPos, StringType, nil)
+		}
+	}
 
 	ast.Inspect(astFile, func(node ast.Node) bool {
 		if node == nil || !node.Pos().IsValid() {
@@ -200,20 +229,10 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 			case token.INT, token.FLOAT, token.IMAG, token.RAT:
 				tokenType = NumberType
 			}
-			addToken(node.ValuePos, node.ValuePos+token.Pos(len(node.Value)), tokenType, nil)
-
-			if node.Extra != nil && len(node.Extra.Parts) > 0 {
-				pos := node.ValuePos
-				for _, part := range node.Extra.Parts {
-					switch v := part.(type) {
-					case string:
-						nextPos := ast.NextPartPos(pos, v)
-						addToken(pos, nextPos, StringType, nil)
-						pos = nextPos
-					case ast.Expr:
-						pos = v.End()
-					}
-				}
+			if tokenType == StringType {
+				addStringToken(node)
+			} else {
+				addToken(node.Pos(), node.End(), tokenType, nil)
 			}
 		case *ast.NumberUnitLit:
 			if isXGoUnitNumberKind(node.Kind) {
@@ -477,41 +496,164 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 		return true
 	})
 
-	sort.Slice(tokenInfos, func(i, j int) bool {
-		if tokenInfos[i].startPos != tokenInfos[j].startPos {
-			return tokenInfos[i].startPos < tokenInfos[j].startPos
+	slices.SortFunc(tokenInfos, func(a, b semanticTokenInfo) int {
+		if a.startPos != b.startPos {
+			return cmp.Compare(a.startPos, b.startPos)
 		}
-		return tokenInfos[i].endPos < tokenInfos[j].endPos
+		return cmp.Compare(a.endPos, b.endPos)
 	})
 
+	type semanticTokenDataSegment struct {
+		semanticTokenSegment
+		typeIndex     uint32
+		modifiersMask uint32
+	}
+
 	var (
-		tokensData         = make([]uint32, 0, len(tokenInfos))
-		prevLine, prevChar uint32
+		lineLengths = semanticTokenLineLengths(astFile.Code)
+		segments    = make([]semanticTokenDataSegment, 0, len(tokenInfos))
 	)
 	for _, info := range tokenInfos {
 		start := fset.Position(info.startPos)
 		end := fset.Position(info.endPos)
 
-		line := uint32(start.Line - 1)
-		char := uint32(start.Column - 1)
-		length := uint32(end.Offset - start.Offset)
-		if line < prevLine || (line == prevLine && char < prevChar) {
-			continue
-		}
-
 		typeIndex := getSemanticTokenTypeIndex(info.tokenType)
 		modifiersMask := getSemanticTokenModifiersMask(info.tokenModifiers)
-
-		if line == prevLine {
-			tokensData = append(tokensData, 0, char-prevChar, length, typeIndex, modifiersMask)
-		} else {
-			tokensData = append(tokensData, line-prevLine, char, length, typeIndex, modifiersMask)
+		for _, segment := range semanticTokenSegments(
+			FromPosition(result.proj, astFile, start),
+			FromPosition(result.proj, astFile, end),
+			lineLengths,
+			semanticTokenFallbackLength(astFile.Code, start.Offset, end.Offset),
+		) {
+			segments = append(segments, semanticTokenDataSegment{
+				semanticTokenSegment: segment,
+				typeIndex:            typeIndex,
+				modifiersMask:        modifiersMask,
+			})
 		}
+	}
 
-		prevLine = line
-		prevChar = char
+	slices.SortStableFunc(segments, func(a, b semanticTokenDataSegment) int {
+		if a.line != b.line {
+			return cmp.Compare(a.line, b.line)
+		}
+		return cmp.Compare(a.char, b.char)
+	})
+
+	var (
+		tokensData         = make([]uint32, 0, len(segments)*5)
+		prevLine, prevChar uint32
+	)
+	for _, segment := range segments {
+		lineDelta := segment.line - prevLine
+		charDelta := segment.char
+		if lineDelta == 0 {
+			charDelta -= prevChar
+		}
+		tokensData = append(tokensData, lineDelta, charDelta, segment.length, segment.typeIndex, segment.modifiersMask)
+
+		prevLine = segment.line
+		prevChar = segment.char
 	}
 	return &SemanticTokens{
 		Data: tokensData,
 	}, nil
+}
+
+// semanticTokenSegment represents a single-line semantic token span encoded
+// with LSP UTF-16 positions.
+type semanticTokenSegment struct {
+	line   uint32
+	char   uint32
+	length uint32
+}
+
+// semanticTokenLineLengths returns the UTF-16 lengths of all source lines.
+func semanticTokenLineLengths(content []byte) []uint32 {
+	lines := bytes.Split(content, []byte("\n"))
+	lengths := make([]uint32, len(lines))
+	for i, line := range lines {
+		line = trimLineEnding(line)
+		lengths[i] = uint32(UTF16Len(string(line)))
+	}
+	return lengths
+}
+
+// semanticTokenFallbackLength returns a UTF-16 length for token.Pos spans
+// whose converted LSP start and end positions collapse to an empty range.
+func semanticTokenFallbackLength(content []byte, startOffset, endOffset int) uint32 {
+	if endOffset <= startOffset {
+		return 0
+	}
+	fallbackLength := uint32(endOffset - startOffset)
+	if startOffset < 0 || startOffset >= len(content) {
+		return fallbackLength
+	}
+
+	clippedEndOffset := min(endOffset, len(content))
+	if clippedEndOffset <= startOffset {
+		return fallbackLength
+	}
+	return uint32(UTF16Len(string(content[startOffset:clippedEndOffset])))
+}
+
+// semanticTokenSegments splits a semantic token range into single-line
+// segments encoded with LSP UTF-16 positions. The fallback length preserves
+// spans whose converted start and end positions collapse to an empty range.
+func semanticTokenSegments(start, end Position, lineLengths []uint32, fallbackLength uint32) []semanticTokenSegment {
+	fallbackSegment := semanticTokenSegment{
+		line:   start.Line,
+		char:   start.Character,
+		length: fallbackLength,
+	}
+	if start.Line > end.Line || (start.Line == end.Line && start.Character >= end.Character) {
+		if fallbackLength == 0 {
+			return nil
+		}
+		return []semanticTokenSegment{fallbackSegment}
+	}
+	if start.Line == end.Line {
+		return []semanticTokenSegment{{
+			line:   start.Line,
+			char:   start.Character,
+			length: end.Character - start.Character,
+		}}
+	}
+
+	segments := make([]semanticTokenSegment, 0, end.Line-start.Line+1)
+	if startLineLength := semanticTokenLineLength(lineLengths, start.Line); start.Character < startLineLength {
+		segments = append(segments, semanticTokenSegment{
+			line:   start.Line,
+			char:   start.Character,
+			length: startLineLength - start.Character,
+		})
+	}
+	for line := start.Line + 1; line < end.Line; line++ {
+		length := semanticTokenLineLength(lineLengths, line)
+		if length == 0 {
+			continue
+		}
+		segments = append(segments, semanticTokenSegment{
+			line:   line,
+			length: length,
+		})
+	}
+	if end.Character > 0 {
+		segments = append(segments, semanticTokenSegment{
+			line:   end.Line,
+			length: end.Character,
+		})
+	}
+	if len(segments) == 0 && fallbackLength > 0 {
+		return []semanticTokenSegment{fallbackSegment}
+	}
+	return segments
+}
+
+// semanticTokenLineLength returns the UTF-16 length of the given line.
+func semanticTokenLineLength(lineLengths []uint32, line uint32) uint32 {
+	if int(line) >= len(lineLengths) {
+		return 0
+	}
+	return lineLengths[line]
 }

--- a/internal/server/semantic_token_test.go
+++ b/internal/server/semantic_token_test.go
@@ -110,6 +110,210 @@ onStart => {
 			tokenType: NumberType,
 		})
 	})
+
+	t.Run("UTF16Positions", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	var 中文 []int
+	中文 = append(中文, 1)
+	println "非英文", 中文
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decodedTokens := decodeSemanticTokens(tokens.Data)
+		assert.Contains(t, decodedTokens, decodedSemanticToken{
+			line:      4,
+			character: 9,
+			length:    5,
+			tokenType: StringType,
+		})
+		assert.Contains(t, decodedTokens, decodedSemanticToken{
+			line:      4,
+			character: 16,
+			length:    2,
+			tokenType: VariableType,
+		})
+	})
+
+	t.Run("MultilineInterpolatedString", func(t *testing.T) {
+		s := newXGoUnitTestServer(`
+onStart => {
+	name := "world"
+	println ` + "`" + `hello
+${name}
+done` + "`" + `
+}
+`)
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decodedTokens := decodeSemanticTokens(tokens.Data)
+		for _, want := range []decodedSemanticToken{
+			{line: 4, character: 0, length: 2, tokenType: StringType},
+			{line: 4, character: 2, length: 4, tokenType: VariableType},
+			{line: 4, character: 6, length: 1, tokenType: StringType},
+			{line: 5, character: 0, length: 5, tokenType: StringType},
+		} {
+			assert.Contains(t, decodedTokens, want)
+		}
+		assertNoOverlappingSemanticToken(t, decodedTokens, decodedSemanticToken{
+			line:      4,
+			character: 2,
+			length:    4,
+			tokenType: StringType,
+		})
+	})
+}
+
+func TestSemanticTokenSegments(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		start          Position
+		end            Position
+		lineLengths    []uint32
+		fallbackLength uint32
+		want           []semanticTokenSegment
+	}{
+		{
+			name:        "SingleLine",
+			start:       Position{Line: 2, Character: 4},
+			end:         Position{Line: 2, Character: 9},
+			lineLengths: []uint32{0, 0, 12},
+			want: []semanticTokenSegment{
+				{line: 2, char: 4, length: 5},
+			},
+		},
+		{
+			name:        "MultiLine",
+			start:       Position{Line: 1, Character: 3},
+			end:         Position{Line: 3, Character: 4},
+			lineLengths: []uint32{0, 10, 5, 8},
+			want: []semanticTokenSegment{
+				{line: 1, char: 3, length: 7},
+				{line: 2, length: 5},
+				{line: 3, length: 4},
+			},
+		},
+		{
+			name:        "StartCharacterPastLineEnd",
+			start:       Position{Line: 1, Character: 10},
+			end:         Position{Line: 2, Character: 3},
+			lineLengths: []uint32{0, 8, 5},
+			want: []semanticTokenSegment{
+				{line: 2, length: 3},
+			},
+		},
+		{
+			name:        "EndCharacterAtLineStart",
+			start:       Position{Line: 1, Character: 3},
+			end:         Position{Line: 3, Character: 0},
+			lineLengths: []uint32{0, 10, 5, 8},
+			want: []semanticTokenSegment{
+				{line: 1, char: 3, length: 7},
+				{line: 2, length: 5},
+			},
+		},
+		{
+			name:           "SyntheticSpan",
+			start:          Position{Line: 0, Character: 5},
+			end:            Position{Line: 0, Character: 5},
+			lineLengths:    []uint32{10},
+			fallbackLength: 1,
+			want: []semanticTokenSegment{
+				{line: 0, char: 5, length: 1},
+			},
+		},
+		{
+			name:           "AllSegmentsEmptyFallback",
+			start:          Position{Line: 1, Character: 10},
+			end:            Position{Line: 2, Character: 0},
+			lineLengths:    []uint32{0, 10, 0},
+			fallbackLength: 2,
+			want: []semanticTokenSegment{
+				{line: 1, char: 10, length: 2},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, semanticTokenSegments(tt.start, tt.end, tt.lineLengths, tt.fallbackLength))
+		})
+	}
+}
+
+func TestSemanticTokenLineLengths(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		content []byte
+		want    []uint32
+	}{
+		{
+			name:    "LF",
+			content: []byte("abc\ndef\n中文"),
+			want:    []uint32{3, 3, 2},
+		},
+		{
+			name:    "CRLF",
+			content: []byte("abc\r\ndef\r\n中文"),
+			want:    []uint32{3, 3, 2},
+		},
+		{
+			name:    "TrailingCRLF",
+			content: []byte("abc\r\n"),
+			want:    []uint32{3, 0},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, semanticTokenLineLengths(tt.content))
+		})
+	}
+}
+
+func TestSemanticTokenFallbackLength(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		content     []byte
+		startOffset int
+		endOffset   int
+		want        uint32
+	}{
+		{
+			name:        "UTF16SourceSpan",
+			content:     []byte("中文"),
+			startOffset: 0,
+			endOffset:   len("中文"),
+			want:        2,
+		},
+		{
+			name:        "SyntheticSpanOutsideSource",
+			content:     nil,
+			startOffset: 0,
+			endOffset:   1,
+			want:        1,
+		},
+		{
+			name:        "InvalidRange",
+			content:     []byte("abc"),
+			startOffset: 2,
+			endOffset:   2,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, semanticTokenFallbackLength(tt.content, tt.startOffset, tt.endOffset))
+		})
+	}
 }
 
 type decodedSemanticToken struct {
@@ -149,4 +353,17 @@ func decodeSemanticTokens(data []uint32) []decodedSemanticToken {
 		})
 	}
 	return tokens
+}
+
+func assertNoOverlappingSemanticToken(t *testing.T, tokens []decodedSemanticToken, forbidden decodedSemanticToken) {
+	t.Helper()
+
+	forbiddenEnd := forbidden.character + forbidden.length
+	for _, token := range tokens {
+		if token.line != forbidden.line || token.tokenType != forbidden.tokenType {
+			continue
+		}
+		tokenEnd := token.character + token.length
+		assert.Falsef(t, token.character < forbiddenEnd && forbidden.character < tokenEnd, "unexpected overlapping token: %#v", token)
+	}
 }

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -67,6 +67,17 @@ func UTF16PosToUTF8Offset(s string, utf16Pos int) int {
 	return utf8Bytes
 }
 
+// trimLineEnding returns content without a trailing line ending.
+func trimLineEnding(content []byte) []byte {
+	if len(content) > 0 && content[len(content)-1] == '\n' {
+		content = content[:len(content)-1]
+	}
+	if len(content) > 0 && content[len(content)-1] == '\r' {
+		content = content[:len(content)-1]
+	}
+	return content
+}
+
 // PositionOffset converts an LSP position (line, character) to a byte offset in the document.
 // It calculates the offset by:
 //  1. Finding the starting byte offset of the requested line
@@ -113,6 +124,7 @@ func PositionOffset(content []byte, position Position) int {
 	}
 
 	lineContent := content[lineOffset:min(lineEndOffset, len(content))]
+	lineContent = trimLineEnding(lineContent)
 
 	// Convert UTF-16 character offset to UTF-8 byte offset
 	utf8Offset := UTF16PosToUTF8Offset(string(lineContent), int(position.Character))
@@ -138,9 +150,7 @@ func FromPosition(proj *xgo.Project, astFile *ast.File, position token.Position)
 	lineEnd := max(min(relLineStart+column-1, lineEndOffset), relLineStart)
 
 	lineContent := astFile.Code[relLineStart:lineEnd]
-	if len(lineContent) > 0 && lineContent[len(lineContent)-1] == '\n' {
-		lineContent = lineContent[:len(lineContent)-1]
-	}
+	lineContent = trimLineEnding(lineContent)
 
 	return Position{
 		Line:      uint32(line - 1),
@@ -159,6 +169,7 @@ func ToPosition(proj *xgo.Project, astFile *ast.File, position Position) token.P
 	if i := bytes.IndexByte(lineContent, '\n'); i >= 0 {
 		lineContent = lineContent[:i]
 	}
+	lineContent = trimLineEnding(lineContent)
 	utf8Offset := UTF16PosToUTF8Offset(string(lineContent), int(position.Character))
 	column := utf8Offset + 1
 

--- a/internal/server/util_test.go
+++ b/internal/server/util_test.go
@@ -3,11 +3,33 @@ package server
 import (
 	"testing"
 
+	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testProjectFile creates a project containing a single test file.
+func testProjectFile(t *testing.T, code string) (*xgo.Project, *ast.File) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	files := map[string]*xgo.File{
+		"test.gop": {Content: []byte(code)},
+	}
+	proj := xgo.NewProject(fset, files, xgo.FeatAll)
+
+	astPkg, err := proj.ASTPackage()
+	require.NoError(t, err)
+	require.NotNil(t, astPkg)
+
+	astFile, ok := astPkg.Files["test.gop"]
+	require.True(t, ok)
+	require.NotNil(t, astFile)
+
+	return proj, astFile
+}
 
 func TestUTF16Len(t *testing.T) {
 	for _, tt := range []struct {
@@ -219,6 +241,91 @@ func TestUTF16PosToUTF8Offset(t *testing.T) {
 	}
 }
 
+func TestPositionOffset(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		content  []byte
+		position Position
+		want     int
+	}{
+		{
+			name:     "LFEndOfLine",
+			content:  []byte("abc\ndef"),
+			position: Position{Line: 0, Character: 3},
+			want:     3,
+		},
+		{
+			name:     "CRLFEndOfLine",
+			content:  []byte("abc\r\ndef"),
+			position: Position{Line: 0, Character: 3},
+			want:     3,
+		},
+		{
+			name:     "CRLFBeyondEndOfLine",
+			content:  []byte("abc\r\ndef"),
+			position: Position{Line: 0, Character: 99},
+			want:     3,
+		},
+		{
+			name:     "CRLFSecondLine",
+			content:  []byte("abc\r\ndef"),
+			position: Position{Line: 1, Character: 1},
+			want:     6,
+		},
+		{
+			name:     "CRLFUTF16EndOfLine",
+			content:  []byte("世界\r\ndef"),
+			position: Position{Line: 0, Character: 2},
+			want:     6,
+		},
+		{
+			name:     "CRLFUTF16BeyondEndOfLine",
+			content:  []byte("世界\r\ndef"),
+			position: Position{Line: 0, Character: 99},
+			want:     6,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, PositionOffset(tt.content, tt.position))
+		})
+	}
+}
+
+func TestToPosition(t *testing.T) {
+	proj, astFile := testProjectFile(t, "package main\r\nvar x int")
+
+	for _, tt := range []struct {
+		name     string
+		position Position
+		want     token.Position
+	}{
+		{
+			name:     "CRLFBeyondEndOfLine",
+			position: Position{Line: 0, Character: 99},
+			want: token.Position{
+				Filename: "test.gop",
+				Offset:   12,
+				Line:     1,
+				Column:   13,
+			},
+		},
+		{
+			name:     "CRLFSecondLine",
+			position: Position{Line: 1, Character: 3},
+			want: token.Position{
+				Filename: "test.gop",
+				Offset:   17,
+				Line:     2,
+				Column:   4,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ToPosition(proj, astFile, tt.position))
+		})
+	}
+}
+
 func TestFromPosition(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
@@ -407,6 +514,18 @@ func TestFromPosition(t *testing.T) {
 			},
 		},
 		{
+			name: "ColumnExceedsLineLengthWithCRLF",
+			code: "package main\r\nvar x int",
+			position: token.Position{
+				Line:   1,
+				Column: 99, // Beyond the first line length
+			},
+			want: Position{
+				Line:      0,
+				Character: 12, // Should be clamped before the CRLF line ending
+			},
+		},
+		{
 			name: "ColumnExceedsLineLengthMultiLine",
 			code: "first\nsecond line\nthird",
 			position: token.Position{
@@ -492,20 +611,7 @@ func TestFromPosition(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			fset := token.NewFileSet()
-			files := map[string]*xgo.File{
-				"test.gop": {Content: []byte(tt.code)},
-			}
-			proj := xgo.NewProject(fset, files, xgo.FeatAll)
-
-			astPkg, err := proj.ASTPackage()
-			require.NoError(t, err)
-			require.NotNil(t, astPkg)
-
-			astFile, ok := astPkg.Files["test.gop"]
-			require.True(t, ok)
-			require.NotNil(t, astFile)
-
+			proj, astFile := testProjectFile(t, tt.code)
 			got := FromPosition(proj, astFile, tt.position)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
Convert semantic token positions through the shared LSP helpers so non-ASCII source text does not shift editor ranges. Split multi-line spans into single-line segments, sort the encoded segments before delta encoding, and keep synthetic SPX token spans visible when generated positions collapse.

Keep interpolated string tokens limited to string text and interpolation delimiters so embedded expressions retain their own semantic tokens. Treat CRLF line endings as terminators in shared position helpers, and document the position encoding convention for future server changes.
