### PR TITLE
fix(server): avoid quadratic input slot normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ interface XGoGetInputSlotsParams {
 
 *Response:*
 
-- result: `XGoInputSlot[]` | `null` describing the XGo input slots found in the document. `null` indicates no XGo input
-  slots were found.
+- result: `XGoInputSlot[]` | `null` describing the XGo input slots found in the document. Returned slots are ordered by
+  source range and have pairwise non-overlapping ranges. `null` indicates no XGo input slots were found.
 - error: code and message set when XGo input slots cannot be retrieved for any reason.
 
 ```typescript

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -128,7 +128,8 @@ func (s *Server) spxRenameResourcesWithCompileResult(result *compileResult, para
 	return &workspaceEdit, nil
 }
 
-// spxGetInputSlots gets input slots in a document.
+// spxGetInputSlots gets input slots in source order. Returned slots have
+// pairwise non-overlapping ranges.
 func (s *Server) spxGetInputSlots(params []XGoGetInputSlotsParams) ([]XGoInputSlot, error) {
 	if l := len(params); l == 0 {
 		return nil, nil
@@ -726,7 +727,69 @@ func (c *inputSlotContext) visibleObjectCount(scope *gotypes.Scope, pos token.Po
 	return count
 }
 
-// findInputSlots finds all input slots in the AST file.
+// compareInputSlotPriority compares input slots by conflict priority. Slots
+// with earlier starts win, and longer slots win when their starts are equal.
+func compareInputSlotPriority(a, b XGoInputSlot) int {
+	if start := comparePositions(a.Range.Start, b.Range.Start); start != 0 {
+		return start
+	}
+	return comparePositions(b.Range.End, a.Range.End)
+}
+
+// normalizeInputSlots orders input slots by source range, drops degenerate
+// ranges, and removes overlaps. Discovery order breaks ties between slots with
+// identical ranges. It takes ownership of inputSlots and may overwrite it.
+func normalizeInputSlots(inputSlots []XGoInputSlot) []XGoInputSlot {
+	// Reuse the input storage when candidates are already in priority order.
+	if slices.IsSortedFunc(inputSlots, compareInputSlotPriority) {
+		normalizedSlots := appendNonOverlappingInputSlots(inputSlots[:0], slices.Values(inputSlots))
+		clear(inputSlots[len(normalizedSlots):])
+		return normalizedSlots
+	}
+
+	// Sorting indices preserves discovery order for exact ties without moving
+	// the comparatively large slot values during every sort operation.
+	indices := make([]int, len(inputSlots))
+	for i := range indices {
+		indices[i] = i
+	}
+	slices.SortFunc(indices, func(i, j int) int {
+		if priority := compareInputSlotPriority(inputSlots[i], inputSlots[j]); priority != 0 {
+			return priority
+		}
+		return cmp.Compare(i, j)
+	})
+	orderedSlots := func(yield func(XGoInputSlot) bool) {
+		for _, index := range indices {
+			if !yield(inputSlots[index]) {
+				return
+			}
+		}
+	}
+	return appendNonOverlappingInputSlots(make([]XGoInputSlot, 0, len(inputSlots)), orderedSlots)
+}
+
+// appendNonOverlappingInputSlots appends valid slots from a sequence ordered by
+// [compareInputSlotPriority] unless they overlap the last accepted slot. The
+// ordering and disjointness of accepted slots mean only the last can overlap
+// the next slot. The destination must be empty and may alias storage read by
+// slots. Appending at most once per input keeps aliased writes behind unread
+// inputs.
+func appendNonOverlappingInputSlots(dst []XGoInputSlot, slots iter.Seq[XGoInputSlot]) []XGoInputSlot {
+	for slot := range slots {
+		if comparePositions(slot.Range.Start, slot.Range.End) >= 0 {
+			continue
+		}
+		if len(dst) > 0 && IsRangesOverlap(dst[len(dst)-1].Range, slot.Range) {
+			continue
+		}
+		dst = append(dst, slot)
+	}
+	return dst
+}
+
+// findInputSlots finds all input slots in the AST file in source order. The
+// returned slots have pairwise non-overlapping ranges.
 func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
@@ -735,26 +798,9 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 	ctx := newInputSlotContext(result, astFile)
 
 	var inputSlots []XGoInputSlot
-	addInputSlots := func(slots ...XGoInputSlot) {
-		for _, slot := range slots {
-			index, _ := slices.BinarySearchFunc(inputSlots, slot, func(a, b XGoInputSlot) int {
-				if a.Range.Start.Line != b.Range.Start.Line {
-					return cmp.Compare(a.Range.Start.Line, b.Range.Start.Line)
-				}
-				return cmp.Compare(a.Range.Start.Character, b.Range.Start.Character)
-			})
-			if index > 0 && IsRangesOverlap(inputSlots[index-1].Range, slot.Range) {
-				continue
-			}
-			if index < len(inputSlots) && IsRangesOverlap(inputSlots[index].Range, slot.Range) {
-				continue
-			}
-			inputSlots = slices.Insert(inputSlots, index, slot)
-		}
-	}
 	addInputSlot := func(slot *SpxInputSlot) {
 		if slot != nil {
-			addInputSlots(*slot)
+			inputSlots = append(inputSlots, *slot)
 		}
 	}
 
@@ -766,10 +812,10 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 		switch node := node.(type) {
 		case *ast.BranchStmt:
 			if callExpr := xgoutil.CreateCallExprFromBranchStmt(typeInfo, node); callExpr != nil {
-				addInputSlots(findInputSlotsFromCallExpr(ctx, callExpr)...)
+				inputSlots = append(inputSlots, findInputSlotsFromCallExpr(ctx, callExpr)...)
 			}
 		case *ast.CallExpr, *ast.FuncDecorator:
-			addInputSlots(findInputSlotsFromCallExpr(ctx, callExprFromNode(node))...)
+			inputSlots = append(inputSlots, findInputSlotsFromCallExpr(ctx, callExprFromNode(node))...)
 		case *ast.BinaryExpr:
 			addInputSlot(checkValueInputSlot(ctx, node.X, nil))
 			addInputSlot(checkValueInputSlot(ctx, node.Y, nil))
@@ -844,7 +890,7 @@ func findInputSlots(result *compileResult, astFile *ast.File) []XGoInputSlot {
 		}
 		return true
 	})
-	return inputSlots
+	return normalizeInputSlots(inputSlots)
 }
 
 // findInputSlotsFromCallExpr finds input slots from a call expression.

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	gotypes "go/types"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
@@ -986,47 +987,260 @@ onStart => {
 			End:   Position{Line: 5, Character: 11},
 		})
 	})
+
+	t.Run("LargeList", func(t *testing.T) {
+		const slotCount = 2_001
+		files := largeListProjectFiles(slotCount)
+		server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+
+		result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		require.NoError(t, err)
+		require.NotNil(t, astFile)
+
+		slots := findInputSlots(result, astFile)
+		require.Len(t, slots, slotCount)
+		for i, slot := range slots {
+			assert.Equal(t, SpxInputSlotKindValue, slot.Kind)
+			assert.Equal(t, SpxInputTypeUnknown, slot.Accept.Type)
+			assert.Equal(t, SpxInputTypeString, slot.Input.Type)
+			assert.Equal(t, "value", slot.Input.Value)
+			if i > 0 {
+				assert.Less(t, slots[i-1].Range.Start.Character, slot.Range.Start.Character)
+				assert.False(t, IsRangesOverlap(slots[i-1].Range, slot.Range))
+			}
+		}
+	})
+
+	t.Run("MixedLargeList", func(t *testing.T) {
+		const expressionCount = 2_001
+		files := mixedListProjectFiles(expressionCount)
+		server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+
+		result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		require.NoError(t, err)
+		require.NotNil(t, astFile)
+
+		slots := findInputSlots(result, astFile)
+		require.Len(t, slots, expressionCount*3)
+		for i := 1; i < len(slots); i++ {
+			assert.LessOrEqual(t, comparePositions(slots[i-1].Range.Start, slots[i].Range.Start), 0)
+			assert.False(t, IsRangesOverlap(slots[i-1].Range, slots[i].Range))
+		}
+	})
+
+	t.Run("DropsDegenerateRanges", func(t *testing.T) {
+		files := map[string][]byte{
+			"main.spx":          []byte("println HSB(1, 2, 3"),
+			"assets/index.json": []byte(`{}`),
+		}
+		server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+
+		result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		require.NoError(t, err)
+		require.NotNil(t, astFile)
+
+		slots := findInputSlots(result, astFile)
+		require.Len(t, slots, 3)
+		for _, slot := range slots {
+			assert.Less(t, comparePositions(slot.Range.Start, slot.Range.End), 0)
+		}
+	})
+
+	t.Run("UTF16Ranges", func(t *testing.T) {
+		mainSpx := []byte("println \"\U0001F600\", \"value\"\r\n")
+		files := map[string][]byte{
+			"main.spx":          mainSpx,
+			"assets/index.json": []byte(`{}`),
+		}
+		server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+
+		result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		require.NoError(t, err)
+		require.NotNil(t, astFile)
+
+		slots := findInputSlots(result, astFile)
+		require.Len(t, slots, 2)
+		assert.Equal(t, Range{Start: Position{Line: 0, Character: 8}, End: Position{Line: 0, Character: 12}}, slots[0].Range)
+		assert.Equal(t, Range{Start: Position{Line: 0, Character: 14}, End: Position{Line: 0, Character: 21}}, slots[1].Range)
+	})
 }
 
-func TestFindInputSlotsWithLargeList(t *testing.T) {
-	const slotCount = 2_001
-	files := largeListProjectFiles(slotCount)
-	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
-
-	result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
-	require.NoError(t, err)
-	require.NotNil(t, astFile)
-
-	slots := findInputSlots(result, astFile)
-	require.Len(t, slots, slotCount)
-	for i, slot := range slots {
-		assert.Equal(t, SpxInputSlotKindValue, slot.Kind)
-		assert.Equal(t, SpxInputTypeUnknown, slot.Accept.Type)
-		assert.Equal(t, SpxInputTypeString, slot.Input.Type)
-		assert.Equal(t, "value", slot.Input.Value)
-		if i > 0 {
-			assert.Less(t, slots[i-1].Range.Start.Character, slot.Range.Start.Character)
-			assert.False(t, IsRangesOverlap(slots[i-1].Range, slot.Range))
+func TestNormalizeInputSlots(t *testing.T) {
+	slot := func(name string, startLine, startCharacter, endLine, endCharacter uint32) XGoInputSlot {
+		return XGoInputSlot{
+			Range: Range{
+				Start: Position{Line: startLine, Character: startCharacter},
+				End:   Position{Line: endLine, Character: endCharacter},
+			},
+			Input: XGoInput{Name: name},
 		}
 	}
-}
 
-func TestFindInputSlotsUTF16Ranges(t *testing.T) {
-	mainSpx := []byte("println \"\U0001F600\", \"value\"\r\n")
-	files := map[string][]byte{
-		"main.spx":          mainSpx,
-		"assets/index.json": []byte(`{}`),
+	for _, tt := range []struct {
+		name  string
+		slots []XGoInputSlot
+		want  []string
+	}{
+		{
+			name: "Empty",
+		},
+		{
+			name:  "Single",
+			slots: []XGoInputSlot{slot("only", 0, 1, 0, 2)},
+			want:  []string{"only"},
+		},
+		{
+			name:  "SingleEmptyRangeIsDropped",
+			slots: []XGoInputSlot{slot("empty", 0, 1, 0, 1)},
+		},
+		{
+			name:  "SingleReversedRangeIsDropped",
+			slots: []XGoInputSlot{slot("reversed", 0, 2, 0, 1)},
+		},
+		{
+			name: "AlreadyOrderedDisjoint",
+			slots: []XGoInputSlot{
+				slot("first", 0, 1, 0, 2),
+				slot("second", 0, 3, 0, 4),
+			},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "ReverseOrderedDisjoint",
+			slots: []XGoInputSlot{
+				slot("second", 0, 3, 0, 4),
+				slot("first", 0, 1, 0, 2),
+			},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "MultilineOrderUsesLineBeforeCharacter",
+			slots: []XGoInputSlot{
+				slot("second", 1, 0, 1, 1),
+				slot("first", 0, 10, 0, 11),
+			},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "IdenticalRangesKeepDiscoveryOrder",
+			slots: []XGoInputSlot{
+				slot("first", 0, 1, 0, 4),
+				slot("second", 0, 1, 0, 4),
+			},
+			want: []string{"first"},
+		},
+		{
+			name: "SameStartKeepsOuterSlot",
+			slots: []XGoInputSlot{
+				slot("inner", 0, 1, 0, 4),
+				slot("outer", 0, 1, 0, 8),
+			},
+			want: []string{"outer"},
+		},
+		{
+			name: "ContainmentKeepsOuterSlot",
+			slots: []XGoInputSlot{
+				slot("inner", 0, 3, 0, 5),
+				slot("outer", 0, 1, 0, 8),
+			},
+			want: []string{"outer"},
+		},
+		{
+			name: "CrossingKeepsEarlierSlot",
+			slots: []XGoInputSlot{
+				slot("later", 0, 3, 0, 8),
+				slot("earlier", 0, 1, 0, 5),
+			},
+			want: []string{"earlier"},
+		},
+		{
+			name: "RejectedCrossingDoesNotHideFollowingSlot",
+			slots: []XGoInputSlot{
+				slot("following", 0, 5, 0, 6),
+				slot("crossing", 0, 2, 0, 8),
+				slot("earlier", 0, 0, 0, 4),
+			},
+			want: []string{"earlier", "following"},
+		},
+		{
+			name: "DegenerateRangesAreDropped",
+			slots: []XGoInputSlot{
+				slot("later", 0, 5, 0, 6),
+				slot("empty", 0, 4, 0, 4),
+				slot("reversed", 0, 7, 0, 2),
+				slot("earlier", 0, 0, 0, 4),
+			},
+			want: []string{"earlier", "later"},
+		},
+		{
+			name: "AdjacentRangesAreDisjoint",
+			slots: []XGoInputSlot{
+				slot("second", 0, 4, 1, 2),
+				slot("first", 0, 1, 0, 4),
+			},
+			want: []string{"first", "second"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeInputSlots(tt.slots)
+			var gotNames []string
+			for i, slot := range got {
+				gotNames = append(gotNames, slot.Input.Name)
+				if i > 0 {
+					assert.LessOrEqual(t, comparePositions(got[i-1].Range.Start, slot.Range.Start), 0)
+					assert.False(t, IsRangesOverlap(got[i-1].Range, slot.Range))
+				}
+			}
+			assert.Equal(t, tt.want, gotNames)
+		})
 	}
-	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
 
-	result, _, astFile, err := server.compileAndGetASTFileForDocumentURI("file:///main.spx")
-	require.NoError(t, err)
-	require.NotNil(t, astFile)
+	t.Run("Exhaustive", func(t *testing.T) {
+		var ranges []Range
+		positions := [...]Position{
+			{Line: 0, Character: 0},
+			{Line: 0, Character: 1},
+			{Line: 0, Character: 2},
+			{Line: 1, Character: 0},
+			{Line: 1, Character: 1},
+		}
+		for start, startPosition := range positions[:len(positions)-1] {
+			for _, endPosition := range positions[start+1:] {
+				ranges = append(ranges, Range{
+					Start: startPosition,
+					End:   endPosition,
+				})
+			}
+		}
 
-	slots := findInputSlots(result, astFile)
-	require.Len(t, slots, 2)
-	assert.Equal(t, Range{Start: Position{Line: 0, Character: 8}, End: Position{Line: 0, Character: 12}}, slots[0].Range)
-	assert.Equal(t, Range{Start: Position{Line: 0, Character: 14}, End: Position{Line: 0, Character: 21}}, slots[1].Range)
+		names := [...]string{"first", "second", "third"}
+		for first, firstRange := range ranges {
+			for second, secondRange := range ranges {
+				for third, thirdRange := range ranges {
+					slots := []XGoInputSlot{
+						{Range: firstRange, Input: XGoInput{Name: names[0]}},
+						{Range: secondRange, Input: XGoInput{Name: names[1]}},
+						{Range: thirdRange, Input: XGoInput{Name: names[2]}},
+					}
+
+					orderedSlots := slices.Clone(slots)
+					slices.SortStableFunc(orderedSlots, compareInputSlotPriority)
+					want := make([]XGoInputSlot, 0, len(orderedSlots))
+					for _, slot := range orderedSlots {
+						if slices.ContainsFunc(want, func(accepted XGoInputSlot) bool {
+							return IsRangesOverlap(accepted.Range, slot.Range)
+						}) {
+							continue
+						}
+						want = append(want, slot)
+					}
+
+					got := normalizeInputSlots(slices.Clone(slots))
+					require.Equal(t, want, got, "range indices: %d, %d, %d", first, second, third)
+				}
+			}
+		}
+	})
 }
 
 func TestCheckValueInputSlot(t *testing.T) {

--- a/internal/server/compile_test.go
+++ b/internal/server/compile_test.go
@@ -112,18 +112,48 @@ func BenchmarkServerGetInputSlotsWithLargeList(b *testing.B) {
 	params := []XGoGetInputSlotsParams{{
 		TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
 	}}
+	slots, err := server.spxGetInputSlots(params)
+	require.NoError(b, err)
+	require.Len(b, slots, slotCount)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		slots, err := server.spxGetInputSlots(params)
+		_, err := server.spxGetInputSlots(params)
 		require.NoError(b, err)
-		require.Len(b, slots, slotCount)
+	}
+}
+
+func BenchmarkServerGetInputSlotsWithMixedLargeList(b *testing.B) {
+	const expressionCount = 8_000
+	files := mixedListProjectFiles(expressionCount)
+	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+	params := []XGoGetInputSlotsParams{{
+		TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+	}}
+	slots, err := server.spxGetInputSlots(params)
+	require.NoError(b, err)
+	require.Len(b, slots, expressionCount*3)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, err := server.spxGetInputSlots(params)
+		require.NoError(b, err)
 	}
 }
 
 func largeListProjectFiles(elementCount int) map[string][]byte {
 	mainSpx := `var large List = NewList("value"` + strings.Repeat(`, "value"`, elementCount-1) + ")\n"
+	return map[string][]byte{
+		"main.spx":          []byte(mainSpx),
+		"assets/index.json": []byte(`{}`),
+	}
+}
+
+func mixedListProjectFiles(expressionCount int) map[string][]byte {
+	mainSpx := `var large List = NewList(` + strings.Repeat(`1 + 2, `, expressionCount) +
+		`"value"` + strings.Repeat(`, "value"`, expressionCount-1) + ")\n"
 	return map[string][]byte{
 		"main.spx":          []byte(mainSpx),
 		"assets/index.json": []byte(`{}`),

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"cmp"
 	"unicode/utf16"
 	"unicode/utf8"
 
@@ -228,8 +229,19 @@ func RangeForNode(proj *xgo.Project, node ast.Node) Range {
 	return RangeForASTFileNode(proj, xgoutil.NodeASTFile(proj.Fset, astPkg, node), node)
 }
 
-// IsRangesOverlap reports whether two ranges overlap.
+// comparePositions compares positions in source order.
+func comparePositions(a, b Position) int {
+	if line := cmp.Compare(a.Line, b.Line); line != 0 {
+		return line
+	}
+	return cmp.Compare(a.Character, b.Character)
+}
+
+// IsRangesOverlap reports whether two half-open ranges overlap. Empty or
+// reversed ranges do not overlap any range.
 func IsRangesOverlap(a, b Range) bool {
-	return a.Start.Line <= b.End.Line && (a.Start.Line != b.End.Line || a.Start.Character <= b.End.Character) &&
-		b.Start.Line <= a.End.Line && (b.Start.Line != a.End.Line || b.Start.Character <= a.End.Character)
+	return comparePositions(a.Start, a.End) < 0 &&
+		comparePositions(b.Start, b.End) < 0 &&
+		comparePositions(a.Start, b.End) < 0 &&
+		comparePositions(b.Start, a.End) < 0
 }

--- a/internal/server/util_test.go
+++ b/internal/server/util_test.go
@@ -656,16 +656,16 @@ func TestIsRangesOverlap(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "RangesTouchAtEndpointExactlyEndOfAEqualsStartOfB",
+			name: "RangesTouchAtEndpointEndOfAEqualsStartOfB",
 			a:    Range{Start: Position{Line: 1, Character: 1}, End: Position{Line: 2, Character: 5}},
 			b:    Range{Start: Position{Line: 2, Character: 5}, End: Position{Line: 3, Character: 1}},
-			want: true,
+			want: false,
 		},
 		{
-			name: "RangesTouchAtEndpointExactlyEndOfBEqualsStartOfA",
+			name: "RangesTouchAtEndpointEndOfBEqualsStartOfA",
 			a:    Range{Start: Position{Line: 2, Character: 5}, End: Position{Line: 3, Character: 1}},
 			b:    Range{Start: Position{Line: 1, Character: 1}, End: Position{Line: 2, Character: 5}},
-			want: true,
+			want: false,
 		},
 		{
 			name: "SameLineOverlappingCharacters",
@@ -683,25 +683,31 @@ func TestIsRangesOverlap(t *testing.T) {
 			name: "ZeroWidthRangeAtSamePosition",
 			a:    Range{Start: Position{Line: 2, Character: 2}, End: Position{Line: 2, Character: 2}},
 			b:    Range{Start: Position{Line: 2, Character: 2}, End: Position{Line: 2, Character: 2}},
-			want: true,
+			want: false,
 		},
 		{
 			name: "ZeroWidthRangeInsideLargerRange",
 			a:    Range{Start: Position{Line: 2, Character: 2}, End: Position{Line: 2, Character: 2}},
 			b:    Range{Start: Position{Line: 1, Character: 1}, End: Position{Line: 3, Character: 3}},
-			want: true,
+			want: false,
 		},
 		{
-			name: "OverlapOnlyOnCharacterPosition",
+			name: "RangesTouchAtSameLineCharacter",
 			a:    Range{Start: Position{Line: 1, Character: 1}, End: Position{Line: 1, Character: 5}},
 			b:    Range{Start: Position{Line: 1, Character: 5}, End: Position{Line: 1, Character: 15}},
-			want: true,
+			want: false,
 		},
 		{
-			name: "StartOfAEqualsEndOfBOnDifferentLinesNoOverlap",
+			name: "StartOfAEqualsEndOfBOnDifferentLines",
 			a:    Range{Start: Position{Line: 3, Character: 0}, End: Position{Line: 4, Character: 0}},
 			b:    Range{Start: Position{Line: 1, Character: 0}, End: Position{Line: 3, Character: 0}},
-			want: true,
+			want: false,
+		},
+		{
+			name: "ReversedRange",
+			a:    Range{Start: Position{Line: 3, Character: 0}, End: Position{Line: 1, Character: 0}},
+			b:    Range{Start: Position{Line: 1, Character: 0}, End: Position{Line: 4, Character: 0}},
+			want: false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Collect input slot candidates before resolving overlaps so out-of-order AST discovery cannot repeatedly insert large values into the middle of a slice.

Use deterministic conflict priorities and LSP half-open range semantics. Preserve a linear fast path for source-ordered candidates, and cover overlap edge cases and large mixed expressions with tests and benchmarks.