### PR TITLE
fix(server): prevent editor stalls in large projects

### DIFF
--- a/internal/analysis/passes/propertyname/propertyname.go
+++ b/internal/analysis/passes/propertyname/propertyname.go
@@ -2,6 +2,7 @@ package propertyname
 
 import (
 	_ "embed"
+	"slices"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
@@ -44,36 +45,53 @@ func run(pass *protocol.Pass) (any, error) {
 			call = &n.CallExpr
 		}
 
-		validNames := pass.GetPropertyNamesForCall(call)
-		if validNames == nil {
-			return
+		isStringValue := func(expr ast.Expr) bool {
+			_, ok := xgoutil.StringLitOrConstValue(expr, pass.TypesInfo.Types[expr])
+			return ok
 		}
-		validNamesSet := make(map[string]struct{}, len(validNames))
-		for _, name := range validNames {
-			validNamesSet[name] = struct{}{}
+		hasStringValueArg := slices.ContainsFunc(call.Args, isStringValue) ||
+			slices.ContainsFunc(call.Kwargs, func(kwarg *ast.KwargExpr) bool {
+				return isStringValue(kwarg.Value)
+			})
+		if !hasStringValueArg {
+			return
 		}
 
 		resolvedCallExprArgs := xgoutil.ResolvedCallExprArgs(pass.TypesInfo, call)
 		if pass.ResolvedCallExprArgs != nil {
 			resolvedCallExprArgs = pass.ResolvedCallExprArgs(call)
 		}
+		type propertyArg struct {
+			expr ast.Expr
+			name string
+		}
+		var propertyArgs []propertyArg
 		for resolvedArg := range resolvedCallExprArgs {
-			if resolvedArg.ExpectedType == nil {
-				continue
-			}
-			if !pass.IsPropertyNameType(resolvedArg.ExpectedType) {
+			if resolvedArg.ExpectedType == nil || !pass.IsPropertyNameType(resolvedArg.ExpectedType) {
 				continue
 			}
 
 			// Only validate string literal / constant arguments.
-			tv := pass.TypesInfo.Types[resolvedArg.Arg]
-			propName, ok := xgoutil.StringLitOrConstValue(resolvedArg.Arg, tv)
+			propName, ok := xgoutil.StringLitOrConstValue(resolvedArg.Arg, pass.TypesInfo.Types[resolvedArg.Arg])
 			if !ok {
 				continue
 			}
+			propertyArgs = append(propertyArgs, propertyArg{
+				expr: resolvedArg.Arg,
+				name: propName,
+			})
+		}
+		if len(propertyArgs) == 0 {
+			return
+		}
 
-			if _, ok := validNamesSet[propName]; !ok {
-				pass.ReportRangef(resolvedArg.Arg, "unknown property %q", propName)
+		validNames := pass.GetPropertyNamesForCall(call)
+		if validNames == nil {
+			return
+		}
+		for _, arg := range propertyArgs {
+			if _, ok := validNames[arg.name]; !ok {
+				pass.ReportRangef(arg.expr, "unknown property %q", arg.name)
 			}
 		}
 	})

--- a/internal/analysis/passes/propertyname/propertyname_test.go
+++ b/internal/analysis/passes/propertyname/propertyname_test.go
@@ -2,6 +2,7 @@ package propertyname
 
 import (
 	gotypes "go/types"
+	"iter"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,11 +16,30 @@ import (
 	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
 	"github.com/goplus/xgolsw/internal/analysis/protocol"
 	"github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
 type propertynameCallbacks struct {
 	isPropertyNameType      func(gotypes.Type) bool
-	getPropertyNamesForCall func(*ast.CallExpr) []string
+	getPropertyNamesForCall func(*ast.CallExpr) map[string]struct{}
+	resolvedCallExprArgs    func(*ast.CallExpr) iter.Seq[xgoutil.ResolvedCallExprArg]
+}
+
+func propertyNameSet(names ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		set[name] = struct{}{}
+	}
+	return set
+}
+
+func isTestPropertyNameType(typ gotypes.Type) bool {
+	named, ok := gotypes.Unalias(typ).(*gotypes.Named)
+	return ok && named.Obj().Name() == "PropertyName"
+}
+
+func testPropertyNames(_ *ast.CallExpr) map[string]struct{} {
+	return propertyNameSet("x", "y")
 }
 
 func TestPropertyname(t *testing.T) {
@@ -43,13 +63,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: true,
 		},
@@ -67,13 +82,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: false,
 		},
@@ -90,13 +100,8 @@ func validate(name PropertyName, fn func()) {}
 func run() {}
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: true,
 		},
@@ -113,13 +118,8 @@ func validate(name PropertyName, fn func()) {}
 func run() {}
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: false,
 		},
@@ -139,13 +139,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: true,
 		},
@@ -165,13 +160,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: false,
 		},
@@ -193,13 +183,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: true,
 		},
@@ -221,13 +206,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      isTestPropertyNameType,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: false,
 		},
@@ -245,10 +225,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: nil,
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{"x", "y"}
-				},
+				isPropertyNameType:      nil,
+				getPropertyNamesForCall: testPropertyNames,
 			},
 			wantDiag: false,
 		},
@@ -266,10 +244,7 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
+				isPropertyNameType:      isTestPropertyNameType,
 				getPropertyNamesForCall: nil,
 			},
 			wantDiag: false,
@@ -288,11 +263,8 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
+				isPropertyNameType: isTestPropertyNameType,
+				getPropertyNamesForCall: func(_ *ast.CallExpr) map[string]struct{} {
 					return nil // target type unknown: skip validation
 				},
 			},
@@ -312,12 +284,9 @@ func run() {
 }
 `,
 			callbacks: propertynameCallbacks{
-				isPropertyNameType: func(typ gotypes.Type) bool {
-					named, ok := gotypes.Unalias(typ).(*gotypes.Named)
-					return ok && named.Obj().Name() == "PropertyName"
-				},
-				getPropertyNamesForCall: func(_ *ast.CallExpr) []string {
-					return []string{} // target type known but has no properties
+				isPropertyNameType: isTestPropertyNameType,
+				getPropertyNamesForCall: func(_ *ast.CallExpr) map[string]struct{} {
+					return propertyNameSet() // target type known but has no properties
 				},
 			},
 			wantDiag: true,
@@ -332,6 +301,40 @@ func run() {
 			}
 		})
 	}
+}
+
+func TestPropertynameSkipsPropertyLookupWithoutValidatableArguments(t *testing.T) {
+	lookups := 0
+	resolutions := 0
+	diagnostics := runPropertynameAnalyzer(t, `
+package test
+
+type PropertyName string
+
+func log(value int) {}
+func showVar(name PropertyName) {}
+
+var property PropertyName
+
+func run() {
+	log(1)
+	showVar(property)
+}
+`, propertynameCallbacks{
+		isPropertyNameType: isTestPropertyNameType,
+		getPropertyNamesForCall: func(_ *ast.CallExpr) map[string]struct{} {
+			lookups++
+			return propertyNameSet("x", "y")
+		},
+		resolvedCallExprArgs: func(_ *ast.CallExpr) iter.Seq[xgoutil.ResolvedCallExprArg] {
+			resolutions++
+			return func(_ func(xgoutil.ResolvedCallExprArg) bool) {}
+		},
+	})
+
+	assert.Empty(t, diagnostics)
+	assert.Zero(t, lookups)
+	assert.Zero(t, resolutions)
 }
 
 func runPropertynameAnalyzer(t *testing.T, src string, callbacks propertynameCallbacks) []protocol.Diagnostic {
@@ -367,6 +370,7 @@ func runPropertynameAnalyzer(t *testing.T, src string, callbacks propertynameCal
 		TypesInfo:               info,
 		IsPropertyNameType:      callbacks.isPropertyNameType,
 		GetPropertyNamesForCall: callbacks.getPropertyNamesForCall,
+		ResolvedCallExprArgs:    callbacks.resolvedCallExprArgs,
 		Report: func(d protocol.Diagnostic) {
 			diagnostics = append(diagnostics, d)
 		},

--- a/internal/analysis/protocol/analysis.go
+++ b/internal/analysis/protocol/analysis.go
@@ -123,7 +123,7 @@ type Pass struct {
 	// responsible for resolving the target type from the explicit selector
 	// receiver (if any) or from the current file's implicit receiver type.
 	// Returns nil when the target cannot be determined.
-	GetPropertyNamesForCall func(call *ast.CallExpr) []string
+	GetPropertyNamesForCall func(call *ast.CallExpr) map[string]struct{}
 
 	// ResolvedCallExprArgs, if non-nil, returns call arguments resolved by the
 	// driver. Analyzers fall back to [xgoutil.ResolvedCallExprArgs] when this is

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -10,11 +10,14 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/internal/pkgdata"
 	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -217,11 +220,19 @@ type propertyMember struct {
 	SpxDef SpxDefinition
 }
 
-// propertyMembers returns an iterator over property fields and property methods
-// in depth-first, outer-scope-first order. Outer members shadow embedded ones
+// propertyObject holds the source object for a property discovered during a
+// type traversal.
+type propertyObject struct {
+	Name             string
+	SelectorTypeName string
+	Object           gotypes.Object
+}
+
+// propertyObjects returns an iterator over property source objects in
+// depth-first, outer-scope-first order. Outer members shadow embedded ones
 // with the same name.
-func propertyMembers(namedType *gotypes.Named, pkgDocFor func(*gotypes.Package) *pkgdoc.PkgDoc) iter.Seq[propertyMember] {
-	return func(yield func(propertyMember) bool) {
+func propertyObjects(namedType *gotypes.Named) iter.Seq[propertyObject] {
+	return func(yield func(propertyObject) bool) {
 		visited := make(map[*gotypes.Named]bool)
 		seenNames := make(map[string]bool)
 		var walk func(namedType *gotypes.Named) bool
@@ -237,65 +248,97 @@ func propertyMembers(namedType *gotypes.Named, pkgDocFor func(*gotypes.Package) 
 			}
 
 			selectorTypeName := namedType.Obj().Name()
-			yieldProperty := func(member propertyMember) bool {
-				if seenNames[member.Name] {
+			yieldProperty := func(property propertyObject) bool {
+				if seenNames[property.Name] {
 					return true
 				}
-				seenNames[member.Name] = true
-				return yield(member)
+				seenNames[property.Name] = true
+				return yield(property)
 			}
 
-			// Single pass over fields: yield direct property fields and collect
-			// embedded types for later recursion, so each field is visited only once.
 			var embeddedTypes []*gotypes.Named
 			for field := range structType.Fields() {
 				if field.Embedded() {
 					embeddedType := gotypes.Unalias(xgoutil.DerefType(field.Type()))
-					if embNamed, ok := embeddedType.(*gotypes.Named); ok {
-						embeddedTypes = append(embeddedTypes, embNamed)
+					if embeddedNamed, ok := embeddedType.(*gotypes.Named); ok {
+						embeddedTypes = append(embeddedTypes, embeddedNamed)
 					}
 					continue
 				}
 				if !isPropertyField(field) {
 					continue
 				}
-				name := field.Name()
-				if !yieldProperty(propertyMember{
-					Name:   name,
-					Type:   field.Type(),
-					Kind:   XGoPropertyKindField,
-					SpxDef: GetSpxDefinitionForVar(field, selectorTypeName, false, pkgDocFor(field.Pkg())),
+				if !yieldProperty(propertyObject{
+					Name:             field.Name(),
+					SelectorTypeName: selectorTypeName,
+					Object:           field,
 				}) {
 					return false
 				}
 			}
 
-			// Collect methods defined directly on this type.
 			for method := range namedType.Methods() {
 				if !isPropertyMethod(method) {
 					continue
 				}
-				name := xgoutil.ToLowerCamelCase(method.Name())
-				sig := method.Signature()
-				if !yieldProperty(propertyMember{
-					Name:   name,
-					Type:   sig.Results().At(0).Type(),
-					Kind:   XGoPropertyKindMethod,
-					SpxDef: GetSpxDefinitionForFunc(method, selectorTypeName, pkgDocFor(method.Pkg())),
+				if !yieldProperty(propertyObject{
+					Name:             xgoutil.ToLowerCamelCase(method.Name()),
+					SelectorTypeName: selectorTypeName,
+					Object:           method,
 				}) {
 					return false
 				}
 			}
 
-			// Recurse into embedded types collected during the field pass.
-			for _, embNamed := range embeddedTypes {
-				if !walk(embNamed) {
+			for _, embeddedType := range embeddedTypes {
+				if !walk(embeddedType) {
 					return false
 				}
 			}
 			return true
 		}
 		walk(namedType)
+	}
+}
+
+// propertyMembers returns an iterator over property fields and property methods
+// in depth-first, outer-scope-first order. Outer members shadow embedded ones
+// with the same name.
+func propertyMembers(namedType *gotypes.Named, pkgDocFor func(*gotypes.Package) *pkgdoc.PkgDoc) iter.Seq[propertyMember] {
+	return func(yield func(propertyMember) bool) {
+		for property := range propertyObjects(namedType) {
+			var member propertyMember
+			switch object := property.Object.(type) {
+			case *gotypes.Var:
+				member = propertyMember{
+					Name: property.Name,
+					Type: object.Type(),
+					Kind: XGoPropertyKindField,
+					SpxDef: GetSpxDefinitionForVar(
+						object,
+						property.SelectorTypeName,
+						false,
+						pkgDocFor(object.Pkg()),
+					),
+				}
+			case *gotypes.Func:
+				member = propertyMember{
+					Name: property.Name,
+					Type: object.Signature().Results().At(0).Type(),
+					Kind: XGoPropertyKindMethod,
+					SpxDef: GetSpxDefinitionForFunc(
+						object,
+						property.SelectorTypeName,
+						pkgDocFor(object.Pkg()),
+					),
+				}
+			default:
+				continue
+			}
+			if !yield(member) {
+				return
+			}
+		}
 	}
 }
 
@@ -517,22 +560,196 @@ func findEnclosingType(obj gotypes.Object) *gotypes.Named {
 	return nil
 }
 
+// inputSlotContext caches file-level data shared by all input slots in one
+// request.
+type inputSlotContext struct {
+	result                   *compileResult
+	astFile                  *ast.File
+	astPkg                   *ast.Package
+	typeInfo                 *types.Info
+	parents                  map[ast.Node]ast.Node
+	scopeObjects             map[*gotypes.Scope][]gotypes.Object
+	scopeObjectPositions     map[*gotypes.Scope][]token.Pos
+	predefinedNames          map[predefinedNamesCacheKey][]string
+	utf16ColumnsByByteOffset []uint32
+}
+
+// predefinedNamesCacheKey identifies expressions with the same visible names.
+type predefinedNamesCacheKey struct {
+	scope              *gotypes.Scope
+	declaredType       gotypes.Type
+	visibleObjectCount int
+}
+
+// newInputSlotContext creates a context for finding input slots in astFile.
+func newInputSlotContext(result *compileResult, astFile *ast.File) *inputSlotContext {
+	typeInfo, _ := result.proj.TypeInfo()
+	astPkg, _ := result.proj.ASTPackage()
+	return &inputSlotContext{
+		result:                   result,
+		astFile:                  astFile,
+		astPkg:                   astPkg,
+		typeInfo:                 typeInfo,
+		parents:                  nodeParents(astFile),
+		scopeObjects:             make(map[*gotypes.Scope][]gotypes.Object),
+		scopeObjectPositions:     make(map[*gotypes.Scope][]token.Pos),
+		predefinedNames:          make(map[predefinedNamesCacheKey][]string),
+		utf16ColumnsByByteOffset: buildUTF16ColumnIndex(astFile.Code),
+	}
+}
+
+// nodeParents returns the parent of each descendant of root.
+func nodeParents(root ast.Node) map[ast.Node]ast.Node {
+	parents := make(map[ast.Node]ast.Node)
+	var stack []ast.Node
+	ast.Inspect(root, func(node ast.Node) bool {
+		if node == nil {
+			stack = stack[:len(stack)-1]
+			return true
+		}
+		if len(stack) > 0 {
+			parents[node] = stack[len(stack)-1]
+		}
+		stack = append(stack, node)
+		return true
+	})
+	return parents
+}
+
+// buildUTF16ColumnIndex returns the UTF-16 column at every byte offset in code.
+func buildUTF16ColumnIndex(code []byte) []uint32 {
+	columns := make([]uint32, len(code)+1)
+	var column uint32
+	for offset := 0; offset < len(code); {
+		columns[offset] = column
+		switch code[offset] {
+		case '\n':
+			offset++
+			column = 0
+			columns[offset] = column
+			continue
+		case '\r':
+			if offset+1 < len(code) && code[offset+1] == '\n' {
+				offset++
+				columns[offset] = column
+				continue
+			}
+		}
+
+		r, size := utf8.DecodeRune(code[offset:])
+		for i := 1; i < size; i++ {
+			columns[offset+i] = column
+		}
+		column += uint32(utf16.RuneLen(r))
+		offset += size
+		columns[offset] = column
+	}
+	return columns
+}
+
+// position converts pos to an LSP position using the precomputed UTF-16
+// column index.
+func (c *inputSlotContext) position(pos token.Pos) Position {
+	filePosition := c.result.proj.Fset.Position(pos)
+	offset := min(max(filePosition.Offset, 0), len(c.astFile.Code))
+	return Position{
+		Line:      uint32(max(filePosition.Line, 1) - 1),
+		Character: c.utf16ColumnsByByteOffset[offset],
+	}
+}
+
+// rangeForNode returns the LSP range for node.
+func (c *inputSlotContext) rangeForNode(node ast.Node) Range {
+	return Range{Start: c.position(node.Pos()), End: c.position(node.End())}
+}
+
+// rangeForPosEnd returns the LSP range for pos and end.
+func (c *inputSlotContext) rangeForPosEnd(pos, end token.Pos) Range {
+	return Range{Start: c.position(pos), End: c.position(end)}
+}
+
+// innermostScope returns the innermost type-checker scope containing node.
+func (c *inputSlotContext) innermostScope(node ast.Node) *gotypes.Scope {
+	for node != nil {
+		if scope := c.typeInfo.Scopes[node]; scope != nil {
+			return scope
+		}
+		switch node := node.(type) {
+		case *ast.FuncDecl:
+			if scope := c.typeInfo.Scopes[node.Type]; scope != nil {
+				return scope
+			}
+		case *ast.FuncLit:
+			if scope := c.typeInfo.Scopes[node.Type]; scope != nil {
+				return scope
+			}
+			if scope := c.typeInfo.Scopes[node.Body]; scope != nil {
+				return scope
+			}
+		}
+		node = c.parents[node]
+	}
+	return nil
+}
+
+// objectsInScope returns the objects in scope in scope-name order.
+func (c *inputSlotContext) objectsInScope(scope *gotypes.Scope) []gotypes.Object {
+	if objects, ok := c.scopeObjects[scope]; ok {
+		return objects
+	}
+	names := scope.Names()
+	objects := make([]gotypes.Object, 0, len(names))
+	for _, name := range names {
+		if obj := scope.Lookup(name); obj != nil {
+			objects = append(objects, obj)
+		}
+	}
+	c.scopeObjects[scope] = objects
+	return objects
+}
+
+// visibleObjectCount returns how many variables and constants in scope are
+// declared before pos.
+func (c *inputSlotContext) visibleObjectCount(scope *gotypes.Scope, pos token.Pos) int {
+	positions, ok := c.scopeObjectPositions[scope]
+	if !ok {
+		for _, obj := range c.objectsInScope(scope) {
+			switch obj.(type) {
+			case *gotypes.Var, *gotypes.Const:
+				positions = append(positions, obj.Pos())
+			}
+		}
+		slices.Sort(positions)
+		c.scopeObjectPositions[scope] = positions
+	}
+	count, _ := slices.BinarySearch(positions, pos)
+	return count
+}
+
 // findInputSlots finds all input slots in the AST file.
 func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
+	ctx := newInputSlotContext(result, astFile)
 
 	var inputSlots []XGoInputSlot
 	addInputSlots := func(slots ...XGoInputSlot) {
 		for _, slot := range slots {
-			if slices.ContainsFunc(inputSlots, func(existing XGoInputSlot) bool {
-				return IsRangesOverlap(existing.Range, slot.Range)
-			}) {
+			index, _ := slices.BinarySearchFunc(inputSlots, slot, func(a, b XGoInputSlot) int {
+				if a.Range.Start.Line != b.Range.Start.Line {
+					return cmp.Compare(a.Range.Start.Line, b.Range.Start.Line)
+				}
+				return cmp.Compare(a.Range.Start.Character, b.Range.Start.Character)
+			})
+			if index > 0 && IsRangesOverlap(inputSlots[index-1].Range, slot.Range) {
 				continue
 			}
-			inputSlots = append(inputSlots, slot)
+			if index < len(inputSlots) && IsRangesOverlap(inputSlots[index].Range, slot.Range) {
+				continue
+			}
+			inputSlots = slices.Insert(inputSlots, index, slot)
 		}
 	}
 	addInputSlot := func(slot *SpxInputSlot) {
@@ -549,20 +766,18 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 		switch node := node.(type) {
 		case *ast.BranchStmt:
 			if callExpr := xgoutil.CreateCallExprFromBranchStmt(typeInfo, node); callExpr != nil {
-				slots := findInputSlotsFromCallExpr(result, callExpr)
-				addInputSlots(slots...)
+				addInputSlots(findInputSlotsFromCallExpr(ctx, callExpr)...)
 			}
 		case *ast.CallExpr, *ast.FuncDecorator:
-			slots := findInputSlotsFromCallExpr(result, callExprFromNode(node))
-			addInputSlots(slots...)
+			addInputSlots(findInputSlotsFromCallExpr(ctx, callExprFromNode(node))...)
 		case *ast.BinaryExpr:
-			addInputSlot(checkValueInputSlot(result, node.X, nil))
-			addInputSlot(checkValueInputSlot(result, node.Y, nil))
+			addInputSlot(checkValueInputSlot(ctx, node.X, nil))
+			addInputSlot(checkValueInputSlot(ctx, node.Y, nil))
 		case *ast.UnaryExpr:
-			addInputSlot(checkValueInputSlot(result, node.X, nil))
+			addInputSlot(checkValueInputSlot(ctx, node.X, nil))
 		case *ast.AssignStmt:
 			for _, lhs := range node.Lhs {
-				addInputSlot(checkAddressInputSlot(result, lhs))
+				addInputSlot(checkAddressInputSlot(ctx, lhs))
 			}
 
 			for i, rhs := range node.Rhs {
@@ -571,23 +786,19 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 					declaredType = typeInfo.TypeOf(node.Lhs[i])
 				}
 
-				addInputSlot(checkValueInputSlot(result, rhs, declaredType))
+				addInputSlot(checkValueInputSlot(ctx, rhs, declaredType))
 			}
 		case *ast.ForStmt:
-			if node.Init != nil {
-				if expr, ok := node.Init.(*ast.ExprStmt); ok {
-					addInputSlot(checkValueInputSlot(result, expr.X, nil))
-				}
+			if expr, ok := node.Init.(*ast.ExprStmt); ok {
+				addInputSlot(checkValueInputSlot(ctx, expr.X, nil))
 			}
 
 			if node.Cond != nil {
-				addInputSlot(checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool]))
+				addInputSlot(checkValueInputSlot(ctx, node.Cond, gotypes.Typ[gotypes.Bool]))
 			}
 
-			if node.Post != nil {
-				if expr, ok := node.Post.(*ast.ExprStmt); ok {
-					addInputSlot(checkValueInputSlot(result, expr.X, nil))
-				}
+			if expr, ok := node.Post.(*ast.ExprStmt); ok {
+				addInputSlot(checkValueInputSlot(ctx, expr.X, nil))
 			}
 		case *ast.ValueSpec:
 			for i, value := range node.Values {
@@ -602,57 +813,55 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 					}
 				}
 
-				addInputSlot(checkValueInputSlot(result, value, declaredType))
+				addInputSlot(checkValueInputSlot(ctx, value, declaredType))
 			}
 		case *ast.ReturnStmt:
 			for _, res := range node.Results {
-				addInputSlot(checkValueInputSlot(result, res, nil))
+				addInputSlot(checkValueInputSlot(ctx, res, nil))
 			}
 		case *ast.IfStmt:
-			addInputSlot(checkValueInputSlot(result, node.Cond, gotypes.Typ[gotypes.Bool]))
+			addInputSlot(checkValueInputSlot(ctx, node.Cond, gotypes.Typ[gotypes.Bool]))
 		case *ast.SwitchStmt:
 			if node.Tag != nil {
-				addInputSlot(checkValueInputSlot(result, node.Tag, nil))
+				addInputSlot(checkValueInputSlot(ctx, node.Tag, nil))
 			}
 		case *ast.CaseClause:
 			for _, expr := range node.List {
-				addInputSlot(checkValueInputSlot(result, expr, nil))
+				addInputSlot(checkValueInputSlot(ctx, expr, nil))
 			}
 		case *ast.RangeStmt:
 			if node.Key != nil && !isBlank(node.Key) {
-				addInputSlot(checkAddressInputSlot(result, node.Key))
+				addInputSlot(checkAddressInputSlot(ctx, node.Key))
 			}
 
 			if node.Value != nil && !isBlank(node.Value) {
-				addInputSlot(checkAddressInputSlot(result, node.Value))
+				addInputSlot(checkAddressInputSlot(ctx, node.Value))
 			}
 
-			addInputSlot(checkValueInputSlot(result, node.X, nil))
+			addInputSlot(checkValueInputSlot(ctx, node.X, nil))
 		case *ast.IncDecStmt:
-			addInputSlot(checkAddressInputSlot(result, node.X))
+			addInputSlot(checkAddressInputSlot(ctx, node.X))
 		}
 		return true
 	})
-	sortSpxInputSlots(inputSlots)
 	return inputSlots
 }
 
 // findInputSlotsFromCallExpr finds input slots from a call expression.
-func findInputSlotsFromCallExpr(result *compileResult, callExpr *ast.CallExpr) []SpxInputSlot {
-	typeInfo, _ := result.proj.TypeInfo()
-	if typeInfo == nil {
+func findInputSlotsFromCallExpr(ctx *inputSlotContext, callExpr *ast.CallExpr) []SpxInputSlot {
+	if ctx.typeInfo == nil {
 		return nil
 	}
 
 	var inputSlots []SpxInputSlot
-	for resolvedArg := range resolvedCallExprArgs(result.proj, typeInfo, callExpr) {
+	for resolvedArg := range resolvedCallExprArgs(ctx.result.proj, ctx.typeInfo, callExpr) {
 		if resolvedArg.ExpectedType == nil || resolvedArg.IsTypeArg() {
 			continue
 		}
 
 		expectedType := resolvedArg.ExpectedType
 		if _, ok := expectedType.(*gotypes.TypeParam); ok {
-			if actualType := typeInfo.TypeOf(resolvedArg.Arg); xgoutil.IsValidType(actualType) {
+			if actualType := ctx.typeInfo.TypeOf(resolvedArg.Arg); xgoutil.IsValidType(actualType) {
 				expectedType = actualType
 			}
 		}
@@ -668,9 +877,9 @@ func findInputSlotsFromCallExpr(result *compileResult, callExpr *ast.CallExpr) [
 				continue
 			}
 			declaredType = xgoutil.DerefType(unitExpectedType)
-			slot = createValueInputSlotFromNumberUnitLit(result, lit, declaredType)
+			slot = createValueInputSlotFromNumberUnitLit(ctx, lit, declaredType)
 		} else {
-			slot = checkValueInputSlot(result, resolvedArg.Arg, declaredType)
+			slot = checkValueInputSlot(ctx, resolvedArg.Arg, declaredType)
 		}
 		if slot != nil {
 			inputSlots = append(inputSlots, *slot)
@@ -680,18 +889,19 @@ func findInputSlotsFromCallExpr(result *compileResult, callExpr *ast.CallExpr) [
 }
 
 // collectPredefinedNames collects all predefined names for the given expression.
-func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType gotypes.Type) []string {
-	typeInfo, _ := result.proj.TypeInfo()
-	astPkg, _ := result.proj.ASTPackage()
-	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, expr)
-	innermostScope := xgoutil.InnermostScopeAt(result.proj.Fset, typeInfo, astPkg, expr.Pos())
+func collectPredefinedNames(ctx *inputSlotContext, expr ast.Expr, declaredType gotypes.Type) []string {
+	innermostScope := ctx.innermostScope(expr)
+	key := predefinedNamesCacheKey{scope: innermostScope, declaredType: declaredType}
+	if innermostScope != nil {
+		key.visibleObjectCount = ctx.visibleObjectCount(innermostScope, expr.Pos())
+	}
+	if names, ok := ctx.predefinedNames[key]; ok {
+		return names
+	}
 
 	var names []string
-	growNames := func(n int) {
-		names = slices.Grow(names, n)
-	}
 	seenNames := make(map[string]struct{})
-	addNameOf := func(obj gotypes.Object) {
+	addObjectName := func(obj gotypes.Object) {
 		name := obj.Name()
 		switch obj := obj.(type) {
 		case *gotypes.Var, *gotypes.Const:
@@ -699,9 +909,7 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 				return
 			}
 
-			switch {
-			case name == "this",
-				xgoutil.IsXGoInternalName(name):
+			if name == "this" || xgoutil.IsXGoInternalName(name) {
 				return
 			}
 		case *gotypes.Func:
@@ -730,41 +938,42 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 	}
 
 	for scope := innermostScope; scope != nil && scope != gotypes.Universe; scope = scope.Parent() {
-		growNames(len(scope.Names()))
-		for _, name := range scope.Names() {
-			obj := scope.Lookup(name)
-			if obj == nil {
-				continue
-			}
-			defIdent := typeInfo.ObjToDef[obj]
-
+		objects := ctx.objectsInScope(scope)
+		names = slices.Grow(names, len(objects))
+		for _, obj := range objects {
 			if scope != innermostScope || obj.Pos() < expr.Pos() {
 				switch obj.(type) {
 				case *gotypes.Var, *gotypes.Const:
-					addNameOf(obj)
+					addObjectName(obj)
 				}
 			}
 
-			if astFile.IsClass && xgoutil.IsSyntheticThisIdent(result.proj.Fset, typeInfo, astPkg, defIdent) {
-				objType := xgoutil.DerefType(obj.Type())
-				named, ok := objType.(*gotypes.Named)
-				if !ok || !xgoutil.IsNamedStructType(named) {
-					continue
-				}
+			if !ctx.astFile.IsClass || !xgoutil.IsSyntheticThisIdent(
+				ctx.result.proj.Fset,
+				ctx.typeInfo,
+				ctx.astPkg,
+				ctx.typeInfo.ObjToDef[obj],
+			) {
+				continue
+			}
+			objType := xgoutil.DerefType(obj.Type())
+			named, ok := objType.(*gotypes.Named)
+			if !ok || !xgoutil.IsNamedStructType(named) {
+				continue
+			}
 
-				for structMember := range xgoutil.StructMembers(named) {
-					switch member := structMember.Member.(type) {
-					case *gotypes.Var:
-						if !member.Origin().Embedded() {
-							addNameOf(member)
-						}
-					case *gotypes.Func:
-						// Add methods with no parameters and exactly one return value.
-						// For example, the method `Game.BackdropName` can be used in `echo backdropname`.
-						funcSig := member.Signature()
-						if funcSig.Params().Len() == 0 && funcSig.Results().Len() == 1 {
-							addNameOf(member)
-						}
+			for structMember := range xgoutil.StructMembers(named) {
+				switch member := structMember.Member.(type) {
+				case *gotypes.Var:
+					if !member.Origin().Embedded() {
+						addObjectName(member)
+					}
+				case *gotypes.Func:
+					// Add methods with no parameters and exactly one return value.
+					// For example, the method `Game.BackdropName` can be used in `echo backdropname`.
+					funcSig := member.Signature()
+					if funcSig.Params().Len() == 0 && funcSig.Results().Len() == 1 {
+						addObjectName(member)
 					}
 				}
 			}
@@ -776,56 +985,55 @@ func collectPredefinedNames(result *compileResult, expr ast.Expr, declaredType g
 		GetMathPkg().Scope(),
 		gotypes.Universe,
 	} {
-		growNames(len(scope.Names()))
-		for _, name := range scope.Names() {
-			obj := scope.Lookup(name)
-			if obj == nil {
-				continue
-			}
+		objects := ctx.objectsInScope(scope)
+		names = slices.Grow(names, len(objects))
+		for _, obj := range objects {
 			if _, ok := obj.(*gotypes.Var); ok {
-				addNameOf(obj)
+				addObjectName(obj)
 			}
 		}
 	}
 
+	ctx.predefinedNames[key] = names
 	return names
 }
 
 // checkValueInputSlot checks if the expression is a value input slot.
-func checkValueInputSlot(result *compileResult, expr ast.Expr, declaredType gotypes.Type) *SpxInputSlot {
+func checkValueInputSlot(ctx *inputSlotContext, expr ast.Expr, declaredType gotypes.Type) *SpxInputSlot {
 	switch expr := expr.(type) {
 	case *ast.BasicLit:
-		return createValueInputSlotFromBasicLit(result, expr, declaredType)
+		return createValueInputSlotFromBasicLit(ctx, expr, declaredType)
 	case *ast.Ident:
-		return createValueInputSlotFromIdent(result, expr, declaredType)
+		return createValueInputSlotFromIdent(ctx, expr, declaredType)
 	case *ast.UnaryExpr:
-		return createValueInputSlotFromUnaryExpr(result, expr, declaredType)
+		return createValueInputSlotFromUnaryExpr(ctx, expr, declaredType)
 	case *ast.CallExpr:
-		return createValueInputSlotFromColorFuncCall(result, expr, declaredType)
+		return createValueInputSlotFromColorFuncCall(ctx, expr, declaredType)
 	}
 	return nil
 }
 
 // checkAddressInputSlot checks if the expression is an address input slot.
-func checkAddressInputSlot(result *compileResult, expr ast.Expr) *SpxInputSlot {
-	if ident, ok := expr.(*ast.Ident); ok {
-		return &SpxInputSlot{
-			Kind:   SpxInputSlotKindAddress,
-			Accept: SpxInputSlotAccept{Type: SpxInputTypeUnknown},
-			Input: SpxInput{
-				Kind: SpxInputKindPredefined,
-				Type: SpxInputTypeUnknown,
-				Name: ident.Name,
-			},
-			PredefinedNames: collectPredefinedNames(result, expr, nil),
-			Range:           RangeForNode(result.proj, ident),
-		}
+func checkAddressInputSlot(ctx *inputSlotContext, expr ast.Expr) *SpxInputSlot {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return nil
 	}
-	return nil
+	return &SpxInputSlot{
+		Kind:   SpxInputSlotKindAddress,
+		Accept: SpxInputSlotAccept{Type: SpxInputTypeUnknown},
+		Input: SpxInput{
+			Kind: SpxInputKindPredefined,
+			Type: SpxInputTypeUnknown,
+			Name: ident.Name,
+		},
+		PredefinedNames: collectPredefinedNames(ctx, expr, nil),
+		Range:           ctx.rangeForNode(ident),
+	}
 }
 
 // createValueInputSlotFromBasicLit creates a value input slot from a basic literal.
-func createValueInputSlotFromBasicLit(result *compileResult, lit *ast.BasicLit, declaredType gotypes.Type) *SpxInputSlot {
+func createValueInputSlotFromBasicLit(ctx *inputSlotContext, lit *ast.BasicLit, declaredType gotypes.Type) *SpxInputSlot {
 	input := SpxInput{Kind: SpxInputKindInPlace}
 	switch lit.Kind {
 	case token.STRING:
@@ -858,7 +1066,7 @@ func createValueInputSlotFromBasicLit(result *compileResult, lit *ast.BasicLit, 
 		accept.Type = inferSpxInputTypeFromType(declaredType)
 	}
 	if accept.Type == SpxInputTypeResourceName {
-		for _, spxResourceRef := range result.spxResourceRefs {
+		for _, spxResourceRef := range ctx.result.spxResourceRefs {
 			if spxResourceRef.Node == lit {
 				input.Type = SpxInputTypeResourceName
 				input.Value = spxResourceRef.ID.URI()
@@ -875,14 +1083,14 @@ func createValueInputSlotFromBasicLit(result *compileResult, lit *ast.BasicLit, 
 		Kind:            SpxInputSlotKindValue,
 		Accept:          accept,
 		Input:           input,
-		PredefinedNames: collectPredefinedNames(result, lit, declaredType),
-		Range:           RangeForNode(result.proj, lit),
+		PredefinedNames: collectPredefinedNames(ctx, lit, declaredType),
+		Range:           ctx.rangeForNode(lit),
 	}
 }
 
 // createValueInputSlotFromNumberUnitLit creates a value input slot from a
 // number-with-unit literal.
-func createValueInputSlotFromNumberUnitLit(result *compileResult, lit *ast.NumberUnitLit, declaredType gotypes.Type) *SpxInputSlot {
+func createValueInputSlotFromNumberUnitLit(ctx *inputSlotContext, lit *ast.NumberUnitLit, declaredType gotypes.Type) *SpxInputSlot {
 	input := SpxInput{Kind: SpxInputKindInPlace}
 	switch lit.Kind {
 	case token.INT:
@@ -914,18 +1122,17 @@ func createValueInputSlotFromNumberUnitLit(result *compileResult, lit *ast.Numbe
 		Kind:            SpxInputSlotKindValue,
 		Accept:          accept,
 		Input:           input,
-		PredefinedNames: collectPredefinedNames(result, lit, declaredType),
-		Range:           RangeForPosEnd(result.proj, lit.ValuePos, xgoUnitStart(lit)),
+		PredefinedNames: collectPredefinedNames(ctx, lit, declaredType),
+		Range:           ctx.rangeForPosEnd(lit.ValuePos, xgoUnitStart(lit)),
 	}
 }
 
 // createValueInputSlotFromIdent creates a value input slot from an identifier.
-func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, declaredType gotypes.Type) *SpxInputSlot {
-	typeInfo, _ := result.proj.TypeInfo()
-	if typeInfo == nil {
+func createValueInputSlotFromIdent(ctx *inputSlotContext, ident *ast.Ident, declaredType gotypes.Type) *SpxInputSlot {
+	if ctx.typeInfo == nil {
 		return nil
 	}
-	typ := typeInfo.TypeOf(ident)
+	typ := ctx.typeInfo.TypeOf(ident)
 	if typ == nil {
 		return nil
 	}
@@ -933,7 +1140,7 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 
 	input := SpxInput{
 		Kind: SpxInputKindPredefined,
-		Type: inferSpxInputTypeFromTypeInProject(result, typ),
+		Type: inferSpxInputTypeFromTypeInProject(ctx.result, typ),
 		Name: ident.Name,
 	}
 	switch input.Type {
@@ -950,7 +1157,7 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 		SpxInputTypeKey,
 		SpxInputTypeSpecialObj,
 		SpxInputTypeRotationStyle:
-		obj := typeInfo.ObjectOf(ident)
+		obj := ctx.typeInfo.ObjectOf(ident)
 		if obj != nil && !IsInSpxPkg(obj) {
 			break
 		}
@@ -970,7 +1177,7 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 
 	accept := SpxInputSlotAccept{Type: input.Type}
 	if declaredType != nil {
-		accept.Type = inferSpxInputTypeFromTypeInProject(result, declaredType)
+		accept.Type = inferSpxInputTypeFromTypeInProject(ctx.result, declaredType)
 	}
 	switch accept.Type {
 	case SpxInputTypeResourceName:
@@ -982,13 +1189,13 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 		case GetSpxSpriteNameType():
 			accept.ResourceContext = ToPtr(SpxSpriteResourceContextURI)
 		case GetSpxSpriteCostumeNameType():
-			spxSpriteResource := inferSpxSpriteResourceEnclosingNode(result, ident)
+			spxSpriteResource := inferSpxSpriteResourceEnclosingNode(ctx.result, ident)
 			if spxSpriteResource == nil {
 				return nil
 			}
 			accept.ResourceContext = ToPtr(FormatSpxSpriteCostumeResourceContextURI(spxSpriteResource.Name))
 		case GetSpxSpriteAnimationNameType():
-			spxSpriteResource := inferSpxSpriteResourceEnclosingNode(result, ident)
+			spxSpriteResource := inferSpxSpriteResourceEnclosingNode(ctx.result, ident)
 			if spxSpriteResource == nil {
 				return nil
 			}
@@ -1000,7 +1207,7 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 		}
 	case SpxInputTypeSpriteInstance:
 		accept.ResourceContext = ToPtr(SpxSpriteResourceContextURI)
-		if spxSpriteResource := spxSpriteResourceForObject(result, typeInfo.ObjectOf(ident)); spxSpriteResource != nil {
+		if spxSpriteResource := spxSpriteResourceForObject(ctx.result, ctx.typeInfo.ObjectOf(ident)); spxSpriteResource != nil {
 			input.Kind = SpxInputKindInPlace
 			input.Value = spxSpriteResource.ID.URI()
 			input.Name = ""
@@ -1011,8 +1218,8 @@ func createValueInputSlotFromIdent(result *compileResult, ident *ast.Ident, decl
 		Kind:            SpxInputSlotKindValue,
 		Accept:          accept,
 		Input:           input,
-		PredefinedNames: collectPredefinedNames(result, ident, declaredType),
-		Range:           RangeForNode(result.proj, ident),
+		PredefinedNames: collectPredefinedNames(ctx, ident, declaredType),
+		Range:           ctx.rangeForNode(ident),
 	}
 }
 
@@ -1052,11 +1259,11 @@ func spxSpriteResourceForObject(result *compileResult, obj gotypes.Object) *SpxS
 }
 
 // createValueInputSlotFromUnaryExpr creates a value input slot from a unary expression.
-func createValueInputSlotFromUnaryExpr(result *compileResult, expr *ast.UnaryExpr, declaredType gotypes.Type) *SpxInputSlot {
+func createValueInputSlotFromUnaryExpr(ctx *inputSlotContext, expr *ast.UnaryExpr, declaredType gotypes.Type) *SpxInputSlot {
 	var inputSlot *SpxInputSlot
 	switch x := expr.X.(type) {
 	case *ast.BasicLit:
-		inputSlot = createValueInputSlotFromBasicLit(result, x, declaredType)
+		inputSlot = createValueInputSlotFromBasicLit(ctx, x, declaredType)
 		if inputSlot == nil {
 			return nil
 		}
@@ -1087,7 +1294,7 @@ func createValueInputSlotFromUnaryExpr(result *compileResult, expr *ast.UnaryExp
 			}
 		}
 	case *ast.Ident:
-		inputSlot = createValueInputSlotFromIdent(result, x, declaredType)
+		inputSlot = createValueInputSlotFromIdent(ctx, x, declaredType)
 		if inputSlot == nil {
 			return nil
 		}
@@ -1104,19 +1311,18 @@ func createValueInputSlotFromUnaryExpr(result *compileResult, expr *ast.UnaryExp
 	default:
 		return nil
 	}
-	inputSlot.Range = RangeForNode(result.proj, expr) // Update the range to include the entire unary expression.
+	inputSlot.Range = ctx.rangeForNode(expr) // Update the range to include the entire unary expression.
 	return inputSlot
 }
 
 // createValueInputSlotFromColorFuncCall creates a value input slot from an spx
 // color function call.
-func createValueInputSlotFromColorFuncCall(result *compileResult, callExpr *ast.CallExpr, declaredType gotypes.Type) *SpxInputSlot {
-	typeInfo, _ := result.proj.TypeInfo()
-	if typeInfo == nil {
+func createValueInputSlotFromColorFuncCall(ctx *inputSlotContext, callExpr *ast.CallExpr, declaredType gotypes.Type) *SpxInputSlot {
+	if ctx.typeInfo == nil {
 		return nil
 	}
 
-	fun := xgoutil.FuncFromCallExpr(typeInfo, callExpr)
+	fun := xgoutil.FuncFromCallExpr(ctx.typeInfo, callExpr)
 	if fun == nil || !IsInSpxPkg(fun) || !isSpxColorFunc(fun) {
 		return nil
 	}
@@ -1175,8 +1381,8 @@ func createValueInputSlotFromColorFuncCall(result *compileResult, callExpr *ast.
 				Args:        args,
 			},
 		},
-		PredefinedNames: collectPredefinedNames(result, callExpr, declaredType),
-		Range:           RangeForNode(result.proj, callExpr),
+		PredefinedNames: collectPredefinedNames(ctx, callExpr, declaredType),
+		Range:           ctx.rangeForNode(callExpr),
 	}
 }
 
@@ -1295,20 +1501,4 @@ func inferSpxSpriteResourceEnclosingNode(result *compileResult, node ast.Node) *
 func isBlank(expr ast.Expr) bool {
 	ident, ok := expr.(*ast.Ident)
 	return ok && ident.Name == "_"
-}
-
-// sortSpxInputSlots sorts the given spx input slots in a stable manner.
-func sortSpxInputSlots(slots []SpxInputSlot) {
-	slices.SortFunc(slots, func(a, b SpxInputSlot) int {
-		// First sort by line number.
-		if a.Range.Start.Line != b.Range.Start.Line {
-			return cmp.Compare(a.Range.Start.Line, b.Range.Start.Line)
-		}
-		// If same line, sort by character position.
-		if a.Range.Start.Character != b.Range.Start.Character {
-			return cmp.Compare(a.Range.Start.Character, b.Range.Start.Character)
-		}
-		// If same position (unlikely), sort by input kind for stability.
-		return cmp.Compare(a.Kind, b.Kind)
-	})
 }

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	gotypes "go/types"
 	"reflect"
-	"slices"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
@@ -989,6 +988,47 @@ onStart => {
 	})
 }
 
+func TestFindInputSlotsWithLargeList(t *testing.T) {
+	const slotCount = 2_001
+	files := largeListProjectFiles(slotCount)
+	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+
+	result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
+	require.NoError(t, err)
+	require.NotNil(t, astFile)
+
+	slots := findInputSlots(result, astFile)
+	require.Len(t, slots, slotCount)
+	for i, slot := range slots {
+		assert.Equal(t, SpxInputSlotKindValue, slot.Kind)
+		assert.Equal(t, SpxInputTypeUnknown, slot.Accept.Type)
+		assert.Equal(t, SpxInputTypeString, slot.Input.Type)
+		assert.Equal(t, "value", slot.Input.Value)
+		if i > 0 {
+			assert.Less(t, slots[i-1].Range.Start.Character, slot.Range.Start.Character)
+			assert.False(t, IsRangesOverlap(slots[i-1].Range, slot.Range))
+		}
+	}
+}
+
+func TestFindInputSlotsUTF16Ranges(t *testing.T) {
+	mainSpx := []byte("println \"\U0001F600\", \"value\"\r\n")
+	files := map[string][]byte{
+		"main.spx":          mainSpx,
+		"assets/index.json": []byte(`{}`),
+	}
+	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+
+	result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
+	require.NoError(t, err)
+	require.NotNil(t, astFile)
+
+	slots := findInputSlots(result, astFile)
+	require.Len(t, slots, 2)
+	assert.Equal(t, Range{Start: Position{Line: 0, Character: 8}, End: Position{Line: 0, Character: 12}}, slots[0].Range)
+	assert.Equal(t, Range{Start: Position{Line: 0, Character: 14}, End: Position{Line: 0, Character: 21}}, slots[1].Range)
+}
+
 func TestCheckValueInputSlot(t *testing.T) {
 	m := map[string][]byte{
 		"main.spx": []byte(`
@@ -1017,6 +1057,7 @@ onStart => {
 	require.NoError(t, err)
 	require.False(t, result.hasErrorSeverityDiagnostic)
 	require.NotNil(t, astFile)
+	ctx := newInputSlotContext(result, astFile)
 
 	for _, tt := range []struct {
 		name           string
@@ -1113,7 +1154,7 @@ onStart => {
 			}
 			require.NotNil(t, expr)
 
-			got := checkValueInputSlot(result, expr, nil)
+			got := checkValueInputSlot(ctx, expr, nil)
 			if tt.wantNil {
 				assert.Nil(t, got)
 			} else {
@@ -1151,6 +1192,7 @@ onStart => {
 	require.NoError(t, err)
 	require.False(t, result.hasErrorSeverityDiagnostic)
 	require.NotNil(t, astFile)
+	ctx := newInputSlotContext(result, astFile)
 
 	for _, tt := range []struct {
 		name         string
@@ -1191,7 +1233,7 @@ onStart => {
 			}
 			require.NotNil(t, expr)
 
-			got := checkAddressInputSlot(result, expr)
+			got := checkAddressInputSlot(ctx, expr)
 			if tt.wantNil {
 				assert.Nil(t, got)
 			} else {
@@ -1236,6 +1278,7 @@ onStart => {
 	require.NoError(t, err)
 	require.False(t, result.hasErrorSeverityDiagnostic)
 	require.NotNil(t, astFile)
+	ctx := newInputSlotContext(result, astFile)
 
 	for _, tt := range []struct {
 		name           string
@@ -1309,7 +1352,7 @@ onStart => {
 			}
 			require.NotNil(t, lit)
 
-			got := createValueInputSlotFromBasicLit(result, lit, tt.declaredType)
+			got := createValueInputSlotFromBasicLit(ctx, lit, tt.declaredType)
 			require.NotNil(t, got)
 			assert.Equal(t, SpxInputSlotKindValue, got.Kind)
 			assert.Equal(t, tt.wantAcceptType, got.Accept.Type)
@@ -1325,7 +1368,7 @@ onStart => {
 			Kind:  token.INT,
 			Value: "not.a.int",
 		}
-		got := createValueInputSlotFromBasicLit(result, invalidIntLit, nil)
+		got := createValueInputSlotFromBasicLit(ctx, invalidIntLit, nil)
 		assert.Nil(t, got)
 	})
 
@@ -1334,7 +1377,7 @@ onStart => {
 			Kind:  token.FLOAT,
 			Value: "not.a.float",
 		}
-		got := createValueInputSlotFromBasicLit(result, invalidFloatLit, nil)
+		got := createValueInputSlotFromBasicLit(ctx, invalidFloatLit, nil)
 		assert.Nil(t, got)
 	})
 
@@ -1343,7 +1386,7 @@ onStart => {
 			Kind:  token.CHAR,
 			Value: "'c'",
 		}
-		got := createValueInputSlotFromBasicLit(result, unsupportedLit, nil)
+		got := createValueInputSlotFromBasicLit(ctx, unsupportedLit, nil)
 		assert.Nil(t, got)
 	})
 
@@ -1352,7 +1395,7 @@ onStart => {
 			Kind:  token.STRING,
 			Value: "\"unclosed string literal", // Missing ending quote.
 		}
-		got := createValueInputSlotFromBasicLit(result, invalidStringLit, nil)
+		got := createValueInputSlotFromBasicLit(ctx, invalidStringLit, nil)
 		assert.Nil(t, got)
 	})
 }
@@ -1399,6 +1442,7 @@ onStart => {
 	require.NoError(t, err)
 	require.False(t, result.hasErrorSeverityDiagnostic)
 	require.NotNil(t, astFile)
+	ctx := newInputSlotContext(result, astFile)
 
 	for _, tt := range []struct {
 		name           string
@@ -1472,7 +1516,7 @@ onStart => {
 			}
 			require.NotNil(t, ident)
 
-			got := createValueInputSlotFromIdent(result, ident, nil)
+			got := createValueInputSlotFromIdent(ctx, ident, nil)
 			require.NotNil(t, got)
 			assert.Equal(t, SpxInputSlotKindValue, got.Kind)
 			assert.Equal(t, tt.wantInputType, got.Accept.Type)
@@ -1502,6 +1546,7 @@ onStart => {
 		require.NoError(t, err)
 		require.False(t, result.hasErrorSeverityDiagnostic)
 		require.NotNil(t, astFile)
+		ctx := newInputSlotContext(result, astFile)
 
 		pos := PosAt(result.proj, astFile, Position{Line: 4, Character: 7})
 		require.True(t, pos.IsValid())
@@ -1518,7 +1563,7 @@ onStart => {
 		pkg := gotypes.NewPackage("example.com/pkg", "pkg")
 		declaredType := gotypes.NewAlias(gotypes.NewTypeName(0, pkg, "MySoundName", nil), GetSpxSoundNameType())
 
-		got := createValueInputSlotFromIdent(result, ident, declaredType)
+		got := createValueInputSlotFromIdent(ctx, ident, declaredType)
 		require.NotNil(t, got)
 		assert.Equal(t, SpxInputTypeResourceName, got.Accept.Type)
 		assert.Equal(t, ToPtr(SpxSoundResourceContextURI), got.Accept.ResourceContext)
@@ -1556,6 +1601,7 @@ onStart => {
 	require.NoError(t, err)
 	require.False(t, result.hasErrorSeverityDiagnostic)
 	require.NotNil(t, astFile)
+	ctx := newInputSlotContext(result, astFile)
 
 	for _, tt := range []struct {
 		name           string
@@ -1625,7 +1671,7 @@ onStart => {
 			}
 			require.NotNil(t, unaryExpr)
 
-			got := createValueInputSlotFromUnaryExpr(result, unaryExpr, nil)
+			got := createValueInputSlotFromUnaryExpr(ctx, unaryExpr, nil)
 			require.NotNil(t, got)
 			assert.Equal(t, tt.wantKind, got.Kind)
 			assert.Equal(t, tt.wantAcceptType, got.Accept.Type)
@@ -1657,6 +1703,7 @@ onStart => {
 	require.NoError(t, err)
 	require.False(t, result.hasErrorSeverityDiagnostic)
 	require.NotNil(t, astFile)
+	ctx := newInputSlotContext(result, astFile)
 
 	for _, tt := range []struct {
 		name             string
@@ -1699,7 +1746,7 @@ onStart => {
 			}
 			require.NotNil(t, callExpr)
 
-			got := createValueInputSlotFromColorFuncCall(result, callExpr, nil)
+			got := createValueInputSlotFromColorFuncCall(ctx, callExpr, nil)
 			if tt.wantNil {
 				assert.Nil(t, got)
 			} else {
@@ -1729,7 +1776,7 @@ onStart => {
 				&ast.BasicLit{Kind: token.INT, Value: "2"},
 			},
 		}
-		got := createValueInputSlotFromColorFuncCall(result, callExpr, nil)
+		got := createValueInputSlotFromColorFuncCall(ctx, callExpr, nil)
 		assert.Nil(t, got)
 	})
 
@@ -1738,7 +1785,7 @@ onStart => {
 			Fun:  &ast.Ident{Name: "unknownFunction"},
 			Args: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: "1"}},
 		}
-		got := createValueInputSlotFromColorFuncCall(result, callExpr, nil)
+		got := createValueInputSlotFromColorFuncCall(ctx, callExpr, nil)
 		assert.Nil(t, got)
 	})
 }
@@ -2022,158 +2069,6 @@ func TestIsBlank(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
-}
-
-func TestSortSpxInputSlots(t *testing.T) {
-	t.Run("SortingOrder", func(t *testing.T) {
-		slots := []SpxInputSlot{
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 42, Character: 0},
-					End:   Position{Line: 42, Character: 10},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 5, Character: 0},
-					End:   Position{Line: 5, Character: 10},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 100, Character: 0},
-					End:   Position{Line: 100, Character: 10},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 1, Character: 0},
-					End:   Position{Line: 1, Character: 10},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 20, Character: 0},
-					End:   Position{Line: 20, Character: 10},
-				},
-			},
-		}
-
-		sortSpxInputSlots(slots)
-
-		assert.Equal(t, uint32(1), slots[0].Range.Start.Line)
-		assert.Equal(t, uint32(100), slots[len(slots)-1].Range.Start.Line)
-		for i := range len(slots) - 1 {
-			assert.LessOrEqual(t, slots[i].Range.Start.Line, slots[i+1].Range.Start.Line)
-		}
-	})
-
-	t.Run("CharacterPositionSorting", func(t *testing.T) {
-		slots := []SpxInputSlot{
-			// Line 5 with different character positions.
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 5, Character: 20},
-					End:   Position{Line: 5, Character: 25},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 5, Character: 5},
-					End:   Position{Line: 5, Character: 10},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 5, Character: 15},
-					End:   Position{Line: 5, Character: 20},
-				},
-			},
-
-			// Line 7 with different character positions.
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 7, Character: 30},
-					End:   Position{Line: 7, Character: 35},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 7, Character: 10},
-					End:   Position{Line: 7, Character: 15},
-				},
-			},
-		}
-
-		sortSpxInputSlots(slots)
-
-		l5Slots := slices.DeleteFunc(slices.Clone(slots), func(s SpxInputSlot) bool {
-			return s.Range.Start.Line != 5
-		})
-		require.Len(t, l5Slots, 3)
-		assert.Equal(t, uint32(5), l5Slots[0].Range.Start.Character)
-		assert.Equal(t, uint32(15), l5Slots[1].Range.Start.Character)
-		assert.Equal(t, uint32(20), l5Slots[2].Range.Start.Character)
-
-		l7Slots := slices.DeleteFunc(slices.Clone(slots), func(s SpxInputSlot) bool {
-			return s.Range.Start.Line != 7
-		})
-		require.Len(t, l7Slots, 2)
-		assert.Equal(t, uint32(10), l7Slots[0].Range.Start.Character)
-		assert.Equal(t, uint32(30), l7Slots[1].Range.Start.Character)
-	})
-
-	t.Run("KindSorting", func(t *testing.T) {
-		slots := []SpxInputSlot{
-			// Same position (5, 10) with different kinds.
-			{
-				Kind: SpxInputSlotKindAddress,
-				Range: Range{
-					Start: Position{Line: 5, Character: 10},
-					End:   Position{Line: 5, Character: 15},
-				},
-			},
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 5, Character: 10},
-					End:   Position{Line: 5, Character: 15},
-				},
-			},
-
-			// Different position.
-			{
-				Kind: SpxInputSlotKindValue,
-				Range: Range{
-					Start: Position{Line: 5, Character: 5},
-					End:   Position{Line: 5, Character: 10},
-				},
-			},
-		}
-
-		sortSpxInputSlots(slots)
-
-		// First, slots are sorted by position.
-		assert.Equal(t, uint32(5), slots[0].Range.Start.Character)
-
-		// Then, slots with the same position are sorted by kind.
-		l5c10Slots := slices.DeleteFunc(slices.Clone(slots), func(s SpxInputSlot) bool {
-			return s.Range.Start.Line != 5 || s.Range.Start.Character != 10
-		})
-		require.Len(t, l5c10Slots, 2)
-		assert.Equal(t, SpxInputSlotKindAddress, l5c10Slots[0].Kind)
-		assert.Equal(t, SpxInputSlotKindValue, l5c10Slots[1].Kind)
-	})
 }
 
 func findInputSlot(inputSlots []SpxInputSlot, value any, name string, inputType SpxInputType, kind SpxInputKind) *SpxInputSlot {

--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -562,13 +562,9 @@ func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
 	if astPkg == nil {
 		return
 	}
-	pkgDoc, _ := proj.PkgDoc()
+	propertyNamesCache := make(map[*gotypes.Named]map[string]struct{})
 	for spxFile, astFile := range astPkg.Files {
 		var diagnostics []Diagnostic
-		// propertyNamesCache memoizes GetPropertyNamesForCall results per
-		// CallExpr. A cached nil result means an unknown target. A map lookup
-		// still distinguishes it from a missing entry.
-		propertyNamesCache := make(map[*ast.CallExpr][]string)
 		pass := &protocol.Pass{
 			Fset:      fset,
 			Files:     []*ast.File{astFile},
@@ -585,20 +581,19 @@ func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
 				inspect.Analyzer: inspector.New([]*ast.File{astFile}),
 			},
 			IsPropertyNameType: IsSpxPropertyNameType,
-			GetPropertyNamesForCall: func(call *ast.CallExpr) []string {
-				if names, ok := propertyNamesCache[call]; ok {
-					return names
-				}
+			GetPropertyNamesForCall: func(call *ast.CallExpr) map[string]struct{} {
 				named := PropertyTargetNamedTypeForCall(typeInfo, call, spxFile, result.mainSpxFile)
 				if named == nil {
-					propertyNamesCache[call] = nil
 					return nil
 				}
-				names := make([]string, 0)
-				for m := range propertyMembers(named, makePkgDocFor(pkgDoc)) {
-					names = append(names, m.Name)
+				if names, ok := propertyNamesCache[named]; ok {
+					return names
 				}
-				propertyNamesCache[call] = names
+				names := make(map[string]struct{})
+				for property := range propertyObjects(named) {
+					names[property.Name] = struct{}{}
+				}
+				propertyNamesCache[named] = names
 				return names
 			},
 			ResolvedCallExprArgs: func(call *ast.CallExpr) iter.Seq[xgoutil.ResolvedCallExprArg] {
@@ -631,6 +626,8 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 	if typeInfo == nil {
 		return
 	}
+	astPkg, _ := result.proj.ASTPackage()
+	returnTypes := spxResourceReturnTypes(astPkg, typeInfo)
 
 	// Check all identifier definitions.
 	for ident, obj := range typeInfo.Defs {
@@ -666,7 +663,7 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 		switch expr := expr.(type) {
 		case *ast.BasicLit:
 			if expr.Kind == token.STRING {
-				if returnType := s.resolveReturnTypeForExpr(result, expr); returnType != nil {
+				if returnType := returnTypes[expr]; returnType != nil {
 					getSpriteContext := sync.OnceValue(func() *SpxSpriteResource {
 						spxFileBaseName := path.Base(xgoutil.NodeFilename(result.proj.Fset, expr))
 						if spxFileBaseName == "main.spx" {
@@ -694,7 +691,6 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 
 	// Check call arguments from the AST, since calls containing invalid or
 	// partially typed arguments may be absent from typeInfo.Types.
-	astPkg, _ := result.proj.ASTPackage()
 	if astPkg == nil {
 		return
 	}
@@ -713,12 +709,16 @@ func (s *Server) inspectForSpxResourceRefs(result *compileResult) {
 // inspectSpxResourceRefsForCallExpr inspects spx resource references in call
 // arguments.
 func (s *Server) inspectSpxResourceRefsForCallExpr(result *compileResult, typeInfo *types.Info, call *ast.CallExpr) {
+	if len(call.Args) == 0 && len(call.Kwargs) == 0 {
+		return
+	}
 	fun := xgoutil.FuncFromCallExpr(typeInfo, call)
 	if fun == nil {
 		return
 	}
-	funcOverloads := callExprFuncOverloads(result.proj, typeInfo, call)
-	if !HasSpxResourceNameTypeParams(fun) && len(call.Kwargs) == 0 && len(funcOverloads) == 0 {
+	mayHaveResourceParams := HasSpxResourceNameTypeParams(fun) || len(call.Kwargs) > 0 ||
+		xgoutil.IsXGoOverloadableFunc(fun) || xgoutil.IsXGoOverloadedFuncName(fun.Name())
+	if !mayHaveResourceParams {
 		return
 	}
 
@@ -823,41 +823,72 @@ func (s *Server) resolveIdentifierToAssignedExpr(result *compileResult, ident *a
 	return resolvedExpr
 }
 
-// resolveReturnTypeForExpr resolves the function return type for an expression
-// when it appears in a return statement.
-func (s *Server) resolveReturnTypeForExpr(result *compileResult, expr ast.Expr) gotypes.Type {
-	typeInfo, _ := result.proj.TypeInfo()
-	if typeInfo == nil {
-		return nil
+// spxResourceReturnTypes returns the expected SPX resource type for each
+// string literal contained in a resource-typed return value.
+func spxResourceReturnTypes(astPkg *ast.Package, typeInfo *types.Info) map[*ast.BasicLit]gotypes.Type {
+	returnTypes := make(map[*ast.BasicLit]gotypes.Type)
+	if astPkg == nil || typeInfo == nil {
+		return returnTypes
 	}
 
-	astPkg, _ := result.proj.ASTPackage()
-	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, expr)
-	if astFile == nil {
-		return nil
+	var inspectResourceReturns func(ast.Node, *gotypes.Signature)
+	inspectResourceReturns = func(root ast.Node, sig *gotypes.Signature) {
+		if root == nil {
+			return
+		}
+		ast.Inspect(root, func(node ast.Node) bool {
+			switch node := node.(type) {
+			case *ast.FuncDecl:
+				fun, _ := typeInfo.ObjectOf(node.Name).(*gotypes.Func)
+				if fun == nil || node.Body == nil {
+					return false
+				}
+				funcSig, _ := fun.Type().(*gotypes.Signature)
+				inspectResourceReturns(node.Body, funcSig)
+				return false
+			case *ast.FuncLit:
+				if node.Body == nil {
+					return false
+				}
+				funcSig, _ := typeInfo.TypeOf(node).(*gotypes.Signature)
+				inspectResourceReturns(node.Body, funcSig)
+				return false
+			case *ast.ReturnStmt:
+				if sig == nil {
+					return true
+				}
+				results := sig.Results()
+				for i, resultExpr := range node.Results {
+					if i >= results.Len() {
+						break
+					}
+					if resultExpr == nil {
+						continue
+					}
+					returnType := xgoutil.DerefType(results.At(i).Type())
+					if !IsSpxResourceNameType(returnType) {
+						continue
+					}
+					ast.Inspect(resultExpr, func(resultNode ast.Node) bool {
+						if _, ok := resultNode.(*ast.FuncLit); ok {
+							return false
+						}
+						literal, ok := resultNode.(*ast.BasicLit)
+						if ok && literal.Kind == token.STRING {
+							returnTypes[literal] = returnType
+						}
+						return true
+					})
+				}
+			}
+			return true
+		})
 	}
 
-	path, _ := xgoutil.PathEnclosingInterval(astFile, expr.Pos(), expr.End())
-	stmt := xgoutil.EnclosingReturnStmt(path)
-	if stmt == nil {
-		return nil
+	for _, astFile := range astPkg.Files {
+		inspectResourceReturns(astFile, nil)
 	}
-
-	idx := xgoutil.ReturnValueIndex(stmt, expr)
-	if idx < 0 {
-		return nil
-	}
-
-	sig := xgoutil.EnclosingFuncSignature(typeInfo, path)
-	if sig == nil || idx >= sig.Results().Len() {
-		return nil
-	}
-
-	typ := xgoutil.DerefType(sig.Results().At(idx).Type())
-	if IsSpxResourceNameType(typ) {
-		return typ
-	}
-	return nil
+	return returnTypes
 }
 
 // resolveSpxSpriteContextFromCallExpr resolves the sprite context from a call expression.

--- a/internal/server/compile_test.go
+++ b/internal/server/compile_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	gotypes "go/types"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/parser"
+	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgo/x/typesutil"
+	"github.com/goplus/xgolsw/xgo/types"
+)
+
+func TestSpxResourceReturnTypes(t *testing.T) {
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, "main.spx", `
+func resource() (string, string) {
+	return wrap("resource", "nested"), "ordinary"
+}
+
+func plain() string {
+	return "plain"
+}
+
+func nested() string {
+	return func() string {
+		return "nestedFunction"
+	}()
+}
+`, parser.ParseComments)
+	require.NoError(t, err)
+
+	typeInfo := &types.Info{
+		Info: typesutil.Info{
+			Defs:  make(map[*ast.Ident]gotypes.Object),
+			Types: make(map[ast.Expr]gotypes.TypeAndValue),
+		},
+	}
+	resourceType := GetSpxBackdropNameType()
+	stringType := gotypes.Typ[gotypes.String]
+	for _, decl := range astFile.Decls {
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		var results *gotypes.Tuple
+		switch funcDecl.Name.Name {
+		case "resource":
+			results = gotypes.NewTuple(
+				gotypes.NewVar(token.NoPos, nil, "", resourceType),
+				gotypes.NewVar(token.NoPos, nil, "", stringType),
+			)
+		case "nested":
+			results = gotypes.NewTuple(gotypes.NewVar(token.NoPos, nil, "", resourceType))
+		default:
+			results = gotypes.NewTuple(gotypes.NewVar(token.NoPos, nil, "", stringType))
+		}
+		sig := gotypes.NewSignatureType(nil, nil, nil, nil, results, false)
+		typeInfo.Defs[funcDecl.Name] = gotypes.NewFunc(token.NoPos, nil, funcDecl.Name.Name, sig)
+	}
+	ast.Inspect(astFile, func(node ast.Node) bool {
+		funcLit, ok := node.(*ast.FuncLit)
+		if !ok {
+			return true
+		}
+		results := gotypes.NewTuple(gotypes.NewVar(token.NoPos, nil, "", stringType))
+		typeInfo.Types[funcLit] = gotypes.TypeAndValue{
+			Type: gotypes.NewSignatureType(nil, nil, nil, nil, results, false),
+		}
+		return true
+	})
+
+	got := spxResourceReturnTypes(&ast.Package{
+		Name:  "main",
+		Files: map[string]*ast.File{"main.spx": astFile},
+	}, typeInfo)
+	gotByValue := make(map[string]gotypes.Type)
+	for literal, typ := range got {
+		gotByValue[literal.Value] = typ
+	}
+
+	assert.Equal(t, resourceType, gotByValue[`"resource"`])
+	assert.Equal(t, resourceType, gotByValue[`"nested"`])
+	assert.NotContains(t, gotByValue, `"ordinary"`)
+	assert.NotContains(t, gotByValue, `"plain"`)
+	assert.NotContains(t, gotByValue, `"nestedFunction"`)
+}
+
+func BenchmarkServerDocumentLinkWithLargeList(b *testing.B) {
+	files := largeListProjectFiles(20_001)
+	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+	params := &DocumentLinkParams{
+		TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, err := server.textDocumentDocumentLink(params)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkServerGetInputSlotsWithLargeList(b *testing.B) {
+	const slotCount = 20_001
+	files := largeListProjectFiles(slotCount)
+	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+	params := []XGoGetInputSlotsParams{{
+		TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+	}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		slots, err := server.spxGetInputSlots(params)
+		require.NoError(b, err)
+		require.Len(b, slots, slotCount)
+	}
+}
+
+func largeListProjectFiles(elementCount int) map[string][]byte {
+	mainSpx := `var large List = NewList("value"` + strings.Repeat(`, "value"`, elementCount-1) + ")\n"
+	return map[string][]byte{
+		"main.spx":          []byte(mainSpx),
+		"assets/index.json": []byte(`{}`),
+	}
+}


### PR DESCRIPTION
Avoid rebuilding AST paths and rescanning source-line prefixes for every literal when compiling and collecting input slots from large calls.

Precompute resource-typed return literals, resolve and cache property metadata only for relevant arguments, and reuse request-level scope, predefined-name, and UTF-16 position indexes. Preserve non-overlapping source order with neighboring range checks.

Add regression coverage and benchmarks for large lists, resource classification, and UTF-16 ranges.