### PR TITLE
feat(server): support XGo enums

### DIFF
--- a/internal/analysis/ast/inspector/inspector_test.go
+++ b/internal/analysis/ast/inspector/inspector_test.go
@@ -165,6 +165,10 @@ func TestInspectorXGoExtensionNodes(t *testing.T) {
 func TestPreorderParsedXGoExtensionNodes(t *testing.T) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "test.xgo", `
+type Color const (
+	Red = iota
+)
+
 @retry
 func fn() int {
 	return 1
@@ -191,10 +195,12 @@ echo [
 
 	var matrixLitCount int
 	var elemEllipsisCount int
+	var enumTypeCount int
 	var funcDecoratorCount int
 	inspect.Preorder([]ast.Node{
 		(*ast.MatrixLit)(nil),
 		(*ast.ElemEllipsis)(nil),
+		(*ast.EnumType)(nil),
 		(*ast.FuncDecorator)(nil),
 	}, func(n ast.Node) {
 		switch n.(type) {
@@ -202,11 +208,14 @@ echo [
 			matrixLitCount++
 		case *ast.ElemEllipsis:
 			elemEllipsisCount++
+		case *ast.EnumType:
+			enumTypeCount++
 		case *ast.FuncDecorator:
 			funcDecoratorCount++
 		}
 	})
 	assert.Equal(t, 1, matrixLitCount)
 	assert.Equal(t, 1, elemEllipsisCount)
+	assert.Equal(t, 1, enumTypeCount)
 	assert.Equal(t, 1, funcDecoratorCount)
 }

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -35,6 +35,9 @@ var errNoMainSpxFile = errors.New("no valid main.spx file found in main package"
 type compileResult struct {
 	proj *xgo.Project
 
+	// enumInfo stores source-level enum types and members.
+	enumInfo *enumInfo
+
 	// mainSpxFile is the main.spx file path.
 	mainSpxFile string
 
@@ -69,6 +72,7 @@ type compileResult struct {
 func newCompileResult(proj *xgo.Project) *compileResult {
 	return &compileResult{
 		proj:                          proj,
+		enumInfo:                      &enumInfo{},
 		spxSpriteTypes:                make(map[gotypes.Type]struct{}),
 		spxSpriteResourceAutoBindings: make(map[gotypes.Object]struct{}),
 		diagnostics:                   make(map[DocumentURI][]Diagnostic),
@@ -94,18 +98,31 @@ func (r *compileResult) spxDefinitionsFor(obj gotypes.Object, selectorTypeName s
 		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
 	}
 
-	typeInfo, _ := r.proj.TypeInfo()
 	switch obj := obj.(type) {
 	case *gotypes.Var:
+		typeInfo, _ := r.proj.TypeInfo()
 		astPkg, _ := r.proj.ASTPackage()
 		forceVar := xgoutil.IsDefinedInClassFieldsDecl(r.proj.Fset, typeInfo, astPkg, obj)
 		return []SpxDefinition{GetSpxDefinitionForVar(obj, selectorTypeName, forceVar, pkgDoc)}
 	case *gotypes.Const:
+		if r.enumInfo.isRegularConstObject(obj) {
+			return []SpxDefinition{GetSpxDefinitionForConst(obj, pkgDoc)}
+		}
+		if r.enumInfo.isSyntheticObject(obj) {
+			return nil
+		}
+		if members := r.enumInfo.membersForObject(obj); len(members) > 0 {
+			return []SpxDefinition{r.spxDefinitionForEnumMembers(members...)}
+		}
 		return []SpxDefinition{GetSpxDefinitionForConst(obj, pkgDoc)}
 	case *gotypes.TypeName:
-		return []SpxDefinition{GetSpxDefinitionForType(obj, pkgDoc)}
+		def := GetSpxDefinitionForType(obj, pkgDoc)
+		if r.enumInfo.typeFor(obj.Type()) != nil {
+			def.CompletionItemKind = EnumCompletion
+		}
+		return []SpxDefinition{def}
 	case *gotypes.Func:
-		if typeInfo != nil {
+		if typeInfo, _ := r.proj.TypeInfo(); typeInfo != nil {
 			if defIdent := typeInfo.ObjToDef[obj]; defIdent != nil && defIdent.Implicit() {
 				return nil
 			}
@@ -138,7 +155,11 @@ func (r *compileResult) spxDefinitionsForIdent(ident *ast.Ident) []SpxDefinition
 	if typeInfo == nil {
 		return nil
 	}
-	return r.spxDefinitionsFor(typeInfo.ObjectOf(ident), SelectorTypeNameForIdent(r.proj, ident))
+	if members := r.enumMembersForIdent(typeInfo, ident); len(members) > 0 {
+		return []SpxDefinition{r.spxDefinitionForEnumMembers(members...)}
+	}
+	obj := r.enumInfo.objectForIdent(typeInfo, ident)
+	return r.spxDefinitionsFor(obj, SelectorTypeNameForIdent(r.proj, ident))
 }
 
 // spxDefinitionsForNamedStruct returns all spx definitions for the given named
@@ -449,6 +470,8 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 			handleErr(err)
 		}
 	}
+	astPkg, _ := snapshot.ASTPackage()
+	result.enumInfo = newEnumInfo(astPkg, typeInfo)
 	pkg := typeInfo.Pkg
 
 	for file := range snapshot.Files() {

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -114,11 +114,12 @@ type completionContext struct {
 	enclosingCallExpr  *ast.CallExpr
 	selectorExpr       *ast.SelectorExpr
 	expectedTypes      []gotypes.Type
+	enumContext        enumIdentContext
 	expectedStructType *gotypes.Struct
 	compositeLitType   *gotypes.Named
 	assignTargets      []gotypes.Object
 	declValueSpec      *ast.ValueSpec
-	switchTag          ast.Expr
+	switchStmt         *ast.SwitchStmt
 	returnIndex        int
 
 	inStringLit             bool
@@ -400,7 +401,13 @@ func (ctx *completionContext) analyze() {
 			ctx.valueExpression = true
 		case *ast.SwitchStmt:
 			ctx.kind = completionKindSwitchCase
-			ctx.switchTag = node.Tag
+			ctx.switchStmt = node
+		case *ast.TypeSwitchStmt:
+			ctx.switchStmt = nil
+		case *ast.CaseClause:
+			if ctx.switchStmt != nil && ctx.pos <= node.Colon {
+				ctx.kind = completionKindSwitchCase
+			}
 		case *ast.SelectStmt:
 			ctx.kind = completionKindSelect
 		case *ast.DeclStmt:
@@ -448,6 +455,11 @@ func (ctx *completionContext) analyze() {
 			if !ctx.isAfterNumberLiteral() {
 				ctx.kind = completionKindGeneral
 			}
+		}
+	}
+	if len(ctx.result.enumInfo.members) > 0 {
+		if ident := xgoutil.EnclosingNode[*ast.Ident](path); ident != nil {
+			ctx.enumContext = ctx.result.enumContextAtIdent(ctx.typeInfo, ident)
 		}
 	}
 
@@ -993,6 +1005,13 @@ func (ctx *completionContext) collectGeneral() error {
 		return nil
 	}
 
+	enumContext := ctx.enumContext
+	if enumContext.status == enumContextUnknown && len(ctx.expectedTypes) > 0 {
+		enumContext.status = enumContextAllowed
+		enumContext.expectedTypes = ctx.expectedTypes
+	}
+	ctx.addVisibleEnumMembers(enumContext.expectedTypes...)
+
 	for _, expectedType := range ctx.expectedTypes {
 		if err := ctx.collectTypeSpecific(expectedType); err != nil {
 			return err
@@ -1008,6 +1027,7 @@ func (ctx *completionContext) collectGeneral() error {
 		if ctx.declValueSpec.Values == nil { // var x in|
 			ctx.itemSet.setSupportedKinds(
 				ClassCompletion,
+				EnumCompletion,
 				InterfaceCompletion,
 				StructCompletion,
 			)
@@ -1018,6 +1038,7 @@ func (ctx *completionContext) collectGeneral() error {
 		ctx.itemSet.setSupportedKinds(
 			VariableCompletion,
 			ConstantCompletion,
+			EnumMemberCompletion,
 			FunctionCompletion, // TODO: Add return type compatibility check for FunctionCompletion.
 			FieldCompletion,
 			MethodCompletion,
@@ -1032,6 +1053,7 @@ func (ctx *completionContext) collectGeneral() error {
 		ctx.itemSet.setExpectedFuncResultCount(ctx.expectedFuncResultCount)
 	}
 	ctx.itemSet.setExpectedTypes(ctx.expectedTypes)
+	ctx.itemSet.setEnumContext(enumContext)
 
 	// Add local definitions from innermost scope and its parents.
 	pkg := ctx.typeInfo.Pkg
@@ -1893,7 +1915,7 @@ func (ctx *completionContext) collectStructLit() error {
 
 // collectSwitchCase collects switch/case completions.
 func (ctx *completionContext) collectSwitchCase() error {
-	if ctx.switchTag == nil {
+	if ctx.switchStmt.Tag == nil {
 		for _, name := range []string{"int", "string", "bool", "error"} {
 			if obj := gotypes.Universe.Lookup(name); obj != nil {
 				ctx.itemSet.addSpxDefs(GetSpxDefinitionForBuiltinObj(obj))
@@ -1902,8 +1924,12 @@ func (ctx *completionContext) collectSwitchCase() error {
 		return nil
 	}
 
-	typ := ctx.typeInfo.TypeOf(ctx.switchTag)
+	typ := ctx.typeInfo.TypeOf(ctx.switchStmt.Tag)
 	if !xgoutil.IsValidType(typ) {
+		return nil
+	}
+	if ctx.result.enumInfo.typeFor(typ) != nil {
+		ctx.addVisibleEnumMembers(typ)
 		return nil
 	}
 	named := resolvedNamedType(typ)
@@ -1938,6 +1964,17 @@ func (ctx *completionContext) collectSwitchCase() error {
 	return nil
 }
 
+// addVisibleEnumMembers adds members of the given types that are not shadowed
+// at the completion position.
+func (ctx *completionContext) addVisibleEnumMembers(expectedTypes ...gotypes.Type) {
+	for _, def := range ctx.result.spxDefinitionsForEnumTypes(expectedTypes...) {
+		_, obj := ctx.innermostScope.LookupParent(def.CompletionItemLabel, ctx.pos)
+		if len(ctx.result.enumInfo.membersForObject(obj)) > 0 {
+			ctx.itemSet.addSpxDefs(def)
+		}
+	}
+}
+
 // collectSelect collects select statement completions.
 func (ctx *completionContext) collectSelect() error {
 	ctx.itemSet.add(
@@ -1960,17 +1997,19 @@ func (ctx *completionContext) collectSelect() error {
 // completionItemKindPriority is the priority order for different completion
 // item kinds.
 var completionItemKindPriority = map[CompletionItemKind]int{
-	VariableCompletion:  1,
-	FieldCompletion:     2,
-	PropertyCompletion:  3,
-	MethodCompletion:    4,
-	FunctionCompletion:  5,
-	ConstantCompletion:  6,
-	UnitCompletion:      7,
-	ClassCompletion:     8,
-	InterfaceCompletion: 9,
-	ModuleCompletion:    10,
-	KeywordCompletion:   11,
+	VariableCompletion:   1,
+	FieldCompletion:      2,
+	PropertyCompletion:   3,
+	MethodCompletion:     4,
+	FunctionCompletion:   5,
+	ConstantCompletion:   6,
+	EnumMemberCompletion: 6,
+	UnitCompletion:       7,
+	ClassCompletion:      8,
+	EnumCompletion:       8,
+	InterfaceCompletion:  9,
+	ModuleCompletion:     10,
+	KeywordCompletion:    11,
 }
 
 // sortedItems returns the sorted items.
@@ -1992,7 +2031,7 @@ type completionItemSet struct {
 	isCompatibleWithExpectedTypes func(typ gotypes.Type) bool
 	disallowVoidFuncs             bool
 	expectedFuncResultCount       int
-	expectedTypes                 []gotypes.Type
+	enumContext                   enumIdentContext
 }
 
 // newCompletionItemSet creates a new [completionItemSet].
@@ -2034,7 +2073,6 @@ func (s *completionItemSet) setExpectedTypes(expectedTypes []gotypes.Type) {
 		return
 	}
 
-	s.expectedTypes = expectedTypes
 	s.isCompatibleWithExpectedTypes = func(typ gotypes.Type) bool {
 		for _, expectedType := range expectedTypes {
 			if xgoutil.IsValidType(expectedType) {
@@ -2050,6 +2088,51 @@ func (s *completionItemSet) setExpectedTypes(expectedTypes []gotypes.Type) {
 		}
 		return false
 	}
+}
+
+// setEnumContext sets the context used to filter enum members.
+func (s *completionItemSet) setEnumContext(context enumIdentContext) {
+	s.enumContext = context
+}
+
+// isEnumMemberCompatibleWithContext reports whether typ satisfies the enum
+// completion context.
+func isEnumMemberCompatibleWithContext(typ gotypes.Type, context enumIdentContext) bool {
+	if !xgoutil.IsValidType(typ) {
+		return false
+	}
+	if len(context.basicTypeConstraints) > 0 {
+		basic, ok := typ.Underlying().(*gotypes.Basic)
+		if !ok {
+			return false
+		}
+		for _, required := range context.basicTypeConstraints {
+			if basic.Info()&required == 0 {
+				return false
+			}
+		}
+	}
+	if len(context.expectedTypes) == 0 {
+		return true
+	}
+	for _, expectedType := range context.expectedTypes {
+		if !xgoutil.IsValidType(expectedType) {
+			continue
+		}
+		if gotypes.AssignableTo(typ, expectedType) {
+			return true
+		}
+		if context.allowConversion && xgoutil.IsTypesConvertible(typ, expectedType) {
+			return true
+		}
+		if typeParam, ok := gotypes.Unalias(expectedType).(*gotypes.TypeParam); ok {
+			constraint := typeParam.Constraint().Underlying().(*gotypes.Interface)
+			if gotypes.Satisfies(typ, constraint) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // add adds items to the set.
@@ -2082,7 +2165,14 @@ func (s *completionItemSet) addSpxDefs(spxDefs ...SpxDefinition) {
 				continue
 			}
 		}
-		if s.isCompatibleWithExpectedTypes != nil {
+		if spxDef.CompletionItemKind == EnumMemberCompletion && s.enumContext.status != enumContextUnknown {
+			if s.enumContext.status == enumContextDisallowed {
+				continue
+			}
+			if !isEnumMemberCompatibleWithContext(spxDef.TypeHint, s.enumContext) {
+				continue
+			}
+		} else if s.isCompatibleWithExpectedTypes != nil {
 			typeToCompare := spxDef.TypeHint
 			if sig, ok := typeToCompare.(*gotypes.Signature); ok {
 				switch sig.Results().Len() {

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	gotypes "go/types"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
@@ -282,6 +283,1085 @@ onStart => {
 		items := itemsResult.([]CompletionItem)
 		assert.True(t, containsCompletionItemLabel(items, "count"))
 		assert.False(t, containsCompletionItemLabel(items, "comment"))
+	})
+
+	t.Run("EnumType", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type TrafficLight const (
+	Red = iota
+)
+
+type Signal = TrafficLight
+
+func run() {
+	var light Tra
+	var signal Sig
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		for _, tt := range []struct {
+			name     string
+			position Position
+			label    string
+		}{
+			{name: "Declaration", position: Position{Line: 7, Character: 14}, label: "TrafficLight"},
+			{name: "Alias", position: Position{Line: 8, Character: 15}, label: "Signal"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				items := requireValueAs[[]CompletionItem](t, itemsResult)
+				item := completionItemByLabel(items, tt.label)
+				require.NotNilf(t, item, "%v", completionItemLabels(items))
+				assert.Equal(t, EnumCompletion, item.Kind)
+			})
+		}
+	})
+
+	t.Run("EnumValue", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`const Result = "text"
+
+func run() {
+	type Color const (
+		// Red documentation.
+		Red = iota
+		Green
+	)
+
+	var color Color = R
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 9, Character: 20},
+			},
+		})
+		require.NoError(t, err)
+		items := itemsResult.([]CompletionItem)
+		item := completionItemByLabel(items, "Red")
+		require.NotNilf(t, item, "%v", completionItemLabels(items))
+		assert.Equal(t, EnumMemberCompletion, item.Kind)
+		require.NotNil(t, item.Documentation)
+		documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+		assert.Contains(t, documentation.Value, "Red documentation.")
+		assert.False(t, containsCompletionItemLabel(items, "Result"))
+	})
+
+	t.Run("StringEnumValueForIndex", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Word const (
+	Hello = "hello"
+)
+
+func run() {
+	var first byte = H[0]
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 5, Character: 19},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[[]CompletionItem](t, itemsResult)
+		item := completionItemByLabel(items, "Hello")
+		require.NotNilf(t, item, "%v", completionItemLabels(items))
+		assert.Equal(t, EnumMemberCompletion, item.Kind)
+	})
+
+	t.Run("EnumValueForUnassignableTarget", func(t *testing.T) {
+		sourcePrefix := `type Color const (
+	Red = iota
+)
+
+type Size const (
+	Small = iota
+)
+
+func run() {
+`
+		for _, tt := range []struct {
+			name       string
+			assignment string
+			wantLabel  string
+		}{
+			{name: "DifferentEnum", assignment: "\tvar size Size = R", wantLabel: "Small"},
+			{name: "ConvertibleBasic", assignment: "\tvar number float64 = R"},
+			{name: "DereferenceOperand", assignment: "\tvar color Color = *R"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				m := map[string][]byte{
+					"main.spx": []byte(sourcePrefix + tt.assignment + "\n}\n"),
+				}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position: Position{
+							Line:      uint32(strings.Count(sourcePrefix, "\n")),
+							Character: uint32(len(tt.assignment)),
+						},
+					},
+				})
+				require.NoError(t, err)
+				items := requireValueAs[[]CompletionItem](t, itemsResult)
+				assert.Falsef(t, containsCompletionItemLabel(items, "Red"), "%v", completionItemLabels(items))
+				if tt.wantLabel != "" {
+					assert.Truef(t, containsCompletionItemLabel(items, tt.wantLabel), "%v", completionItemLabels(items))
+				}
+			})
+		}
+	})
+
+	t.Run("EnumSwitchCase", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+func run(value Second) {
+	switch value {
+	case U:
+	}
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 12, Character: 7},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[[]CompletionItem](t, itemsResult)
+		item := completionItemByLabel(items, "Unknown")
+		require.NotNilf(t, item, "%v", completionItemLabels(items))
+		assert.Equal(t, 1, countCompletionItemLabel(items, "Unknown"))
+		assert.Equal(t, EnumMemberCompletion, item.Kind)
+		require.NotNil(t, item.Documentation)
+		documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+		assert.Contains(t, documentation.Value, "Second member documentation.")
+		assert.NotContains(t, documentation.Value, "First member documentation.")
+	})
+
+	t.Run("EnumBlankIdentifier", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Color const (
+	_ = iota
+	Red
+)
+
+func run() {
+	var color Color =
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 6, Character: 19},
+			},
+		})
+		require.NoError(t, err)
+		items := itemsResult.([]CompletionItem)
+		assert.Falsef(t, containsCompletionItemLabel(items, "_"), "%v", completionItemLabels(items))
+		assert.Truef(t, containsCompletionItemLabel(items, "Red"), "%v", completionItemLabels(items))
+	})
+
+	t.Run("EnumMemberSharedWithRegularConstant", func(t *testing.T) {
+		sourcePrefix := `const (
+	// Regular documentation.
+	Shared = 1
+)
+
+type Color const (
+	// Enum documentation.
+	Shared = 1
+)
+
+func run() {
+`
+		for _, tt := range []struct {
+			name        string
+			assignment  string
+			position    Position
+			wantKind    CompletionItemKind
+			wantDoc     string
+			unwantedDoc string
+		}{
+			{
+				name:        "RegularContext",
+				assignment:  "\tvar value any = Sh",
+				position:    Position{Line: 11, Character: 19},
+				wantKind:    ConstantCompletion,
+				wantDoc:     "Regular documentation.",
+				unwantedDoc: "Enum documentation.",
+			},
+			{
+				name:        "EnumContext",
+				assignment:  "\tvar value Color = Sh",
+				position:    Position{Line: 11, Character: 21},
+				wantKind:    EnumMemberCompletion,
+				wantDoc:     "Enum documentation.",
+				unwantedDoc: "Regular documentation.",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				m := map[string][]byte{
+					"main.spx": []byte(sourcePrefix + tt.assignment + "\n}\n"),
+				}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				items := itemsResult.([]CompletionItem)
+				item := completionItemByLabel(items, "Shared")
+				require.NotNilf(t, item, "%v", completionItemLabels(items))
+				assert.Equal(t, 1, countCompletionItemLabel(items, "Shared"))
+				assert.Equal(t, tt.wantKind, item.Kind)
+				require.NotNil(t, item.Documentation)
+				documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+				assert.Contains(t, documentation.Value, tt.wantDoc)
+				assert.NotContains(t, documentation.Value, tt.unwantedDoc)
+			})
+		}
+	})
+
+	t.Run("EnumMemberShadowedByLocal", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Color const (
+	// Enum documentation.
+	Red = iota
+)
+
+func run() {
+	var Red Color
+	var color Color = R
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 7, Character: 20},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[[]CompletionItem](t, itemsResult)
+		item := completionItemByLabel(items, "Red")
+		require.NotNilf(t, item, "%v", completionItemLabels(items))
+		assert.Equal(t, VariableCompletion, item.Kind)
+		require.NotNil(t, item.Documentation)
+		documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+		assert.NotContains(t, documentation.Value, "Enum documentation.")
+	})
+
+	t.Run("EnumValueForBroadAssignmentTarget", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Color const (
+	Red = iota
+)
+
+func run() {
+	var declared any = R
+	var assigned any
+	assigned = R
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		for _, position := range []Position{
+			{Line: 5, Character: 21},
+			{Line: 7, Character: 13},
+		} {
+			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					Position:     position,
+				},
+			})
+			require.NoError(t, err)
+			items := itemsResult.([]CompletionItem)
+			item := completionItemByLabel(items, "Red")
+			require.NotNilf(t, item, "%v", completionItemLabels(items))
+			assert.Equal(t, EnumMemberCompletion, item.Kind)
+		}
+	})
+
+	t.Run("EnumValueForBasicTypeContext", func(t *testing.T) {
+		sourcePrefix := `type Integer const (
+	IntegerValue = iota
+)
+
+type Float const (
+	FloatValue = 1.5
+)
+
+type ComplexNumber const (
+	ComplexValue = 1i
+)
+
+type Text const (
+	StringValue = "value"
+)
+
+type Toggle const (
+	BoolValue = true
+)
+
+var integerMap map[Integer]int
+var integers []Integer
+var bytes []byte
+
+func run() {
+`
+		labels := []string{"IntegerValue", "FloatValue", "ComplexValue", "StringValue", "BoolValue"}
+		for _, tt := range []struct {
+			name       string
+			expression string
+			wantLabels []string
+		}{
+			{name: "IfCondition", expression: "\tif I {}", wantLabels: []string{"BoolValue"}},
+			{name: "ForCondition", expression: "\tfor I {}", wantLabels: []string{"BoolValue"}},
+			{name: "LogicalOperand", expression: "\t_ = true && I", wantLabels: []string{"BoolValue"}},
+			{name: "UnaryNot", expression: "\t_ = !I", wantLabels: []string{"BoolValue"}},
+			{name: "UnaryAdd", expression: "\t_ = +I", wantLabels: []string{"IntegerValue", "FloatValue", "ComplexValue"}},
+			{
+				name:       "NumericAddition",
+				expression: "\t_ = 1 + I",
+				wantLabels: []string{"IntegerValue", "FloatValue", "ComplexValue"},
+			},
+			{
+				name:       "FractionalAddition",
+				expression: "\t_ = 1.5 + I",
+				wantLabels: []string{"FloatValue", "ComplexValue"},
+			},
+			{
+				name:       "IntegralFloatAddition",
+				expression: "\t_ = 1.0 + I",
+				wantLabels: []string{"IntegerValue", "FloatValue", "ComplexValue"},
+			},
+			{name: "ImaginaryAddition", expression: "\t_ = 1i + I", wantLabels: []string{"ComplexValue"}},
+			{name: "StringAddition", expression: "\t_ = \"\" + I", wantLabels: []string{"StringValue"}},
+			{
+				name:       "Subtraction",
+				expression: "\t_ = 1 - I",
+				wantLabels: []string{"IntegerValue", "FloatValue", "ComplexValue"},
+			},
+			{name: "BitwiseOperand", expression: "\t_ = 1 & I", wantLabels: []string{"IntegerValue"}},
+			{name: "BooleanComparison", expression: "\t_ = I == false", wantLabels: []string{"BoolValue"}},
+			{name: "NumericComparison", expression: "\t_ = I < 1", wantLabels: []string{"IntegerValue", "FloatValue"}},
+			{name: "StringComparison", expression: "\t_ = I < \"\"", wantLabels: []string{"StringValue"}},
+			{name: "NilComparison", expression: "\t_ = I == nil"},
+			{name: "ShiftCount", expression: "\t_ = 1 << I", wantLabels: []string{"IntegerValue"}},
+			{name: "Index", expression: "\t_ = []int{1}[I]", wantLabels: []string{"IntegerValue"}},
+			{name: "SliceBound", expression: "\t_ = []int{1}[I:]", wantLabels: []string{"IntegerValue"}},
+			{name: "CompositeLiteralIndex", expression: "\t_ = []int{I: 1}", wantLabels: []string{"IntegerValue"}},
+			{name: "IndexContainer", expression: "\t_ = I[0]", wantLabels: []string{"StringValue"}},
+			{name: "Len", expression: "\t_ = len(I)", wantLabels: []string{"StringValue"}},
+			{name: "Cap", expression: "\t_ = cap(I)"},
+			{name: "MakeLength", expression: "\t_ = make([]int, I)", wantLabels: []string{"IntegerValue"}},
+			{name: "ComplexReal", expression: "\t_ = complex(I, 1)", wantLabels: []string{"FloatValue"}},
+			{name: "Real", expression: "\t_ = real(I)", wantLabels: []string{"ComplexValue"}},
+			{name: "AppendElement", expression: "\t_ = append(integers, I)", wantLabels: []string{"IntegerValue"}},
+			{name: "AppendString", expression: "\t_ = append(bytes, I...)", wantLabels: []string{"StringValue"}},
+			{name: "AppendListContainer", expression: "\t_ = append([I], IntegerValue)", wantLabels: []string{"IntegerValue"}},
+			{name: "AppendListContainerString", expression: "\t_ = append([I], \"value\"...)"},
+			{name: "AppendableSend", expression: "\tintegers <- I", wantLabels: []string{"IntegerValue"}},
+			{name: "AppendableSendString", expression: "\tbytes <- I...", wantLabels: []string{"StringValue"}},
+			{name: "AppendableSendEllipsis", expression: "\tintegers <- I..."},
+			{name: "DeleteKey", expression: "\tdelete(integerMap, I)", wantLabels: []string{"IntegerValue"}},
+			{name: "AppendContainer", expression: "\t_ = append(I, IntegerValue)"},
+			{name: "Clear", expression: "\tclear(I)"},
+			{name: "Close", expression: "\tclose(I)"},
+			{name: "Copy", expression: "\t_ = copy(I, integers)"},
+			{name: "CopyString", expression: "\t_ = copy(bytes, I)", wantLabels: []string{"StringValue"}},
+			{name: "CopyListSource", expression: "\t_ = copy(integers, [I])", wantLabels: []string{"IntegerValue"}},
+			{name: "CopyListDestination", expression: "\t_ = copy([I], integers)", wantLabels: []string{"IntegerValue"}},
+			{name: "IncompleteCopyDestination", expression: "\t_ = copy([I])", wantLabels: labels},
+			{name: "New", expression: "\t_ = new(I)"},
+			{name: "Range", expression: "\tfor value <- I { _ = value }", wantLabels: []string{"IntegerValue", "StringValue"}},
+			{name: "RangeExpressionStart", expression: "\tfor value <- I:10 { _ = value }", wantLabels: []string{"IntegerValue", "FloatValue"}},
+			{
+				name:       "ListComprehensionRange",
+				expression: "\t_ = [value for value <- I]",
+				wantLabels: []string{"IntegerValue", "StringValue"},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				m := map[string][]byte{
+					"main.spx": []byte(sourcePrefix + tt.expression + "\n}\n"),
+				}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position: Position{
+							Line:      uint32(strings.Count(sourcePrefix, "\n")),
+							Character: uint32(strings.Index(tt.expression, "I") + 1),
+						},
+					},
+				})
+				require.NoError(t, err)
+				items := requireValueAs[[]CompletionItem](t, itemsResult)
+				for _, label := range labels {
+					item := completionItemByLabel(items, label)
+					if slices.Contains(tt.wantLabels, label) {
+						require.NotNilf(t, item, "%v", completionItemLabels(items))
+						assert.Equal(t, EnumMemberCompletion, item.Kind)
+					} else {
+						assert.Nilf(t, item, "%v", completionItemLabels(items))
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("EnumValueForPointerTarget", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Color const (
+	Red = iota
+)
+
+func use(*Color) {}
+
+func run() {
+	use(R)
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 7, Character: 6},
+			},
+		})
+		require.NoError(t, err)
+		items := itemsResult.([]CompletionItem)
+		assert.Falsef(t, containsCompletionItemLabel(items, "Red"), "%v", completionItemLabels(items))
+	})
+
+	t.Run("EnumValueForPointerConversionTarget", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Color const (
+	Red = iota
+)
+
+type ColorPtr = *Color
+
+func run() {
+	_ = ColorPtr(R)
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 7, Character: 15},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[[]CompletionItem](t, itemsResult)
+		assert.Falsef(t, containsCompletionItemLabel(items, "Red"), "%v", completionItemLabels(items))
+	})
+
+	t.Run("EnumValueForExplicitConversion", func(t *testing.T) {
+		sourcePrefix := `type Color const (
+	Red = iota
+)
+
+type Size const (
+	Small = iota
+)
+
+func run() {
+`
+		for _, tt := range []struct {
+			name       string
+			expression string
+		}{
+			{name: "Direct", expression: "R"},
+			{name: "BinaryExpression", expression: "R + 1"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				line := "\t_ = Size(" + tt.expression + ")"
+				m := map[string][]byte{
+					"main.spx": []byte(sourcePrefix + line + "\n}\n"),
+				}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position: Position{
+							Line:      uint32(strings.Count(sourcePrefix, "\n")),
+							Character: uint32(strings.Index(line, "R") + len("R")),
+						},
+					},
+				})
+				require.NoError(t, err)
+				items := requireValueAs[[]CompletionItem](t, itemsResult)
+				item := completionItemByLabel(items, "Red")
+				require.NotNilf(t, item, "%v", completionItemLabels(items))
+				assert.Equal(t, EnumMemberCompletion, item.Kind)
+			})
+		}
+	})
+
+	t.Run("DuplicateEnumValue", func(t *testing.T) {
+		sourcePrefix := `type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+func run() {
+`
+		for _, tt := range []struct {
+			name        string
+			assignment  string
+			position    Position
+			wantDoc     string
+			unwantedDoc string
+		}{
+			{
+				name:        "First",
+				assignment:  "\tvar value First = Un",
+				position:    Position{Line: 11, Character: 21},
+				wantDoc:     "First member documentation.",
+				unwantedDoc: "Second member documentation.",
+			},
+			{
+				name:        "Second",
+				assignment:  "\tvar value Second = U",
+				position:    Position{Line: 11, Character: 21},
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				m := map[string][]byte{
+					"main.spx": []byte(sourcePrefix + tt.assignment + "\n}\n"),
+				}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				items := itemsResult.([]CompletionItem)
+				item := completionItemByLabel(items, "Unknown")
+				require.NotNilf(t, item, "%v", completionItemLabels(items))
+				assert.Equal(t, 1, countCompletionItemLabel(items, "Unknown"))
+				assert.Equal(t, EnumMemberCompletion, item.Kind)
+				require.NotNil(t, item.Documentation)
+				documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+				assert.Contains(t, documentation.Value, tt.wantDoc)
+				assert.NotContains(t, documentation.Value, tt.unwantedDoc)
+				assert.Falsef(t, containsCompletionItemLabel(items, "_Unknown_1"), "%v", completionItemLabels(items))
+				assert.Falsef(t, containsCompletionItemLabel(items, "_Unknown_2"), "%v", completionItemLabels(items))
+			})
+		}
+	})
+
+	t.Run("ContextualDuplicateEnumValue", func(t *testing.T) {
+		sourcePrefix := `type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+func useSlice([]Second) {}
+func useMatrix([][]Second) {}
+
+func run(second Second, values map[Second]int, ch chan Second) {
+`
+		for _, tt := range []struct {
+			name         string
+			expression   string
+			wantFirstDoc bool
+		}{
+			{name: "SliceLiteral", expression: "\t_ = []Second{Un}"},
+			{name: "BinaryExpression", expression: "\t_ = second == Un"},
+			{name: "BinaryWithUntypedOperand", expression: "\tvar value Second = Un + 1"},
+			{name: "UnaryExpression", expression: "\tvar value Second = +Un"},
+			{name: "MapIndex", expression: "\t_ = values[Un]"},
+			{name: "Send", expression: "\tch <- Un"},
+			{name: "ShiftCount", expression: "\t_ = second << Un", wantFirstDoc: true},
+			{name: "SliceBound", expression: "\tvar slice []int = []int{1}[Un:]", wantFirstDoc: true},
+			{name: "XGoSliceLiteral", expression: "\tuseSlice([Un])"},
+			{name: "XGoMatrixLiteral", expression: "\tuseMatrix([Un; Unknown])"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				m := map[string][]byte{
+					"main.spx": []byte(sourcePrefix + tt.expression + "\n}\n"),
+				}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position: Position{
+							Line:      uint32(strings.Count(sourcePrefix, "\n")),
+							Character: uint32(strings.Index(tt.expression, "Un") + len("Un")),
+						},
+					},
+				})
+				require.NoError(t, err)
+				items := requireValueAs[[]CompletionItem](t, itemsResult)
+				item := completionItemByLabel(items, "Unknown")
+				require.NotNilf(t, item, "%v", completionItemLabels(items))
+				assert.Equal(t, EnumMemberCompletion, item.Kind)
+				require.NotNil(t, item.Documentation)
+				documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+				assert.Contains(t, documentation.Value, "Second member documentation.")
+				if tt.wantFirstDoc {
+					assert.Contains(t, documentation.Value, "First member documentation.")
+				} else {
+					assert.NotContains(t, documentation.Value, "First member documentation.")
+				}
+			})
+		}
+	})
+
+	t.Run("EnumValueForXGoExpressionContext", func(t *testing.T) {
+		declarations := `type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+type Unique const (
+	SecondValue = iota
+)
+
+type Key const (
+	KeyValue = iota
+)
+
+type Element const (
+	ElementValue = iota
+)
+
+type RangeValue const (
+	RangeStart = iota
+	RangeEnd
+	RangeStep
+)
+
+type OtherRange const (
+	OtherRangeValue = iota
+)
+
+type FirstText const (
+	TextFirst = "first"
+)
+
+type SecondText const (
+	TextSecond = "second"
+)
+
+type FirstToggle const (
+	FirstEnabled = true
+)
+
+type SecondToggle const (
+	SecondEnabled = true
+)
+
+func loadSecond() (Second, error) { return Unknown, nil }
+
+`
+		for _, tt := range []struct {
+			name        string
+			body        string
+			cursorText  string
+			label       string
+			absentLabel string
+			wantDoc     string
+			unwantedDoc string
+		}{
+			{
+				name: "TupleFirstElement",
+				body: `func use(First, Second) {}
+
+func run() {
+	use((Un, Unknown))
+}
+`,
+				cursorText:  "Un,",
+				label:       "Unknown",
+				wantDoc:     "First member documentation.",
+				unwantedDoc: "Second member documentation.",
+			},
+			{
+				name: "TupleSecondElement",
+				body: `func use(First, Second) {}
+
+func run() {
+	use((Unknown, Un))
+}
+`,
+				cursorText:  "Un))",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "ListComprehensionElement",
+				body: `func run() {
+	var values []Unique = [Se for _ <- [1]]
+}
+`,
+				cursorText: "Se for",
+				label:      "SecondValue",
+			},
+			{
+				name: "MapComprehensionKey",
+				body: `func run() {
+	var values map[Key]Element = {Ke: ElementValue for _ <- [1]}
+}
+`,
+				cursorText: "Ke:",
+				label:      "KeyValue",
+			},
+			{
+				name: "MapComprehensionValue",
+				body: `func run() {
+	var values map[Key]Element = {KeyValue: El for _ <- [1]}
+}
+`,
+				cursorText: "El for",
+				label:      "ElementValue",
+			},
+			{
+				name: "NestedMapComprehensionValue",
+				body: `func run() {
+	var values map[Key][]Element = {KeyValue: [El] for _ <- [1]}
+}
+`,
+				cursorText: "El]",
+				label:      "ElementValue",
+			},
+			{
+				name: "LambdaResult",
+				body: `func use(func() Second) {}
+
+func run() {
+	use(=> Un)
+}
+`,
+				cursorText:  "Un)",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "AppendNestedList",
+				body: `var values [][]Second
+
+func run() {
+	_ = append(values, [Un])
+}
+`,
+				cursorText:  "Un]",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "AppendNestedListEllipsis",
+				body: `var values []Second
+
+func run() {
+	_ = append(values, [Un]...)
+}
+`,
+				cursorText:  "Un]",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "AppendLambda",
+				body: `var funcs []func() Second
+
+func run() {
+	_ = append(funcs, => Un)
+}
+`,
+				cursorText:  "Un)",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "LambdaBlockReturn",
+				body: `func use(func() Second) {}
+
+func run() {
+	use(=> { return Un })
+}
+`,
+				cursorText:  "Un }",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "LambdaCollectionResult",
+				body: `func use(func() []Second) {}
+
+func run() {
+	use(=> [Un])
+}
+`,
+				cursorText:  "Un]",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "LambdaSelectComprehensionResult",
+				body: `func use(func() Second) {}
+
+func run() {
+	use(=> ({Un for _ <- [1]}))
+}
+`,
+				cursorText:  "Un for",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "LambdaErrorWrapDefault",
+				body: `func use(func() Second) {}
+
+func run() {
+	use(=> loadSecond()?:Un)
+}
+`,
+				cursorText:  "Un)",
+				label:       "Unknown",
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+			{
+				name: "LambdaStringSliceResult",
+				body: `func use(func() SecondText) {}
+
+func run() {
+	use(=> Te[:])
+}
+`,
+				cursorText:  "Te[:",
+				label:       "TextSecond",
+				absentLabel: "TextFirst",
+			},
+			{
+				name: "CompoundShiftCount",
+				body: `func run() {
+	var value First = Unknown
+	value <<= Se
+}
+`,
+				cursorText: "Se\n",
+				label:      "SecondValue",
+			},
+			{
+				name: "LogicalExpressionResult",
+				body: `func run() {
+	var value SecondToggle = Se && true
+}
+`,
+				cursorText:  "Se &&",
+				label:       "SecondEnabled",
+				absentLabel: "FirstEnabled",
+			},
+			{
+				name: "RangeExpressionEnd",
+				body: `func run() {
+	for value <- RangeStart:Ra { _ = value }
+}
+`,
+				cursorText:  "Ra {",
+				label:       "RangeEnd",
+				absentLabel: "OtherRangeValue",
+			},
+			{
+				name: "RangeExpressionStep",
+				body: `func run() {
+	for value <- RangeStart:RangeEnd:Ra { _ = value }
+}
+`,
+				cursorText:  "Ra {",
+				label:       "RangeStep",
+				absentLabel: "OtherRangeValue",
+			},
+			{
+				name: "RangeExpressionDefaultStart",
+				body: `func run() {
+	for value <- :Ra { _ = value }
+}
+`,
+				cursorText:  "Ra {",
+				absentLabel: "RangeEnd",
+			},
+			{
+				name: "AssignmentTarget",
+				body: `func run() {
+	Un = 1
+}
+`,
+				cursorText:  "Un =",
+				absentLabel: "Unknown",
+			},
+			{
+				name: "IncrementTarget",
+				body: `func run() {
+	Un++
+}
+`,
+				cursorText:  "Un++",
+				absentLabel: "Unknown",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				source := declarations + tt.body
+				offset := strings.LastIndex(source, tt.cursorText)
+				require.NotEqual(t, -1, offset)
+				offset += 2
+				prefix := source[:offset]
+				m := map[string][]byte{"main.spx": []byte(source)}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position: Position{
+							Line:      uint32(strings.Count(prefix, "\n")),
+							Character: uint32(len(prefix) - strings.LastIndex(prefix, "\n") - 1),
+						},
+					},
+				})
+				require.NoError(t, err)
+				items := requireValueAs[[]CompletionItem](t, itemsResult)
+				if tt.absentLabel != "" {
+					assert.Nilf(t, completionItemByLabel(items, tt.absentLabel), "%v", completionItemLabels(items))
+				}
+				if tt.label == "" {
+					return
+				}
+				item := completionItemByLabel(items, tt.label)
+				require.NotNilf(t, item, "%v", completionItemLabels(items))
+				assert.Equal(t, EnumMemberCompletion, item.Kind)
+				if tt.wantDoc == "" {
+					return
+				}
+				require.NotNil(t, item.Documentation)
+				documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+				assert.Contains(t, documentation.Value, tt.wantDoc)
+				assert.NotContains(t, documentation.Value, tt.unwantedDoc)
+			})
+		}
+	})
+
+	t.Run("OverloadedDuplicateEnumValue", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+func useFirst(First) {}
+func useSecond(Second) {}
+func use = (
+	useFirst
+	useSecond
+)
+
+func run() {
+	use(Un)
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 18, Character: 7},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[[]CompletionItem](t, itemsResult)
+		item := completionItemByLabel(items, "Unknown")
+		require.NotNilf(t, item, "%v", completionItemLabels(items))
+		require.NotNil(t, item.Documentation)
+		documentation := requireValueAs[MarkupContent](t, item.Documentation.Value)
+		assert.Contains(t, documentation.Value, "First member documentation.")
+		assert.Contains(t, documentation.Value, "Second member documentation.")
 	})
 
 	t.Run("InStringLit", func(t *testing.T) {

--- a/internal/server/diagnostic_test.go
+++ b/internal/server/diagnostic_test.go
@@ -98,6 +98,31 @@ func TestServerTextDocumentDiagnostic(t *testing.T) {
 		assert.Empty(t, fullReport.Items)
 	})
 
+	t.Run("LocalEnum", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`func check() {
+	type Permission const (
+		Read = 1 << iota
+		Write
+	)
+	var permission Permission = Write
+	println(permission)
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
+		assert.Empty(t, fullReport.Items)
+	})
+
 	t.Run("FuncDecoratorResourceArgument", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`func withSound(sound SoundName, fn func()) {

--- a/internal/server/enum.go
+++ b/internal/server/enum.go
@@ -1,0 +1,1265 @@
+package server
+
+import (
+	"go/constant"
+	gotoken "go/token"
+	gotypes "go/types"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/xgo"
+	"github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/xgoutil"
+)
+
+// enumInfo describes source-level enum types and members.
+type enumInfo struct {
+	typesByObject   map[*gotypes.TypeName]*enumTypeInfo
+	typesByIdent    map[*ast.Ident]*enumTypeInfo
+	members         []*enumMemberInfo
+	membersByIdent  map[*ast.Ident]*enumMemberInfo
+	membersByObject map[gotypes.Object][]*enumMemberInfo
+
+	regularConstsByIdent  map[*ast.Ident]*gotypes.Const
+	regularConstsByObject map[*gotypes.Const]struct{}
+}
+
+// enumTypeInfo describes one source-level enum type.
+type enumTypeInfo struct {
+	name    string
+	object  *gotypes.TypeName
+	named   *gotypes.Named
+	members []*enumMemberInfo
+}
+
+// enumMemberInfo describes one source-level enum member.
+type enumMemberInfo struct {
+	owner  *enumTypeInfo
+	ident  *ast.Ident
+	object *gotypes.Const
+	doc    string
+}
+
+type enumContextStatus uint8
+
+const (
+	enumContextUnknown enumContextStatus = iota
+	enumContextAllowed
+	enumContextDisallowed
+)
+
+type enumTypePathPartKind uint8
+
+const (
+	enumTypePathElement enumTypePathPartKind = iota
+	enumTypePathMapKey
+	enumTypePathMapValue
+	enumTypePathFunctionResult
+)
+
+type enumTypePathPart struct {
+	kind  enumTypePathPartKind
+	index int
+}
+
+// enumIdentContext describes how an identifier can be used as an enum member
+// in its surrounding expression.
+type enumIdentContext struct {
+	status               enumContextStatus
+	expectedTypes        []gotypes.Type
+	basicTypeConstraints []gotypes.BasicInfo
+	allowConversion      bool
+}
+
+// newEnumInfo builds source-level enum information from an AST package.
+func newEnumInfo(astPkg *ast.Package, typeInfo *types.Info) *enumInfo {
+	info := &enumInfo{
+		typesByObject:   make(map[*gotypes.TypeName]*enumTypeInfo),
+		typesByIdent:    make(map[*ast.Ident]*enumTypeInfo),
+		membersByIdent:  make(map[*ast.Ident]*enumMemberInfo),
+		membersByObject: make(map[gotypes.Object][]*enumMemberInfo),
+
+		regularConstsByIdent:  make(map[*ast.Ident]*gotypes.Const),
+		regularConstsByObject: make(map[*gotypes.Const]struct{}),
+	}
+	if astPkg == nil || typeInfo == nil {
+		return info
+	}
+
+	for _, filename := range slices.Sorted(maps.Keys(astPkg.Files)) {
+		astFile := astPkg.Files[filename]
+		ast.Inspect(astFile, func(node ast.Node) bool {
+			switch node := node.(type) {
+			case *ast.GenDecl:
+				if node.Tok == token.CONST {
+					info.addRegularConsts(node.Specs, typeInfo)
+				}
+			case *ast.TypeSpec:
+				if enumType, ok := node.Type.(*ast.EnumType); ok {
+					info.addEnumType(node, enumType, typeInfo)
+				}
+			}
+			return true
+		})
+	}
+
+	return info
+}
+
+// addRegularConsts indexes ordinary const declarations.
+func (i *enumInfo) addRegularConsts(specs []ast.Spec, typeInfo *types.Info) {
+	for _, spec := range specs {
+		valueSpec, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for _, ident := range valueSpec.Names {
+			if ident.Name == "_" {
+				continue
+			}
+			constant := constObjectForIdent(typeInfo, ident)
+			i.regularConstsByIdent[ident] = constant
+			if constant != nil {
+				i.regularConstsByObject[constant] = struct{}{}
+			}
+		}
+	}
+}
+
+// addEnumType indexes one source-level enum type and its members.
+func (i *enumInfo) addEnumType(typeSpec *ast.TypeSpec, enumType *ast.EnumType, typeInfo *types.Info) {
+	typeName, _ := typeInfo.ObjectOf(typeSpec.Name).(*gotypes.TypeName)
+	owner := &enumTypeInfo{
+		name:   typeSpec.Name.Name,
+		object: typeName,
+	}
+	i.typesByIdent[typeSpec.Name] = owner
+	if typeName != nil {
+		owner.named = resolvedNamedType(typeName.Type())
+		i.typesByObject[typeName] = owner
+	}
+
+	for _, spec := range enumType.Specs {
+		valueSpec := spec.(*ast.ValueSpec)
+		var doc string
+		if valueSpec.Doc != nil {
+			doc = valueSpec.Doc.Text()
+		}
+		for _, ident := range valueSpec.Names {
+			if ident.Name == "_" {
+				continue
+			}
+			constant := constObjectForIdent(typeInfo, ident)
+			member := &enumMemberInfo{
+				owner:  owner,
+				ident:  ident,
+				object: constant,
+				doc:    doc,
+			}
+			owner.members = append(owner.members, member)
+			i.members = append(i.members, member)
+			i.membersByIdent[ident] = member
+			if constant == nil {
+				continue
+			}
+			if owner.named == nil {
+				if named, ok := gotypes.Unalias(constant.Type()).(*gotypes.Named); ok {
+					owner.object = named.Obj()
+					owner.named = named
+					i.typesByObject[named.Obj()] = owner
+				}
+			}
+			i.membersByObject[constant] = append(i.membersByObject[constant], member)
+		}
+	}
+}
+
+// constObjectForIdent returns the constant visible under ident's source name.
+func constObjectForIdent(typeInfo *types.Info, ident *ast.Ident) *gotypes.Const {
+	if constant, ok := sourceObjectForIdent(typeInfo, ident).(*gotypes.Const); ok {
+		return constant
+	}
+	constant, _ := typeInfo.ObjectOf(ident).(*gotypes.Const)
+	return constant
+}
+
+// sourceObjectForIdent returns the object visible under ident's source name.
+func sourceObjectForIdent(typeInfo *types.Info, ident *ast.Ident) gotypes.Object {
+	if typeInfo.Pkg != nil {
+		scope := typeInfo.Pkg.Scope()
+		if innermost := scope.Innermost(ident.Pos()); innermost != nil {
+			scope = innermost
+		}
+		_, obj := scope.LookupParent(ident.Name, ident.Pos())
+		if obj != nil {
+			return obj
+		}
+	}
+	return typeInfo.ObjectOf(ident)
+}
+
+// sourceTypeForExpr returns the recorded type of expr, falling back to the
+// source-visible object for identifiers omitted by the XGo recorder.
+func sourceTypeForExpr(typeInfo *types.Info, expr ast.Expr) gotypes.Type {
+	if typ := typeInfo.TypeOf(expr); xgoutil.IsValidType(typ) {
+		return typ
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		if obj := sourceObjectForIdent(typeInfo, ident); obj != nil {
+			return obj.Type()
+		}
+	}
+	return nil
+}
+
+// typeFor returns source-level enum information for typ.
+func (i *enumInfo) typeFor(typ gotypes.Type) *enumTypeInfo {
+	named, ok := gotypes.Unalias(typ).(*gotypes.Named)
+	if !ok {
+		return nil
+	}
+	return i.typesByObject[named.Obj()]
+}
+
+// declarationType returns the enum type declared by ident.
+func (i *enumInfo) declarationType(ident *ast.Ident) *enumTypeInfo {
+	return i.typesByIdent[ident]
+}
+
+// declarationMember returns the enum member declared by ident.
+func (i *enumInfo) declarationMember(ident *ast.Ident) *enumMemberInfo {
+	return i.membersByIdent[ident]
+}
+
+// declarationMemberAt returns the enum member declaration covering pos.
+func (i *enumInfo) declarationMemberAt(pos token.Pos) *enumMemberInfo {
+	for _, member := range i.members {
+		if member.ident.Pos() <= pos && pos < member.ident.End() {
+			return member
+		}
+	}
+	return nil
+}
+
+// membersForObject returns source-level enum members represented by obj.
+func (i *enumInfo) membersForObject(obj gotypes.Object) []*enumMemberInfo {
+	return i.membersByObject[obj]
+}
+
+// isRegularConstDeclaration reports whether ident declares an ordinary constant.
+func (i *enumInfo) isRegularConstDeclaration(ident *ast.Ident) bool {
+	_, ok := i.regularConstsByIdent[ident]
+	return ok
+}
+
+// objectForIdent returns the object denoted by ident, including indexed
+// ordinary const declarations.
+func (i *enumInfo) objectForIdent(typeInfo *types.Info, ident *ast.Ident) gotypes.Object {
+	if obj := typeInfo.ObjectOf(ident); obj != nil {
+		return obj
+	}
+	if constant := i.regularConstsByIdent[ident]; constant != nil {
+		return constant
+	}
+	return nil
+}
+
+// regularConstDeclarationAt returns the ordinary const declaration covering pos.
+func (i *enumInfo) regularConstDeclarationAt(pos token.Pos) (*ast.Ident, *gotypes.Const) {
+	for ident, obj := range i.regularConstsByIdent {
+		if obj != nil && ident.Pos() <= pos && pos < ident.End() {
+			return ident, obj
+		}
+	}
+	return nil, nil
+}
+
+// isRegularConstObject reports whether obj has an ordinary const declaration.
+func (i *enumInfo) isRegularConstObject(obj gotypes.Object) bool {
+	constant, ok := obj.(*gotypes.Const)
+	if !ok {
+		return false
+	}
+	_, ok = i.regularConstsByObject[constant]
+	return ok
+}
+
+// isSyntheticObject reports whether obj is an XGo-generated enum constant.
+func (i *enumInfo) isSyntheticObject(obj gotypes.Object) bool {
+	constant, ok := obj.(*gotypes.Const)
+	return ok && !constant.Pos().IsValid() && i.typeFor(constant.Type()) != nil
+}
+
+// membersForExpectedTypes selects members whose enum types are expected at a use.
+func (i *enumInfo) membersForExpectedTypes(members []*enumMemberInfo, expectedTypes []gotypes.Type) []*enumMemberInfo {
+	expectedOwners := make(map[*enumTypeInfo]struct{})
+	for _, typ := range expectedTypes {
+		if owner := i.typeFor(typ); owner != nil {
+			expectedOwners[owner] = struct{}{}
+		}
+	}
+	if len(expectedOwners) == 0 {
+		return nil
+	}
+	selected := make([]*enumMemberInfo, 0, len(members))
+	for _, member := range members {
+		if _, ok := expectedOwners[member.owner]; ok {
+			selected = append(selected, member)
+		}
+	}
+	return selected
+}
+
+// enumMembersForIdent resolves the source-level enum members represented by ident.
+func (r *compileResult) enumMembersForIdent(typeInfo *types.Info, ident *ast.Ident) []*enumMemberInfo {
+	if member := r.enumInfo.declarationMember(ident); member != nil {
+		return []*enumMemberInfo{member}
+	}
+	if r.enumInfo.isRegularConstDeclaration(ident) {
+		return nil
+	}
+	obj := typeInfo.ObjectOf(ident)
+	members := r.enumInfo.membersForObject(obj)
+	if len(members) == 0 {
+		return nil
+	}
+	context := r.enumContextAtIdent(typeInfo, ident)
+	if selected := r.enumInfo.membersForExpectedTypes(members, context.expectedTypes); len(selected) > 0 {
+		return selected
+	}
+	if r.enumInfo.isRegularConstObject(obj) {
+		return nil
+	}
+	return members
+}
+
+// enumContextAtIdent returns the enum context provided by ident's surrounding
+// expression.
+func (r *compileResult) enumContextAtIdent(typeInfo *types.Info, ident *ast.Ident) enumIdentContext {
+	astPkg, _ := r.proj.ASTPackage()
+	astFile := xgoutil.NodeASTFile(r.proj.Fset, astPkg, ident)
+	if astFile == nil {
+		return enumIdentContext{}
+	}
+	path, _ := xgoutil.PathEnclosingInterval(astFile, ident.Pos(), ident.End())
+	var (
+		target                   ast.Expr = ident
+		typePath                 []enumTypePathPart
+		basicTypeConstraints     []gotypes.BasicInfo
+		pendingLambdaResultIndex = -1
+	)
+	contextForTypes := func(expectedTypes []gotypes.Type) enumIdentContext {
+		context := enumIdentContext{
+			status:               enumContextAllowed,
+			basicTypeConstraints: slices.Clone(basicTypeConstraints),
+		}
+		for _, typ := range expectedTypes {
+			if typ := enumTypePathTargetType(typ, typePath); typ != nil {
+				context.expectedTypes = append(context.expectedTypes, typ)
+			}
+		}
+		context.expectedTypes = deduplicateTypes(context.expectedTypes)
+		return context
+	}
+	contextForType := func(typ gotypes.Type) enumIdentContext {
+		return contextForTypes([]gotypes.Type{typ})
+	}
+	addBasicTypeConstraint := func(info gotypes.BasicInfo) {
+		if !slices.Contains(basicTypeConstraints, info) {
+			basicTypeConstraints = append(basicTypeConstraints, info)
+		}
+	}
+	for pathIndex, node := range path {
+		switch node := node.(type) {
+		case *ast.ParenExpr:
+			if node.X == target {
+				target = node
+			}
+			continue
+		case *ast.UnaryExpr:
+			if node.X != target {
+				continue
+			}
+			switch node.Op {
+			case token.ADD, token.SUB:
+				addBasicTypeConstraint(gotypes.IsNumeric)
+			case token.XOR:
+				addBasicTypeConstraint(gotypes.IsInteger)
+			case token.NOT:
+				addBasicTypeConstraint(gotypes.IsBoolean)
+			default:
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+			target = node
+			continue
+		case *ast.StarExpr:
+			if node.X == target {
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+			continue
+		case *ast.LambdaExpr:
+			if resultIndex := slices.Index(node.Rhs, target); resultIndex >= 0 {
+				typePath = append(typePath, enumTypePathPart{
+					kind:  enumTypePathFunctionResult,
+					index: resultIndex,
+				})
+				target = node
+			}
+			continue
+		case *ast.LambdaExpr2:
+			if pendingLambdaResultIndex >= 0 {
+				typePath = append(typePath, enumTypePathPart{
+					kind:  enumTypePathFunctionResult,
+					index: pendingLambdaResultIndex,
+				})
+				target = node
+				pendingLambdaResultIndex = -1
+			}
+			continue
+		case *ast.SliceLit:
+			if slices.Contains(node.Elts, target) {
+				typePath = append(typePath, enumTypePathPart{kind: enumTypePathElement})
+				target = node
+			}
+			continue
+		case *ast.MatrixLit:
+			if slices.ContainsFunc(node.Elts, func(row []ast.Expr) bool {
+				return slices.Contains(row, target)
+			}) {
+				typePath = append(typePath,
+					enumTypePathPart{kind: enumTypePathElement},
+					enumTypePathPart{kind: enumTypePathElement},
+				)
+				target = node
+			}
+			continue
+		case *ast.ComprehensionExpr:
+			switch {
+			case node.Tok == token.LBRACK && node.Elt == target:
+				typePath = append(typePath, enumTypePathPart{kind: enumTypePathElement})
+			case node.Tok == token.LBRACE && node.Elt == target:
+			case node.Tok == token.LBRACE:
+				keyValue, ok := node.Elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				switch target {
+				case keyValue.Key:
+					typePath = append(typePath, enumTypePathPart{kind: enumTypePathMapKey})
+				case keyValue.Value:
+					typePath = append(typePath, enumTypePathPart{kind: enumTypePathMapValue})
+				default:
+					continue
+				}
+			default:
+				continue
+			}
+			target = node
+			continue
+		case *ast.ErrWrapExpr:
+			if node.Default == target {
+				if typ := enumErrWrapDefaultType(typeInfo, node); typ != nil {
+					return contextForType(typ)
+				}
+				target = node
+			}
+			continue
+		case *ast.ElemEllipsis:
+			if node.Elt == target {
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+			continue
+		}
+
+		if call := callExprFromNode(node); call != nil {
+			if builtinContext, ok := enumBuiltinCallContext(typeInfo, call, target, len(typePath) > 0); ok {
+				if builtinContext.status == enumContextDisallowed {
+					return builtinContext
+				}
+				for _, required := range builtinContext.basicTypeConstraints {
+					addBasicTypeConstraint(required)
+				}
+				return contextForTypes(builtinContext.expectedTypes)
+			}
+			expected, allowConversion := enumExpectedTypesForCallArg(r.proj, typeInfo, call, target)
+			if len(expected) > 0 {
+				context := contextForTypes(expected)
+				context.allowConversion = allowConversion && len(typePath) == 0
+				return context
+			}
+			if slices.Contains(call.Args, target) || slices.ContainsFunc(call.Kwargs, func(kwarg *ast.KwargExpr) bool {
+				return kwarg.Value == target
+			}) {
+				return contextForTypes(nil)
+			}
+		}
+
+		switch node := node.(type) {
+		case *ast.ValueSpec:
+			valueIndex := slices.Index(node.Values, target)
+			if valueIndex < 0 {
+				continue
+			}
+			if len(node.Names) == 0 {
+				return contextForTypes(nil)
+			}
+			nameIndex := min(valueIndex, len(node.Names)-1)
+			if obj := typeInfo.ObjectOf(node.Names[nameIndex]); obj != nil {
+				return contextForType(obj.Type())
+			}
+			if node.Type != nil {
+				return contextForType(typeInfo.TypeOf(node.Type))
+			}
+			return contextForTypes(nil)
+		case *ast.AssignStmt:
+			valueIndex := slices.Index(node.Rhs, target)
+			if valueIndex >= 0 && valueIndex < len(node.Lhs) {
+				if node.Tok == token.SHL_ASSIGN || node.Tok == token.SHR_ASSIGN {
+					addBasicTypeConstraint(gotypes.IsInteger)
+					return contextForTypes(nil)
+				}
+				return contextForType(typeInfo.TypeOf(node.Lhs[valueIndex]))
+			}
+			if slices.Contains(node.Lhs, target) {
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+		case *ast.IncDecStmt:
+			if node.X == target {
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+		case *ast.ReturnStmt:
+			resultIndex := slices.Index(node.Results, target)
+			if resultIndex < 0 {
+				continue
+			}
+			sig, inLambda := enumEnclosingFunctionContext(typeInfo, path[pathIndex+1:])
+			if sig != nil {
+				if resultIndex < sig.Results().Len() {
+					return contextForType(sig.Results().At(resultIndex).Type())
+				}
+				return contextForTypes(nil)
+			}
+			if inLambda {
+				pendingLambdaResultIndex = resultIndex
+				continue
+			}
+			return contextForTypes(nil)
+		case *ast.CaseClause:
+			if !slices.Contains(node.List, target) {
+				continue
+			}
+			for _, outer := range path[pathIndex+1:] {
+				switchStmt, ok := outer.(*ast.SwitchStmt)
+				if ok && switchStmt.Tag != nil {
+					return contextForType(typeInfo.TypeOf(switchStmt.Tag))
+				}
+			}
+			addBasicTypeConstraint(gotypes.IsBoolean)
+			return contextForTypes(nil)
+		case *ast.CompositeLit:
+			context := enumCompositeElementContext(typeInfo, node, target)
+			if context.status == enumContextUnknown {
+				continue
+			}
+			if context.status == enumContextDisallowed {
+				return context
+			}
+			for _, required := range context.basicTypeConstraints {
+				addBasicTypeConstraint(required)
+			}
+			return contextForTypes(context.expectedTypes)
+		case *ast.IfStmt:
+			if node.Cond == target {
+				addBasicTypeConstraint(gotypes.IsBoolean)
+				return contextForTypes(nil)
+			}
+		case *ast.ForStmt:
+			if node.Cond == target {
+				addBasicTypeConstraint(gotypes.IsBoolean)
+				return contextForTypes(nil)
+			}
+		case *ast.ForPhrase:
+			if node.Cond == target {
+				addBasicTypeConstraint(gotypes.IsBoolean)
+				return contextForTypes(nil)
+			}
+			if node.X == target {
+				addBasicTypeConstraint(gotypes.IsInteger | gotypes.IsString)
+				return contextForTypes(nil)
+			}
+		case *ast.RangeStmt:
+			if node.X == target {
+				addBasicTypeConstraint(gotypes.IsInteger | gotypes.IsString)
+				return contextForTypes(nil)
+			}
+		case *ast.RangeExpr:
+			switch target {
+			case node.First:
+				if typ := typeInfo.TypeOf(node.Last); xgoutil.IsValidType(typ) && !isUntypedType(typ) {
+					return contextForType(typ)
+				}
+				addBasicTypeConstraint(gotypes.IsInteger | gotypes.IsFloat)
+				return contextForTypes(nil)
+			case node.Last, node.Expr3:
+				if node.First == nil {
+					return enumIdentContext{status: enumContextDisallowed}
+				}
+				if typ := typeInfo.TypeOf(node.First); xgoutil.IsValidType(typ) && !isUntypedType(typ) {
+					return contextForType(typ)
+				}
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+		case *ast.BinaryExpr:
+			var (
+				other        ast.Expr
+				targetIsLeft bool
+			)
+			switch target {
+			case node.X:
+				other = node.Y
+				targetIsLeft = true
+			case node.Y:
+				other = node.X
+			default:
+				continue
+			}
+			if node.Op == token.SHL || node.Op == token.SHR {
+				addBasicTypeConstraint(gotypes.IsInteger)
+				if targetIsLeft {
+					target = node
+					continue
+				}
+				return contextForTypes(nil)
+			}
+			var required gotypes.BasicInfo
+			switch node.Op {
+			case token.LAND, token.LOR:
+				required = gotypes.IsBoolean
+			case token.ADD:
+				required = gotypes.IsNumeric | gotypes.IsString
+			case token.SUB, token.MUL, token.QUO:
+				required = gotypes.IsNumeric
+			case token.REM, token.AND, token.OR, token.XOR, token.AND_NOT:
+				required = gotypes.IsInteger
+			case token.LSS, token.LEQ, token.GTR, token.GEQ:
+				required = gotypes.IsOrdered
+			}
+			if required != 0 {
+				addBasicTypeConstraint(required)
+			}
+			if typ := typeInfo.TypeOf(other); xgoutil.IsValidType(typ) && !isUntypedType(typ) {
+				return contextForType(typ)
+			}
+			if required := enumBasicTypeConstraintForExpr(typeInfo, other); required != 0 {
+				addBasicTypeConstraint(required)
+			}
+			if ident, ok := other.(*ast.Ident); ok && ident.Name == "nil" {
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+			switch node.Op {
+			case token.ADD, token.SUB, token.MUL, token.QUO, token.REM,
+				token.AND, token.OR, token.XOR, token.AND_NOT, token.LAND, token.LOR:
+				target = node
+				continue
+			default:
+				return contextForTypes(nil)
+			}
+		case *ast.IndexExpr:
+			if node.X == target {
+				addBasicTypeConstraint(gotypes.IsString)
+				return contextForTypes(nil)
+			}
+			if node.Index == target {
+				if typ := typeInfo.TypeOf(node.X); xgoutil.IsValidType(typ) {
+					if mapType, ok := typ.Underlying().(*gotypes.Map); ok {
+						return contextForType(mapType.Key())
+					}
+				}
+				addBasicTypeConstraint(gotypes.IsInteger)
+				return contextForTypes(nil)
+			}
+		case *ast.SliceExpr:
+			if node.X == target {
+				addBasicTypeConstraint(gotypes.IsString)
+				target = node
+				continue
+			}
+			if node.Low == target || node.High == target || node.Max == target {
+				addBasicTypeConstraint(gotypes.IsInteger)
+				return contextForTypes(nil)
+			}
+		case *ast.ArrayType:
+			if node.Len == target {
+				addBasicTypeConstraint(gotypes.IsInteger)
+				return contextForTypes(nil)
+			}
+		case *ast.SendStmt:
+			if node.Chan == target {
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+			if slices.Contains(node.Values, target) {
+				if typ := typeInfo.TypeOf(node.Chan); xgoutil.IsValidType(typ) {
+					switch underlying := typ.Underlying().(type) {
+					case *gotypes.Chan:
+						if len(node.Values) != 1 || node.Ellipsis.IsValid() {
+							return enumIdentContext{status: enumContextDisallowed}
+						}
+						return contextForType(underlying.Elem())
+					case *gotypes.Slice:
+						if node.Ellipsis.IsValid() {
+							if enumIsByteSlice(typ) {
+								addBasicTypeConstraint(gotypes.IsString)
+								return contextForTypes(nil)
+							}
+							return enumIdentContext{status: enumContextDisallowed}
+						}
+						return contextForType(underlying.Elem())
+					}
+				}
+				return contextForTypes(nil)
+			}
+		}
+	}
+	return enumIdentContext{}
+}
+
+// enumErrWrapDefaultType returns the non-error result type replaced by the
+// default expression.
+func enumErrWrapDefaultType(typeInfo *types.Info, expr *ast.ErrWrapExpr) gotypes.Type {
+	tuple, ok := typeInfo.TypeOf(expr.X).(*gotypes.Tuple)
+	if !ok || tuple.Len() != 2 {
+		return nil
+	}
+	return tuple.At(0).Type()
+}
+
+// enumBuiltinCallContext returns the enum context for a Go built-in argument.
+// wrapped reports whether the direct argument wraps the enum identifier in a
+// type-carrying expression.
+func enumBuiltinCallContext(
+	typeInfo *types.Info,
+	call *ast.CallExpr,
+	target ast.Expr,
+	wrapped bool,
+) (enumIdentContext, bool) {
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return enumIdentContext{}, false
+	}
+	obj := typeInfo.ObjectOf(ident)
+	if _, ok := obj.(*gotypes.Builtin); !ok && !xgoutil.IsInBuiltinPkg(obj) {
+		return enumIdentContext{}, false
+	}
+	argIndex := slices.Index(call.Args, target)
+	if argIndex < 0 {
+		return enumIdentContext{}, false
+	}
+	name := obj.Name()
+	if wrapped && name != "append" && name != "copy" {
+		return enumIdentContext{}, false
+	}
+
+	context := enumIdentContext{status: enumContextAllowed}
+	switch name {
+	case "len":
+		context.basicTypeConstraints = []gotypes.BasicInfo{gotypes.IsString}
+	case "cap", "clear", "close", "new":
+		context.status = enumContextDisallowed
+	case "make":
+		if argIndex == 0 {
+			context.status = enumContextDisallowed
+		} else {
+			context.basicTypeConstraints = []gotypes.BasicInfo{gotypes.IsInteger}
+		}
+	case "complex":
+		context.basicTypeConstraints = []gotypes.BasicInfo{gotypes.IsFloat}
+		for index, arg := range call.Args {
+			if index == argIndex {
+				continue
+			}
+			if typ := typeInfo.TypeOf(arg); xgoutil.IsValidType(typ) && !isUntypedType(typ) {
+				context.expectedTypes = []gotypes.Type{typ}
+				break
+			}
+		}
+	case "real", "imag":
+		context.basicTypeConstraints = []gotypes.BasicInfo{gotypes.IsComplex}
+	case "append":
+		return enumAppendBuiltinCallContext(typeInfo, call, argIndex, wrapped)
+	case "delete":
+		if argIndex == 0 {
+			context.status = enumContextDisallowed
+			break
+		}
+		if typ := typeInfo.TypeOf(call.Args[0]); xgoutil.IsValidType(typ) {
+			if mapType, ok := typ.Underlying().(*gotypes.Map); ok {
+				context.expectedTypes = []gotypes.Type{mapType.Key()}
+			}
+		}
+	case "copy":
+		if wrapped {
+			if len(call.Args) != 2 {
+				return enumIdentContext{}, false
+			}
+			otherType := sourceTypeForExpr(typeInfo, call.Args[1-argIndex])
+			if !xgoutil.IsValidType(otherType) {
+				return enumIdentContext{}, false
+			}
+			if _, ok := otherType.Underlying().(*gotypes.Slice); !ok {
+				return enumIdentContext{}, false
+			}
+			context.expectedTypes = []gotypes.Type{otherType}
+		} else if argIndex == 0 {
+			context.status = enumContextDisallowed
+		} else if enumIsByteSlice(typeInfo.TypeOf(call.Args[0])) {
+			context.basicTypeConstraints = []gotypes.BasicInfo{gotypes.IsString}
+		} else {
+			context.status = enumContextDisallowed
+		}
+	default:
+		return enumIdentContext{}, false
+	}
+	return context, true
+}
+
+// enumAppendBuiltinCallContext returns the enum context for an append argument.
+func enumAppendBuiltinCallContext(
+	typeInfo *types.Info,
+	call *ast.CallExpr,
+	argIndex int,
+	wrapped bool,
+) (enumIdentContext, bool) {
+	context := enumIdentContext{status: enumContextAllowed}
+	if argIndex != 0 {
+		containerType := typeInfo.TypeOf(call.Args[0])
+		if call.Ellipsis.IsValid() {
+			switch {
+			case wrapped && xgoutil.IsValidType(containerType):
+				context.expectedTypes = []gotypes.Type{containerType}
+			case enumIsByteSlice(containerType):
+				context.basicTypeConstraints = []gotypes.BasicInfo{gotypes.IsString}
+			default:
+				context.status = enumContextDisallowed
+			}
+			return context, true
+		}
+		if xgoutil.IsValidType(containerType) {
+			if sliceType, ok := containerType.Underlying().(*gotypes.Slice); ok {
+				context.expectedTypes = []gotypes.Type{sliceType.Elem()}
+			}
+		}
+		return context, true
+	}
+
+	if !wrapped {
+		context.status = enumContextDisallowed
+		return context, true
+	}
+	if len(call.Args) == 1 {
+		return enumIdentContext{}, false
+	}
+
+	firstValue := call.Args[1]
+	firstValueType := sourceTypeForExpr(typeInfo, firstValue)
+	if call.Ellipsis.IsValid() && len(call.Args) == 2 {
+		if !xgoutil.IsValidType(firstValueType) {
+			if enumBasicTypeConstraintForExpr(typeInfo, firstValue) != gotypes.IsString {
+				return enumIdentContext{}, false
+			}
+			context.expectedTypes = []gotypes.Type{gotypes.NewSlice(gotypes.Typ[gotypes.Byte])}
+			return context, true
+		}
+		switch underlying := firstValueType.Underlying().(type) {
+		case *gotypes.Basic:
+			if underlying.Info()&gotypes.IsString == 0 {
+				return enumIdentContext{}, false
+			}
+			context.expectedTypes = []gotypes.Type{gotypes.NewSlice(gotypes.Typ[gotypes.Byte])}
+		case *gotypes.Slice:
+			context.expectedTypes = []gotypes.Type{firstValueType}
+		default:
+			return enumIdentContext{}, false
+		}
+		return context, true
+	}
+	if required := enumBasicTypeConstraintForExpr(typeInfo, firstValue); required != 0 {
+		context.basicTypeConstraints = []gotypes.BasicInfo{required}
+		return context, true
+	}
+	if !xgoutil.IsValidType(firstValueType) {
+		return enumIdentContext{}, false
+	}
+	context.expectedTypes = []gotypes.Type{gotypes.NewSlice(firstValueType)}
+	return context, true
+}
+
+// enumIsByteSlice reports whether typ is the []byte type accepted by the
+// append and copy string special cases.
+func enumIsByteSlice(typ gotypes.Type) bool {
+	if !xgoutil.IsValidType(typ) {
+		return false
+	}
+	sliceType, ok := typ.Underlying().(*gotypes.Slice)
+	return ok && gotypes.Identical(gotypes.Unalias(sliceType.Elem()), gotypes.Typ[gotypes.Uint8])
+}
+
+// enumTypePathTargetType returns the type selected by typePath.
+func enumTypePathTargetType(typ gotypes.Type, typePath []enumTypePathPart) gotypes.Type {
+	if !xgoutil.IsValidType(typ) {
+		return nil
+	}
+	for _, part := range slices.Backward(typePath) {
+		switch part.kind {
+		case enumTypePathElement:
+			switch underlying := typ.Underlying().(type) {
+			case *gotypes.Array:
+				typ = underlying.Elem()
+			case *gotypes.Slice:
+				typ = underlying.Elem()
+			default:
+				return nil
+			}
+		case enumTypePathMapKey:
+			mapType, ok := typ.Underlying().(*gotypes.Map)
+			if !ok {
+				return nil
+			}
+			typ = mapType.Key()
+		case enumTypePathMapValue:
+			mapType, ok := typ.Underlying().(*gotypes.Map)
+			if !ok {
+				return nil
+			}
+			typ = mapType.Elem()
+		case enumTypePathFunctionResult:
+			sig, ok := typ.Underlying().(*gotypes.Signature)
+			if !ok || part.index >= sig.Results().Len() {
+				return nil
+			}
+			typ = sig.Results().At(part.index).Type()
+		}
+	}
+	return typ
+}
+
+// enumExpectedTypesForCallArg returns expected types when target is a direct
+// call argument.
+func enumExpectedTypesForCallArg(
+	proj *xgo.Project,
+	typeInfo *types.Info,
+	call *ast.CallExpr,
+	target ast.Expr,
+) ([]gotypes.Type, bool) {
+	var expected []gotypes.Type
+	expected = append(expected, enumExpectedTypesForTupleElement(proj, typeInfo, call, target)...)
+
+	for resolvedArg := range resolvedCallExprArgs(proj, typeInfo, call) {
+		if resolvedArg.Arg == target && xgoutil.IsValidType(resolvedArg.ExpectedType) {
+			expected = append(expected, resolvedArg.ExpectedType)
+		}
+	}
+	allowConversion := false
+	if len(call.Args) == 1 && call.Args[0] == target {
+		if tv, ok := typeInfo.Types[call.Fun]; ok && tv.IsType() && xgoutil.IsValidType(tv.Type) {
+			expected = append(expected, gotypes.Unalias(tv.Type))
+			allowConversion = true
+		}
+	}
+	return deduplicateTypes(expected), allowConversion
+}
+
+// enumExpectedTypesForTupleElement returns expected types when target is an
+// element of an expanded tuple argument.
+func enumExpectedTypesForTupleElement(
+	proj *xgo.Project,
+	typeInfo *types.Info,
+	call *ast.CallExpr,
+	target ast.Expr,
+) []gotypes.Type {
+	if len(call.Args) != 1 || len(call.Kwargs) > 0 || call.Ellipsis.IsValid() {
+		return nil
+	}
+	tuple, ok := call.Args[0].(*ast.TupleLit)
+	if !ok {
+		return nil
+	}
+	elementIndex := slices.Index(tuple.Elts, target)
+	if elementIndex < 0 {
+		return nil
+	}
+
+	funcs := callExprFuncOverloads(proj, typeInfo, call)
+	if len(funcs) == 0 {
+		if fun := xgoutil.FuncFromCallExpr(typeInfo, call); fun != nil {
+			funcs = []*gotypes.Func{fun}
+		}
+	}
+	var expected []gotypes.Type
+	for _, fun := range funcs {
+		sig, params := xgoutil.ResolveFuncSignatureForCall(typeInfo, call, fun)
+		if sig == nil || params == nil || params.Len() == 1 && enumIsTupleType(params.At(0).Type()) {
+			continue
+		}
+		if typ := callExprArgType(sig, params, elementIndex); xgoutil.IsValidType(typ) {
+			expected = append(expected, typ)
+		}
+	}
+	return deduplicateTypes(expected)
+}
+
+// enumIsTupleType reports whether typ uses XGo's generated tuple structure.
+func enumIsTupleType(typ gotypes.Type) bool {
+	strct, ok := typ.Underlying().(*gotypes.Struct)
+	return ok && strct.NumFields() > 0 && strct.Field(0).Name() == "X_0"
+}
+
+// enumEnclosingFunctionContext returns the nearest enclosing ordinary
+// function signature, or reports that the nearest function is a lambda.
+func enumEnclosingFunctionContext(typeInfo *types.Info, path []ast.Node) (*gotypes.Signature, bool) {
+	for _, node := range path {
+		switch node := node.(type) {
+		case *ast.LambdaExpr2:
+			return nil, true
+		case *ast.FuncLit:
+			if sig, _ := typeInfo.TypeOf(node).(*gotypes.Signature); sig != nil {
+				return sig, false
+			}
+		case *ast.FuncDecl:
+			if fun, _ := typeInfo.ObjectOf(node.Name).(*gotypes.Func); fun != nil {
+				return fun.Signature(), false
+			}
+		}
+	}
+	return nil, false
+}
+
+// enumCompositeElementContext returns the enum context for target in literal.
+func enumCompositeElementContext(
+	typeInfo *types.Info,
+	literal *ast.CompositeLit,
+	target ast.Expr,
+) enumIdentContext {
+	typ := typeInfo.TypeOf(literal)
+	if !xgoutil.IsValidType(typ) && literal.Type != nil {
+		typ = typeInfo.TypeOf(literal.Type)
+	}
+	if !xgoutil.IsValidType(typ) {
+		return enumIdentContext{}
+	}
+	underlyingType := xgoutil.DerefType(typ).Underlying()
+	contextForType := func(typ gotypes.Type) enumIdentContext {
+		return enumIdentContext{status: enumContextAllowed, expectedTypes: []gotypes.Type{typ}}
+	}
+	for index, element := range literal.Elts {
+		if element == target {
+			switch compositeType := underlyingType.(type) {
+			case *gotypes.Array:
+				return contextForType(compositeType.Elem())
+			case *gotypes.Slice:
+				return contextForType(compositeType.Elem())
+			case *gotypes.Struct:
+				if index < compositeType.NumFields() {
+					return contextForType(compositeType.Field(index).Type())
+				}
+			}
+			return enumIdentContext{status: enumContextDisallowed}
+		}
+
+		keyValue, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if keyValue.Key == target {
+			switch compositeType := underlyingType.(type) {
+			case *gotypes.Map:
+				return contextForType(compositeType.Key())
+			case *gotypes.Array, *gotypes.Slice:
+				return enumIdentContext{
+					status:               enumContextAllowed,
+					basicTypeConstraints: []gotypes.BasicInfo{gotypes.IsInteger},
+				}
+			default:
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+		}
+		if keyValue.Value != target {
+			continue
+		}
+		switch compositeType := underlyingType.(type) {
+		case *gotypes.Map:
+			return contextForType(compositeType.Elem())
+		case *gotypes.Struct:
+			key, ok := keyValue.Key.(*ast.Ident)
+			if !ok {
+				return enumIdentContext{status: enumContextDisallowed}
+			}
+			for fieldIndex := range compositeType.NumFields() {
+				field := compositeType.Field(fieldIndex)
+				if field.Name() == key.Name {
+					return contextForType(field.Type())
+				}
+			}
+		}
+		return enumIdentContext{status: enumContextDisallowed}
+	}
+	return enumIdentContext{}
+}
+
+// isUntypedType reports whether typ is an untyped basic type.
+func isUntypedType(typ gotypes.Type) bool {
+	basic, ok := typ.Underlying().(*gotypes.Basic)
+	return ok && basic.Info()&gotypes.IsUntyped != 0
+}
+
+// enumBasicTypeConstraintForExpr returns the basic type category imposed by
+// expr when it denotes an untyped value.
+func enumBasicTypeConstraintForExpr(typeInfo *types.Info, expr ast.Expr) gotypes.BasicInfo {
+	if typeAndValue, ok := typeInfo.Types[expr]; ok && xgoutil.IsValidType(typeAndValue.Type) {
+		if basic, ok := typeAndValue.Type.Underlying().(*gotypes.Basic); ok && basic.Info()&gotypes.IsUntyped != 0 {
+			return enumUntypedBasicConstraint(basic, typeAndValue.Value)
+		}
+	}
+	switch expr := expr.(type) {
+	case *ast.BasicLit:
+		switch expr.Kind {
+		case token.STRING, token.CSTRING:
+			return gotypes.IsString
+		case token.INT, token.FLOAT, token.IMAG, token.CHAR:
+			value := constant.MakeFromLiteral(expr.Value, gotoken.Token(expr.Kind), 0)
+			return enumNumericConstantConstraint(value)
+		case token.RAT:
+			return gotypes.IsNumeric
+		}
+	case *ast.Ident:
+		if expr.Name == "true" || expr.Name == "false" {
+			return gotypes.IsBoolean
+		}
+	}
+	return 0
+}
+
+// enumUntypedBasicConstraint returns the enum basic types compatible with an
+// untyped basic value.
+func enumUntypedBasicConstraint(basic *gotypes.Basic, value constant.Value) gotypes.BasicInfo {
+	info := basic.Info()
+	switch {
+	case info&gotypes.IsBoolean != 0:
+		return gotypes.IsBoolean
+	case info&gotypes.IsString != 0:
+		return gotypes.IsString
+	case info&gotypes.IsNumeric != 0:
+		if value != nil {
+			return enumNumericConstantConstraint(value)
+		}
+		return gotypes.IsNumeric
+	default:
+		return 0
+	}
+}
+
+// enumNumericConstantConstraint returns the numeric enum basic types to which
+// value can be assigned without changing its exact numeric category.
+func enumNumericConstantConstraint(value constant.Value) gotypes.BasicInfo {
+	if value == nil || value.Kind() == constant.Unknown {
+		return gotypes.IsNumeric
+	}
+	if constant.ToInt(value).Kind() != constant.Unknown {
+		return gotypes.IsNumeric
+	}
+	if constant.ToFloat(value).Kind() != constant.Unknown {
+		return gotypes.IsFloat | gotypes.IsComplex
+	}
+	return gotypes.IsComplex
+}
+
+// spxDefinitionForEnumMembers returns one definition for a non-empty set of
+// source-level members.
+func (r *compileResult) spxDefinitionForEnumMembers(members ...*enumMemberInfo) SpxDefinition {
+	first := members[0]
+	var def SpxDefinition
+	for _, member := range members {
+		if member.object != nil {
+			def = GetSpxDefinitionForConst(member.object, nil)
+			break
+		}
+	}
+	if def.CompletionItemLabel == "" {
+		var pkgPath string
+		if first.owner.object != nil {
+			pkgPath = xgoutil.PkgPath(first.owner.object.Pkg())
+		}
+		def = SpxDefinition{
+			ID: SpxDefinitionIdentifier{
+				Package: ToPtr(pkgPath),
+				Name:    ToPtr(first.ident.Name),
+			},
+			Overview: "const " + first.ident.Name,
+
+			CompletionItemLabel:            first.ident.Name,
+			CompletionItemInsertText:       first.ident.Name,
+			CompletionItemInsertTextFormat: PlainTextTextFormat,
+		}
+	}
+	def.CompletionItemKind = EnumMemberCompletion
+	if len(members) == 1 {
+		if first.owner.named != nil {
+			def.TypeHint = first.owner.named
+		}
+		def.Detail = first.doc
+		return def
+	}
+
+	var detail strings.Builder
+	for memberIndex, member := range members {
+		if memberIndex > 0 {
+			detail.WriteString("\n\n")
+		}
+		detail.WriteString(member.owner.name)
+		detail.WriteByte('.')
+		detail.WriteString(member.ident.Name)
+		detail.WriteByte(':')
+		if doc := strings.TrimSpace(member.doc); doc != "" {
+			detail.WriteByte('\n')
+			detail.WriteString(doc)
+		}
+	}
+	def.Detail = detail.String()
+	return def
+}
+
+// spxDefinitionsForEnumTypes returns definitions for members of the given
+// types. Members with the same source name are represented by one definition.
+func (r *compileResult) spxDefinitionsForEnumTypes(expectedTypes ...gotypes.Type) []SpxDefinition {
+	if len(expectedTypes) == 0 {
+		return nil
+	}
+	membersByName := make(map[string][]*enumMemberInfo)
+	var names []string
+	seenOwners := make(map[*enumTypeInfo]struct{})
+	for _, typ := range expectedTypes {
+		owner := r.enumInfo.typeFor(typ)
+		if owner == nil {
+			continue
+		}
+		if _, ok := seenOwners[owner]; ok {
+			continue
+		}
+		seenOwners[owner] = struct{}{}
+		for _, member := range owner.members {
+			name := member.ident.Name
+			if _, ok := membersByName[name]; !ok {
+				names = append(names, name)
+			}
+			membersByName[name] = append(membersByName[name], member)
+		}
+	}
+
+	defs := make([]SpxDefinition, 0, len(names))
+	for _, name := range names {
+		defs = append(defs, r.spxDefinitionForEnumMembers(membersByName[name]...))
+	}
+	return defs
+}

--- a/internal/server/format_test.go
+++ b/internal/server/format_test.go
@@ -50,7 +50,7 @@ var (
 		})
 	})
 
-	t.Run("FuncDecorator", func(t *testing.T) {
+	t.Run("EnumAndFuncDecorator", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`import "time"
 
@@ -58,7 +58,9 @@ var (
 func run() {
 }
 
-type Marker int
+type Color const (
+	Red = iota
+)
 
 func retry(delay time.Duration, fn func()) {
 	fn()
@@ -75,7 +77,9 @@ func retry(delay time.Duration, fn func()) {
 		require.Len(t, edits, 1)
 		assert.Equal(t, `import "time"
 
-type Marker int
+type Color const (
+	Red = iota
+)
 
 @retry(time.Second)
 func run() {

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -40,6 +40,16 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 	if hover := hoverForXGoUnit(result.proj, typeInfo, astFile, position); hover != nil {
 		return hover, nil
 	}
+	if tokenFile := xgoutil.NodeTokenFile(result.proj.Fset, astFile); tokenFile != nil {
+		pos := tokenFile.Pos(position.Offset)
+		if member := result.enumInfo.declarationMemberAt(pos); member != nil {
+			def := result.spxDefinitionForEnumMembers(member)
+			return hoverForSpxDefs(result.proj, []SpxDefinition{def}, member.ident), nil
+		}
+		if ident, obj := result.enumInfo.regularConstDeclarationAt(pos); ident != nil {
+			return hoverForSpxDefs(result.proj, result.spxDefinitionsFor(obj, ""), ident), nil
+		}
+	}
 	ident, obj, kwargTarget := objectAtPosition(result.proj, typeInfo, astFile, position)
 	if kwargTarget != nil {
 		return hoverForSpxDefs(result.proj, result.spxDefinitionsFor(obj, getTypeFromObject(typeInfo, obj)), kwargTarget.ident), nil

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -856,6 +856,388 @@ onStart => {
 		assert.Contains(t, hover.Contents.Value, `overview="func MaxTokens(n int64) main.Params"`)
 	})
 
+	t.Run("DuplicateEnumMembers", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+var (
+	first First = Unknown
+	second Second = Unknown
+)
+
+echo Unknown
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		hoverAt := func(line, character uint32) *Hover {
+			hover, err := s.textDocumentHover(&HoverParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					Position:     Position{Line: line, Character: character},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, hover)
+			return hover
+		}
+
+		firstDeclaration := hoverAt(2, 2)
+		assert.Contains(t, firstDeclaration.Contents.Value, "First member documentation.")
+		assert.NotContains(t, firstDeclaration.Contents.Value, "Second member documentation.")
+
+		firstReference := hoverAt(11, 16)
+		assert.Contains(t, firstReference.Contents.Value, "First member documentation.")
+		assert.NotContains(t, firstReference.Contents.Value, "Second member documentation.")
+
+		secondReference := hoverAt(12, 18)
+		assert.NotContains(t, secondReference.Contents.Value, "First member documentation.")
+		assert.Contains(t, secondReference.Contents.Value, "Second member documentation.")
+
+		ambiguousReference := hoverAt(15, 6)
+		assert.Contains(t, ambiguousReference.Contents.Value, "First.Unknown:")
+		assert.Contains(t, ambiguousReference.Contents.Value, "First member documentation.")
+		assert.Contains(t, ambiguousReference.Contents.Value, "Second.Unknown:")
+		assert.Contains(t, ambiguousReference.Contents.Value, "Second member documentation.")
+	})
+
+	t.Run("EnumMemberSharedWithRegularConstant", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`const (
+	// Regular documentation.
+	Shared = 1
+)
+
+type Color const (
+	// Enum documentation.
+	Shared = 1
+)
+
+func run() {
+	println(Shared)
+	var color Color = Shared
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		for _, tt := range []struct {
+			name        string
+			position    Position
+			wantDoc     string
+			unwantedDoc string
+		}{
+			{
+				name:        "RegularDeclaration",
+				position:    Position{Line: 2, Character: 2},
+				wantDoc:     "Regular documentation.",
+				unwantedDoc: "Enum documentation.",
+			},
+			{
+				name:        "RegularReference",
+				position:    Position{Line: 11, Character: 10},
+				wantDoc:     "Regular documentation.",
+				unwantedDoc: "Enum documentation.",
+			},
+			{
+				name:        "EnumDeclaration",
+				position:    Position{Line: 7, Character: 2},
+				wantDoc:     "Enum documentation.",
+				unwantedDoc: "Regular documentation.",
+			},
+			{
+				name:        "EnumReference",
+				position:    Position{Line: 12, Character: 20},
+				wantDoc:     "Enum documentation.",
+				unwantedDoc: "Regular documentation.",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, hover)
+				assert.Contains(t, hover.Contents.Value, tt.wantDoc)
+				assert.NotContains(t, hover.Contents.Value, tt.unwantedDoc)
+			})
+		}
+	})
+
+	t.Run("ParenthesizedDuplicateEnumMembers", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+func use(Second) {}
+
+func run() {
+	var value Second = (Unknown)
+	use((Unknown))
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		for _, position := range []Position{
+			{Line: 13, Character: 22},
+			{Line: 14, Character: 7},
+		} {
+			hover, err := s.textDocumentHover(&HoverParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					Position:     position,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, hover)
+			assert.Contains(t, hover.Contents.Value, "Second member documentation.")
+			assert.NotContains(t, hover.Contents.Value, "First member documentation.")
+		}
+	})
+
+	t.Run("TupleDuplicateEnumMembers", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+func use(First, Second) {}
+
+func run() {
+	use((Unknown, Unknown))
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		for _, tt := range []struct {
+			name        string
+			position    Position
+			wantDoc     string
+			unwantedDoc string
+		}{
+			{
+				name:        "FirstElement",
+				position:    Position{Line: 13, Character: 8},
+				wantDoc:     "First member documentation.",
+				unwantedDoc: "Second member documentation.",
+			},
+			{
+				name:        "SecondElement",
+				position:    Position{Line: 13, Character: 17},
+				wantDoc:     "Second member documentation.",
+				unwantedDoc: "First member documentation.",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, hover)
+				assert.Contains(t, hover.Contents.Value, tt.wantDoc)
+				assert.NotContains(t, hover.Contents.Value, tt.unwantedDoc)
+			})
+		}
+	})
+
+	t.Run("ContextualDuplicateEnumMembers", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+type Pair struct {
+	Left Second
+	Right Second
+}
+
+func returnSecond() Second {
+	return Unknown
+}
+
+func run(second Second) {
+	second = Unknown
+	switch second {
+	case Unknown:
+	}
+	_ = Unknown == second
+	_ = second == Unknown
+	_ = []Second{Unknown}
+	_ = [1]Second{Unknown}
+	_ = Pair{Unknown, Unknown}
+	_ = Pair{Left: Unknown}
+	_ = map[Second]Second{Unknown: Unknown}
+	var unary Second = +Unknown
+	values := map[Second]int{Unknown: 1}
+	_ = values[Unknown]
+	ch := make(chan Second, 1)
+	ch <- Unknown
+	var binary Second = Unknown + 1
+	_ = second << Unknown
+	var slice []int = []int{1}[Unknown:]
+	var collection []Second = [Unknown]
+	literal := func() Second { return Unknown }
+	_ = literal
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		for _, tt := range []struct {
+			name     string
+			position Position
+		}{
+			{name: "ReturnFuncDecl", position: Position{Line: 16, Character: 9}},
+			{name: "Assignment", position: Position{Line: 20, Character: 11}},
+			{name: "SwitchCase", position: Position{Line: 22, Character: 7}},
+			{name: "BinaryLeft", position: Position{Line: 24, Character: 6}},
+			{name: "BinaryRight", position: Position{Line: 25, Character: 16}},
+			{name: "SliceLiteral", position: Position{Line: 26, Character: 15}},
+			{name: "ArrayLiteral", position: Position{Line: 27, Character: 16}},
+			{name: "StructPositionalFirst", position: Position{Line: 28, Character: 11}},
+			{name: "StructPositionalSecond", position: Position{Line: 28, Character: 19}},
+			{name: "StructKeyed", position: Position{Line: 29, Character: 17}},
+			{name: "MapKey", position: Position{Line: 30, Character: 24}},
+			{name: "MapValue", position: Position{Line: 30, Character: 33}},
+			{name: "UnaryExpression", position: Position{Line: 31, Character: 22}},
+			{name: "MapIndex", position: Position{Line: 33, Character: 13}},
+			{name: "Send", position: Position{Line: 35, Character: 8}},
+			{name: "BinaryWithUntypedOperand", position: Position{Line: 36, Character: 22}},
+			{name: "XGoSliceLiteral", position: Position{Line: 39, Character: 29}},
+			{name: "ReturnFuncLit", position: Position{Line: 40, Character: 36}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, hover)
+				assert.Contains(t, hover.Contents.Value, "Second member documentation.")
+				assert.NotContains(t, hover.Contents.Value, "First member documentation.")
+			})
+		}
+
+		for _, tt := range []struct {
+			name     string
+			position Position
+		}{
+			{name: "ShiftCount", position: Position{Line: 37, Character: 16}},
+			{name: "SliceBound", position: Position{Line: 38, Character: 29}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, hover)
+				assert.Contains(t, hover.Contents.Value, "First member documentation.")
+				assert.Contains(t, hover.Contents.Value, "Second member documentation.")
+			})
+		}
+	})
+
+	t.Run("ContextualDuplicateEnumMemberInLambda", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	// First member documentation.
+	Unknown = iota
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+
+func use(func() Second) {}
+
+func run() {
+	use(=> Unknown)
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		hover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 13, Character: 9},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Contains(t, hover.Contents.Value, "Second member documentation.")
+		assert.NotContains(t, hover.Contents.Value, "First member documentation.")
+	})
+
+	t.Run("LocalEnumMember", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`func run() {
+	type Color const (
+		// Local red documentation.
+		Red = iota
+	)
+	var color Color = Red
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		for _, position := range []Position{
+			{Line: 3, Character: 2},
+			{Line: 5, Character: 20},
+		} {
+			hover, err := s.textDocumentHover(&HoverParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					Position:     position,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, hover)
+			assert.Contains(t, hover.Contents.Value, "Local red documentation.")
+		}
+	})
+
 	t.Run("XGoUnit", func(t *testing.T) {
 		s := newXGoUnitTestServer(xgoUnitCompletionSource)
 

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -101,19 +101,21 @@ const (
 	SeverityError   = protocol.SeverityError
 	SeverityWarning = protocol.SeverityWarning
 
-	TextCompletion      = protocol.TextCompletion
-	ClassCompletion     = protocol.ClassCompletion
-	InterfaceCompletion = protocol.InterfaceCompletion
-	StructCompletion    = protocol.StructCompletion
-	VariableCompletion  = protocol.VariableCompletion
-	ConstantCompletion  = protocol.ConstantCompletion
-	UnitCompletion      = protocol.UnitCompletion
-	KeywordCompletion   = protocol.KeywordCompletion
-	FieldCompletion     = protocol.FieldCompletion
-	MethodCompletion    = protocol.MethodCompletion
-	PropertyCompletion  = protocol.PropertyCompletion
-	FunctionCompletion  = protocol.FunctionCompletion
-	ModuleCompletion    = protocol.ModuleCompletion
+	TextCompletion       = protocol.TextCompletion
+	ClassCompletion      = protocol.ClassCompletion
+	EnumCompletion       = protocol.EnumCompletion
+	InterfaceCompletion  = protocol.InterfaceCompletion
+	StructCompletion     = protocol.StructCompletion
+	VariableCompletion   = protocol.VariableCompletion
+	ConstantCompletion   = protocol.ConstantCompletion
+	UnitCompletion       = protocol.UnitCompletion
+	KeywordCompletion    = protocol.KeywordCompletion
+	FieldCompletion      = protocol.FieldCompletion
+	MethodCompletion     = protocol.MethodCompletion
+	PropertyCompletion   = protocol.PropertyCompletion
+	FunctionCompletion   = protocol.FunctionCompletion
+	ModuleCompletion     = protocol.ModuleCompletion
+	EnumMemberCompletion = protocol.EnumMemberCompletion
 
 	DiagnosticFull = protocol.DiagnosticFull
 
@@ -126,23 +128,24 @@ const (
 	PlainTextTextFormat = protocol.PlainTextTextFormat
 	SnippetTextFormat   = protocol.SnippetTextFormat
 
-	NamespaceType = protocol.NamespaceType
-	TypeType      = protocol.TypeType
-	InterfaceType = protocol.InterfaceType
-	StructType    = protocol.StructType
-	EnumType      = protocol.EnumType
-	EnumMember    = protocol.EnumMember
-	VariableType  = protocol.VariableType
-	ParameterType = protocol.ParameterType
-	FunctionType  = protocol.FunctionType
-	MethodType    = protocol.MethodType
-	PropertyType  = protocol.PropertyType
-	KeywordType   = protocol.KeywordType
-	CommentType   = protocol.CommentType
-	StringType    = protocol.StringType
-	NumberType    = protocol.NumberType
-	OperatorType  = protocol.OperatorType
-	LabelType     = protocol.LabelType
+	NamespaceType  = protocol.NamespaceType
+	TypeType       = protocol.TypeType
+	InterfaceType  = protocol.InterfaceType
+	StructType     = protocol.StructType
+	EnumType       = protocol.EnumType
+	EnumMemberType = protocol.EnumMemberType
+	EnumMember     = protocol.EnumMember
+	VariableType   = protocol.VariableType
+	ParameterType  = protocol.ParameterType
+	FunctionType   = protocol.FunctionType
+	MethodType     = protocol.MethodType
+	PropertyType   = protocol.PropertyType
+	KeywordType    = protocol.KeywordType
+	CommentType    = protocol.CommentType
+	StringType     = protocol.StringType
+	NumberType     = protocol.NumberType
+	OperatorType   = protocol.OperatorType
+	LabelType      = protocol.LabelType
 
 	ModDeclaration    = protocol.ModDeclaration
 	ModReadonly       = protocol.ModReadonly

--- a/internal/server/semantic_token.go
+++ b/internal/server/semantic_token.go
@@ -31,6 +31,8 @@ var (
 		NumberType,
 		OperatorType,
 		LabelType,
+		EnumType,
+		EnumMemberType,
 	}
 
 	// semanticTokenModifiersLegend defines the semantic token modifiers we
@@ -171,7 +173,20 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 				addToken(node.Semicolon, node.Semicolon+1, OperatorType, nil)
 			}
 		case *ast.Ident:
-			obj := typeInfo.ObjectOf(node)
+			if result.enumInfo.declarationType(node) != nil {
+				addToken(node.Pos(), node.End(), EnumType, []SemanticTokenModifiers{ModDeclaration})
+				return true
+			}
+			if result.enumInfo.declarationMember(node) != nil {
+				addToken(
+					node.Pos(),
+					node.End(),
+					EnumMemberType,
+					[]SemanticTokenModifiers{ModDeclaration, ModStatic, ModReadonly},
+				)
+				return true
+			}
+			obj := result.enumInfo.objectForIdent(typeInfo, node)
 			if obj == nil {
 				if token.Lookup(node.Name).IsKeyword() {
 					addToken(node.Pos(), node.End(), KeywordType, nil)
@@ -182,13 +197,17 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 			var (
 				tokenType SemanticTokenTypes
 				modifiers []SemanticTokenModifiers
-				isDef     = typeInfo.ObjToDef[obj] == node
+				isDef     = typeInfo.ObjToDef[obj] == node || result.enumInfo.isRegularConstDeclaration(node)
 			)
 			switch obj := obj.(type) {
 			case *gotypes.Builtin:
 				tokenType = KeywordType
 				modifiers = append(modifiers, ModDefaultLibrary)
 			case *gotypes.TypeName:
+				if result.enumInfo.typeFor(obj.Type()) != nil {
+					tokenType = EnumType
+					break
+				}
 				if named := resolvedNamedType(obj.Type()); named != nil {
 					switch named.Underlying().(type) {
 					case *gotypes.Struct:
@@ -220,7 +239,11 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 					tokenType = VariableType
 				}
 			case *gotypes.Const:
-				tokenType = VariableType
+				if len(result.enumMembersForIdent(typeInfo, node)) > 0 {
+					tokenType = EnumMemberType
+				} else {
+					tokenType = VariableType
+				}
 				modifiers = append(modifiers, ModStatic, ModReadonly)
 			case *gotypes.Func:
 				if obj.Signature().Recv() != nil {
@@ -260,6 +283,12 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 		case *ast.CompositeLit:
 			addToken(node.Lbrace, node.Lbrace+1, OperatorType, nil)
 			addToken(node.Rbrace, node.Rbrace+1, OperatorType, nil)
+		case *ast.EnumType:
+			addToken(node.Const, node.Const+token.Pos(len("const")), KeywordType, nil)
+			if node.Lparen.IsValid() {
+				addToken(node.Lparen, node.Lparen+1, OperatorType, nil)
+				addToken(node.Rparen, node.Rparen+1, OperatorType, nil)
+			}
 		case *ast.FuncDecorator:
 			addToken(node.At, node.At+1, OperatorType, nil)
 			addCallExprTokens(&node.CallExpr, false)
@@ -397,10 +426,6 @@ func (s *Server) textDocumentSemanticTokensFull(params *SemanticTokensParams) (*
 		case *ast.ImportSpec:
 			if node.Path != nil {
 				addToken(node.Path.Pos(), node.Path.End(), StringType, nil)
-			}
-		case *ast.ValueSpec:
-			if node.Type != nil {
-				addToken(node.Type.Pos(), node.Type.End(), TypeType, nil)
 			}
 		case *ast.FieldList:
 			if node.Opening.IsValid() {

--- a/internal/server/semantic_token_test.go
+++ b/internal/server/semantic_token_test.go
@@ -197,7 +197,7 @@ done` + "`" + `
 		})
 	})
 
-	t.Run("FuncDecorator", func(t *testing.T) {
+	t.Run("EnumAndFuncDecorator", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`func retry(fn func()) {
 	fn()
@@ -205,6 +205,10 @@ done` + "`" + `
 
 @retry
 func run() {}
+
+type Color const (
+	Red = iota
+)
 `),
 		}
 		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
@@ -222,6 +226,282 @@ func run() {}
 			length:    1,
 			tokenType: OperatorType,
 		})
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      7,
+			character: 11,
+			length:    5,
+			tokenType: KeywordType,
+		})
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      7,
+			character: 5,
+			length:    5,
+			tokenType: EnumType,
+		})
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      8,
+			character: 1,
+			length:    3,
+			tokenType: EnumMemberType,
+		})
+	})
+
+	t.Run("EnumBlankIdentifier", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Color const (
+	_ = iota
+	Red
+)
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		assert.NotContains(t, decoded, decodedSemanticToken{
+			line:      1,
+			character: 1,
+			length:    1,
+			tokenType: EnumMemberType,
+		})
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      2,
+			character: 1,
+			length:    3,
+			tokenType: EnumMemberType,
+		})
+	})
+
+	t.Run("EnumMemberSharedWithRegularConstant", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`const (
+	Shared = 1
+)
+
+type Color const (
+	Shared = 1
+)
+
+func run() {
+	println(Shared)
+	var color Color = (Shared)
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		declarationMask := getSemanticTokenModifiersMask([]SemanticTokenModifiers{
+			ModDeclaration,
+			ModStatic,
+			ModReadonly,
+		})
+		referenceMask := getSemanticTokenModifiersMask([]SemanticTokenModifiers{ModStatic, ModReadonly})
+		for _, want := range []struct {
+			token decodedSemanticToken
+			mask  uint32
+		}{
+			{decodedSemanticToken{line: 1, character: 1, length: 6, tokenType: VariableType}, declarationMask},
+			{decodedSemanticToken{line: 5, character: 1, length: 6, tokenType: EnumMemberType}, declarationMask},
+			{decodedSemanticToken{line: 9, character: 9, length: 6, tokenType: VariableType}, referenceMask},
+			{decodedSemanticToken{line: 10, character: 20, length: 6, tokenType: EnumMemberType}, referenceMask},
+		} {
+			assert.Contains(t, decoded, want.token)
+			assertSemanticTokenModifierMask(t, tokens.Data, want.token, want.mask)
+		}
+	})
+
+	t.Run("CrossFileEnumReference", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`var color Color = Red
+`),
+			"enums.xgo": []byte(`type Color const (
+	Red = iota
+)
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      0,
+			character: 10,
+			length:    5,
+			tokenType: EnumType,
+		})
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      0,
+			character: 18,
+			length:    3,
+			tokenType: EnumMemberType,
+		})
+	})
+
+	t.Run("EnumAlias", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Shade = Color
+
+var color Shade = Red
+`),
+			"enums.xgo": []byte(`type Color const (
+	Red = iota
+)
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		for _, want := range []decodedSemanticToken{
+			{line: 0, character: 5, length: 5, tokenType: EnumType},
+			{line: 0, character: 13, length: 5, tokenType: EnumType},
+			{line: 2, character: 10, length: 5, tokenType: EnumType},
+			{line: 2, character: 18, length: 3, tokenType: EnumMemberType},
+		} {
+			assert.Contains(t, decoded, want)
+		}
+	})
+
+	t.Run("EnumPointerAlias", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type Color const (
+	Red = iota
+)
+
+type ColorPtr = *Color
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      4,
+			character: 5,
+			length:    8,
+			tokenType: TypeType,
+		})
+		assert.NotContains(t, decoded, decodedSemanticToken{
+			line:      4,
+			character: 5,
+			length:    8,
+			tokenType: EnumType,
+		})
+		assert.Contains(t, decoded, decodedSemanticToken{
+			line:      4,
+			character: 17,
+			length:    5,
+			tokenType: EnumType,
+		})
+	})
+
+	t.Run("LocalEnum", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`func run() {
+	type Color const (
+		Red = iota
+	)
+	var color Color = Red
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		for _, want := range []decodedSemanticToken{
+			{line: 1, character: 6, length: 5, tokenType: EnumType},
+			{line: 2, character: 2, length: 3, tokenType: EnumMemberType},
+			{line: 4, character: 11, length: 5, tokenType: EnumType},
+			{line: 4, character: 19, length: 3, tokenType: EnumMemberType},
+		} {
+			assert.Contains(t, decoded, want)
+		}
+		for _, unwanted := range []decodedSemanticToken{
+			{line: 1, character: 6, length: 5, tokenType: TypeType},
+			{line: 2, character: 2, length: 3, tokenType: VariableType},
+			{line: 4, character: 11, length: 5, tokenType: TypeType},
+			{line: 4, character: 19, length: 3, tokenType: VariableType},
+		} {
+			assert.NotContains(t, decoded, unwanted)
+		}
+	})
+
+	t.Run("DuplicateEnumMembers", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`type First const (
+	Unknown = iota
+)
+
+type Second const (
+	Unknown = iota
+)
+
+var (
+	first First = Unknown
+	second Second = Unknown
+)
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+
+		decoded := decodeSemanticTokens(tokens.Data)
+		declarationMask := getSemanticTokenModifiersMask([]SemanticTokenModifiers{
+			ModDeclaration,
+			ModStatic,
+			ModReadonly,
+		})
+		referenceMask := getSemanticTokenModifiersMask([]SemanticTokenModifiers{ModStatic, ModReadonly})
+		for _, want := range []struct {
+			token decodedSemanticToken
+			mask  uint32
+		}{
+			{decodedSemanticToken{line: 1, character: 1, length: 7, tokenType: EnumMemberType}, declarationMask},
+			{decodedSemanticToken{line: 5, character: 1, length: 7, tokenType: EnumMemberType}, declarationMask},
+			{decodedSemanticToken{line: 9, character: 15, length: 7, tokenType: EnumMemberType}, referenceMask},
+			{decodedSemanticToken{line: 10, character: 17, length: 7, tokenType: EnumMemberType}, referenceMask},
+		} {
+			assert.Contains(t, decoded, want.token)
+			assertSemanticTokenModifierMask(t, tokens.Data, want.token, want.mask)
+		}
 	})
 
 	t.Run("ImportedPositionCollision", func(t *testing.T) {

--- a/pkgdoc/doc.go
+++ b/pkgdoc/doc.go
@@ -39,20 +39,23 @@ type PkgDoc struct {
 // typeDoc returns the documentation for the given type name. It creates a new
 // [TypeDoc] if the type name is not found.
 func (p *PkgDoc) typeDoc(typeName string) *TypeDoc {
-	if _, ok := p.Types[typeName]; !ok {
-		p.Types[typeName] = &TypeDoc{
+	typeDoc, ok := p.Types[typeName]
+	if !ok {
+		typeDoc = &TypeDoc{
 			Fields:  make(map[string]string),
 			Methods: make(map[string]string),
 		}
+		p.Types[typeName] = typeDoc
 	}
-	return p.Types[typeName]
+	return typeDoc
 }
 
 // TypeDoc is the documentation for a type.
 type TypeDoc struct {
-	Doc     string
-	Fields  map[string]string
-	Methods map[string]string
+	Doc         string
+	Fields      map[string]string
+	Methods     map[string]string
+	EnumMembers map[string]string `json:",omitempty"`
 }
 
 // NewGo creates a new [PkgDoc] from the given Go [ast.Package].

--- a/pkgdoc/xgodoc.go
+++ b/pkgdoc/xgodoc.go
@@ -90,10 +90,11 @@ func NewXGo(pkgPath string, pkg *ast.Package) *PkgDoc {
 							}
 						}
 					case *ast.TypeSpec:
-						if structType, ok := spec.Type.(*ast.StructType); ok {
+						switch typ := spec.Type.(type) {
+						case *ast.StructType:
 							typeDoc := pkgDoc.typeDoc(spec.Name.Name)
 							typeDoc.Doc = doc
-							for _, field := range structType.Fields.List {
+							for _, field := range typ.Fields.List {
 								fieldDoc := ""
 								if field.Doc != nil {
 									fieldDoc = field.Doc.Text()
@@ -109,6 +110,25 @@ func NewXGo(pkgPath string, pkg *ast.Package) *PkgDoc {
 									for _, name := range field.Names {
 										typeDoc.Fields[name.Name] = fieldDoc
 									}
+								}
+							}
+						case *ast.EnumType:
+							typeDoc := pkgDoc.typeDoc(spec.Name.Name)
+							typeDoc.Doc = doc
+							for _, enumSpec := range typ.Specs {
+								valueSpec := enumSpec.(*ast.ValueSpec)
+								var valueDoc string
+								if valueSpec.Doc != nil {
+									valueDoc = valueSpec.Doc.Text()
+								}
+								for _, name := range valueSpec.Names {
+									if name.Name == "_" {
+										continue
+									}
+									if typeDoc.EnumMembers == nil {
+										typeDoc.EnumMembers = make(map[string]string)
+									}
+									typeDoc.EnumMembers[name.Name] = valueDoc
 								}
 							}
 						}

--- a/pkgdoc/xgodoc_test.go
+++ b/pkgdoc/xgodoc_test.go
@@ -1,0 +1,50 @@
+package pkgdoc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/parser"
+	"github.com/goplus/xgo/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewXGoEnumMemberDocumentation(t *testing.T) {
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, "main.xgo", `type First const (
+	_ = iota
+	// First member documentation.
+	Unknown
+)
+
+type Second const (
+	// Second member documentation.
+	Unknown = iota
+)
+`, parser.ParseComments)
+	require.NoError(t, err)
+
+	pkgDoc := NewXGo("main", &ast.Package{
+		Name:  "main",
+		Files: map[string]*ast.File{"main.xgo": astFile},
+	})
+
+	require.Contains(t, pkgDoc.Types, "First")
+	require.Contains(t, pkgDoc.Types, "Second")
+	assert.Equal(t, "First member documentation.\n", pkgDoc.Types["First"].EnumMembers["Unknown"])
+	assert.Equal(t, "Second member documentation.\n", pkgDoc.Types["Second"].EnumMembers["Unknown"])
+	assert.NotContains(t, pkgDoc.Types["First"].EnumMembers, "_")
+	assert.NotContains(t, pkgDoc.Consts, "Unknown")
+}
+
+func TestTypeDocJSON(t *testing.T) {
+	data, err := json.Marshal(&TypeDoc{})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "EnumMembers")
+
+	data, err = json.Marshal(&TypeDoc{EnumMembers: map[string]string{"Red": "Red documentation."}})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"Doc":"","Fields":null,"Methods":null,"EnumMembers":{"Red":"Red documentation."}}`, string(data))
+}

--- a/xgo/pkgdoc_test.go
+++ b/xgo/pkgdoc_test.go
@@ -136,6 +136,33 @@ func Test() {}
 		assert.Same(t, pkgDoc1, pkgDoc2)
 	})
 
+	t.Run("Enum", func(t *testing.T) {
+		proj := NewProject(nil, map[string]*File{
+			"main.spx": file(`
+// Color describes a display color.
+type Color const (
+	// Red is the first color.
+	Red = iota
+
+	// Green is the second color.
+	Green
+)
+`),
+		}, FeatAll)
+
+		pkgDoc, err := proj.PkgDoc()
+		require.NoError(t, err)
+		require.NotNil(t, pkgDoc)
+
+		colorDoc, ok := pkgDoc.Types["Color"]
+		require.True(t, ok)
+		assert.Equal(t, "Color describes a display color.\n", colorDoc.Doc)
+		assert.Equal(t, "Red is the first color.\n", colorDoc.EnumMembers["Red"])
+		assert.Equal(t, "Green is the second color.\n", colorDoc.EnumMembers["Green"])
+		assert.NotContains(t, pkgDoc.Consts, "Red")
+		assert.NotContains(t, pkgDoc.Consts, "Green")
+	})
+
 	t.Run("CacheError", func(t *testing.T) {
 		// Create a project without the PkgDocCache feature enabled.
 		// This will cause Cache() to return ErrUnknownCacheKind.

--- a/xgo/xgoutil/enclosing.go
+++ b/xgo/xgoutil/enclosing.go
@@ -284,6 +284,14 @@ func childrenOf(n ast.Node) []ast.Node {
 	case *ast.EmptyStmt:
 		// nop
 
+	case *ast.EnumType:
+		children = append(children, tok(n.Const, len("const")))
+		if n.Lparen.IsValid() {
+			children = append(children,
+				tok(n.Lparen, len("(")),
+				tok(n.Rparen, len(")")))
+		}
+
 	case *ast.ExprStmt:
 		// nop
 

--- a/xgo/xgoutil/xgoutil_test.go
+++ b/xgo/xgoutil/xgoutil_test.go
@@ -594,6 +594,24 @@ echo [
 		assert.NotNil(t, EnclosingNode[*ast.CallExpr](path))
 	})
 
+	t.Run("EnumType", func(t *testing.T) {
+		_, astFile, err := newTestFile("main.xgo", `
+type Color const (
+	Red = iota
+)
+`)
+		require.NoError(t, err)
+
+		redIdent := findIdent(astFile, "Red")
+		require.NotNil(t, redIdent)
+
+		path, _ := PathEnclosingInterval(astFile, redIdent.Pos(), redIdent.End())
+		require.NotEmpty(t, path)
+		assert.Equal(t, redIdent, path[0])
+		assert.NotNil(t, EnclosingNode[*ast.ValueSpec](path))
+		assert.NotNil(t, EnclosingNode[*ast.EnumType](path))
+	})
+
 	t.Run("FuncDecorator", func(t *testing.T) {
 		_, astFile, err := newTestFile("main.xgo", `
 @retry("now")


### PR DESCRIPTION
Track source-level enum types and members across completion, hover, and semantic tokens, including context-sensitive resolution for duplicate member names.

Preserve enum member documentation under its owning type and expose enum nodes through shared AST traversal helpers.